### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ python examples/echo.py
 ```python
 import pyisolate as iso
 
-sandbox = iso.spawn(policy="stdlib.readonly", mem_mb=32)
+sandbox = iso.spawn("demo", policy="stdlib.readonly")
 
 code = """
 from math import sqrt
 post(sqrt(2))
 """
 
-sandbox.run(code)
+sandbox.exec(code)
 print("Result:", sandbox.recv())   # 1.4142135623730951
 sandbox.close()
 ```


### PR DESCRIPTION
## Summary
- fix `Hello World` to use `sandbox.exec` instead of the removed `run`
- remove invalid `mem_mb` argument and provide a sandbox name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2cdde7c08328aaf76769c9075896