### PR TITLE
Expose PyIsolate error classes

### DIFF
--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -4,10 +4,22 @@ This module exposes the high-level API described in API.md.
 """
 
 from .supervisor import Supervisor, spawn, list_active, Sandbox
+from .errors import (
+    SandboxError,
+    PolicyError,
+    TimeoutError,
+    MemoryExceeded,
+    CPUExceeded,
+)
 
 __all__ = [
     "spawn",
     "list_active",
     "Sandbox",
     "Supervisor",
+    "SandboxError",
+    "PolicyError",
+    "TimeoutError",
+    "MemoryExceeded",
+    "CPUExceeded",
 ]

--- a/pyisolate/errors.py
+++ b/pyisolate/errors.py
@@ -1,0 +1,20 @@
+"""Exception hierarchy for PyIsolate."""
+
+class SandboxError(Exception):
+    """Base class for all sandbox related errors."""
+
+
+class PolicyError(SandboxError):
+    """Raised when a policy violation occurs."""
+
+
+class TimeoutError(SandboxError):
+    """Raised when a sandbox operation times out."""
+
+
+class MemoryExceeded(SandboxError):
+    """Raised when a sandbox exceeds its memory quota."""
+
+
+class CPUExceeded(SandboxError):
+    """Raised when a sandbox exceeds its CPU quota."""

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -12,6 +12,8 @@ import threading
 from types import ModuleType
 from typing import Any, Optional
 
+from .. import errors
+
 
 class SandboxThread(threading.Thread):
     """Thread that runs guest code and communicates via a queue."""
@@ -39,7 +41,7 @@ class SandboxThread(threading.Thread):
         try:
             return self._outbox.get(timeout=timeout)
         except queue.Empty:
-            raise TimeoutError("no message received")
+            raise errors.TimeoutError("no message received")
 
     def stop(self, timeout: float = 0.2) -> None:
         self._stop_event.set()


### PR DESCRIPTION
## Summary
- define sandbox error hierarchy in `pyisolate/errors.py`
- export error classes at package level
- use the new `TimeoutError` inside runtime thread

## Testing
- `python -c "import sys; sys.path.insert(0, '.'); import examples.echo"`

------
https://chatgpt.com/codex/tasks/task_e_685c2cdf40e88328b4f8dd0d9f7fc580