### PR TITLE
Implement policy refresh workflow

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -38,6 +38,10 @@ sandboxes:
 ## 3  Live reloading
 `pyisolate.policy.refresh(path)` calls `bpftool map update` for every
 changed row; new limits apply within µs—no guest restart required.
+The file is parsed and validated first.  Only after a successful parse
+does `BPFManager.hot_reload()` install a new set of maps.  The previous
+policy remains active until the swap completes so running sandboxes
+never observe partial state.
 
 ## 4  Extending the schema
 Add custom keys by shipping a new eBPF object and registering a

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -1,6 +1,32 @@
 """Policy helpers stub."""
 
 from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # minimal fallback when PyYAML is unavailable
+    def _mini_load(text: str) -> dict:
+        result = {}
+        for line in text.splitlines():
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if ":" not in line:
+                raise ValueError("invalid YAML line")
+            k, v = line.split(":", 1)
+            result[k.strip()] = v.strip()
+        return result
+
+    class _MiniYaml:
+        @staticmethod
+        def safe_load(stream):
+            if hasattr(stream, "read"):
+                return _mini_load(stream.read())
+            return _mini_load(stream)
+
+    yaml = _MiniYaml()
+
+from ..supervisor import reload_policy
 
 
 @dataclass
@@ -15,8 +41,14 @@ class Policy:
 
 
 def refresh(path: str) -> None:
-    """Placeholder for policy hot-reload logic."""
-    return None
+    """Parse *path* and atomically update eBPF policy maps."""
+
+    # Fail fast if the YAML is malformed before touching BPF maps
+    with open(path, "r", encoding="utf-8") as fh:
+        yaml.safe_load(fh)
+
+    # Upon successful parse, swap the live maps via the supervisor
+    reload_policy(str(Path(path).resolve()))
 
 
 __all__ = ["Policy", "refresh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 description = "Minimal skeleton for PyIsolate sandbox"
 authors = [{ name = "PyIsolate" }]
 requires-python = ">=3.11"
+dependencies = ["pyyaml"]
 
 [build-system]
 requires = ["setuptools>=64"]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -51,3 +51,13 @@ def test_call_raises_exception():
             sb.call("math.sqrt", -1)
     finally:
         sb.close()
+
+
+def test_policy_refresh_parses_yaml(tmp_path):
+    policy_file = tmp_path / "p.yml"
+    policy_file.write_text("version: 0.1\n")
+
+    # Should not raise for valid YAML
+    import pyisolate.policy as policy
+
+    policy.refresh(str(policy_file))


### PR DESCRIPTION
## Summary
- parse policy files before hot-reload
- update BPF maps atomically using the supervisor
- document how policy refresh works
- require PyYAML
- test refresh function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c42c15d9083288c26518b35305172