### PR TITLE
Add isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,20 @@ jobs:
       - name: Run black
         run: pre-commit run black --all-files
 
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install -e .[dev]
+          pre-commit install-hooks
+      - name: Run isort
+        run: pre-commit run isort --all-files
+
   flake8:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@ repos:
     rev: 23.9.1
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PyIsolate
 
 [![Black](https://github.com/your/pyisolate/actions/workflows/ci.yml/badge.svg?branch=main&label=black)](https://github.com/your/pyisolate/actions/workflows/ci.yml)
+[![Isort](https://github.com/your/pyisolate/actions/workflows/ci.yml/badge.svg?branch=main&label=isort)](https://github.com/your/pyisolate/actions/workflows/ci.yml)
 [![Flake8](https://github.com/your/pyisolate/actions/workflows/ci.yml/badge.svg?branch=main&label=flake8)](https://github.com/your/pyisolate/actions/workflows/ci.yml)
 [![Pylint](https://github.com/your/pyisolate/actions/workflows/ci.yml/badge.svg?branch=main&label=pylint)](https://github.com/your/pyisolate/actions/workflows/ci.yml)
 

--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -3,15 +3,14 @@
 This module exposes the high-level API described in API.md.
 """
 
-from .supervisor import Supervisor, spawn, list_active, Sandbox, reload_policy
 from .errors import (
-    SandboxError,
-    PolicyError,
-    TimeoutError,
-    MemoryExceeded,
     CPUExceeded,
+    MemoryExceeded,
+    PolicyError,
+    SandboxError,
+    TimeoutError,
 )
-
+from .supervisor import Sandbox, Supervisor, list_active, reload_policy, spawn
 
 __all__ = [
     "spawn",

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -7,9 +7,9 @@ sub‑interpreters and eBPF enforcement as outlined in AGENTS.md.
 
 from __future__ import annotations
 
+import json
 import queue
 import threading
-import json
 from types import ModuleType
 from typing import Any, Optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,8 @@ dev = [
     "black",
     "flake8",
     "pylint",
+    "isort",
 ]
+
+[tool.isort]
+profile = "black"

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -5,8 +5,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-import pyisolate as iso
 import pytest
+
+import pyisolate as iso
 
 
 def test_spawn_returns_sandbox():


### PR DESCRIPTION
## Summary
- include isort in development dependencies and tooling
- enforce import sorting with pre-commit
- run isort as part of CI
- sort existing imports
- add badge for isort job

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3923083c83288bb7767e81f733f7