### PR TITLE
Add simple CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install -e .
+          python -m pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/pyisolate/errors.py
+++ b/pyisolate/errors.py
@@ -8,8 +8,12 @@ class PolicyError(SandboxError):
     """Raised when a policy violation occurs."""
 
 
-class TimeoutError(SandboxError):
+import builtins as _builtins
+
+
+class TimeoutError(SandboxError, _builtins.TimeoutError):
     """Raised when a sandbox operation times out."""
+    pass
 
 
 class MemoryExceeded(SandboxError):


### PR DESCRIPTION
## Summary
- run tests on Python 3.11 in GitHub Actions
- make TimeoutError subclass builtin TimeoutError so tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c374faa648328b9c41b173bb20fe3