### PR TITLE
Fix supervisor sandbox cleanup

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -52,10 +52,13 @@ class Supervisor:
         thread.start()
         with self._lock:
             self._sandboxes[name] = thread
+        # Remove references to any terminated sandboxes
+        self._cleanup()
         return Sandbox(thread)
 
     def list_active(self) -> Dict[str, Sandbox]:
         """Return currently active sandboxes."""
+        self._cleanup()
         with self._lock:
             return {name: Sandbox(t) for name, t in self._sandboxes.items() if t.is_alive()}
 


### PR DESCRIPTION
## Summary
- clean up terminated sandboxes after spawning a new one
- run cleanup when listing active sandboxes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2cdeec7c8328bf89acd4e43bb4fa