### PR TITLE
Propagate call exceptions

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -42,7 +42,13 @@ class SandboxThread(threading.Thread):
             ]
         )
         self.exec(code)
-        return self.recv()
+        result = self.recv()
+        if isinstance(result, Exception):
+            # Propagate sandbox exceptions to the caller
+            if isinstance(result, errors.SandboxError):
+                raise result
+            raise errors.SandboxError(str(result)) from result
+        return result
 
     def recv(self, timeout: Optional[float] = None):
         try:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -43,3 +43,12 @@ def test_recv_timeout_raises():
             sb.recv(timeout=0.1)
     finally:
         sb.close()
+
+
+def test_call_raises_exception():
+    sb = iso.spawn("t5")
+    try:
+        with pytest.raises(iso.SandboxError):
+            sb.call("math.sqrt", -1)
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- raise any sandboxed exception from `SandboxThread.call`
- test that exceptions raised inside the sandbox are surfaced

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3b8bc0dc8328b8b8be31033de213