### PR TITLE
Remove unused os import in test

### DIFF
--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- clean up `tests/test_sandbox.py` by removing unused `os` import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3b8ac3188328905c89b48ad83a94