### PR TITLE
Implement AEAD broker with replay counters

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,32 @@
+# Broker Protocol
+
+The supervisor and each sandbox communicate over an authenticated channel. Keys
+are negotiated using X25519 and all frames are protected with
+ChaCha20-Poly1305.
+
+## Handshake
+
+1. Each side generates an X25519 key pair.
+2. Public keys are exchanged out of band.
+3. A shared secret is derived via `X25519PrivateKey.exchange()`.
+4. The secret feeds HKDF-SHA256 with `info=b"pyisolate-channel"` to produce the
+   32 byte AEAD key.
+
+## Framing
+
+Frames are formatted as:
+
+```
+nonce (12 bytes little-endian counter) || ciphertext
+```
+
+The nonce is a monotonically increasing counter per direction. The same counter
+serves as the ChaCha20-Poly1305 nonce. Frames received with a counter that does
+not match the expected value are rejected to prevent replay.
+
+## Security notes
+
+* Nonces are counters starting at zero to guarantee uniqueness.
+* HKDF provides key separation between channels.
+* Empty associated data is used by default but can be extended in future
+  revisions.

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,59 @@
+import pytest
+from cryptography.hazmat.primitives.asymmetric import x25519
+from cryptography.hazmat.primitives import serialization
+
+from pyisolate.broker.crypto import CryptoBroker
+
+
+def make_pair():
+    priv_a = x25519.X25519PrivateKey.generate()
+    priv_b = x25519.X25519PrivateKey.generate()
+    a = CryptoBroker(
+        priv_a.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        priv_b.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ),
+    )
+    b = CryptoBroker(
+        priv_b.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        priv_a.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ),
+    )
+    return a, b
+
+
+def test_roundtrip():
+    a, b = make_pair()
+    msg = b"secret"
+    frame = a.frame(msg)
+    assert b.unframe(frame) == msg
+
+
+def test_replay_detection():
+    a, b = make_pair()
+    frame = a.frame(b"hi")
+    b.unframe(frame)
+    with pytest.raises(ValueError):
+        b.unframe(frame)
+
+
+def test_out_of_order():
+    a, b = make_pair()
+    dropped = a.frame(b"one")
+    later = a.frame(b"two")
+    with pytest.raises(ValueError):
+        b.unframe(later)
+    # deliver the dropped frame then the next
+    assert b.unframe(dropped) == b"one"
+    assert b.unframe(later) == b"two"


### PR DESCRIPTION
## Summary
- implement X25519/ChaCha20-Poly1305 framing in `CryptoBroker`
- detect replayed frames using per-direction counters
- document channel protocol
- add encryption tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685c42be92f083288647e3535dc56aab