### PR TITLE
Implement rudimentary resource watchdog

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -9,21 +9,43 @@ from __future__ import annotations
 
 import json
 import queue
+import signal
 import threading
+import time
+import tracemalloc
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from .. import errors
 
 
+def _sigxcpu_handler(signum, frame):
+    raise errors.CPUExceeded()
+
+
+signal.signal(signal.SIGXCPU, _sigxcpu_handler)
+
+
+@dataclass
+class Stats:
+    cpu_ms: float
+    mem_bytes: int
+
+
 class SandboxThread(threading.Thread):
     """Thread that runs guest code and communicates via a queue."""
 
-    def __init__(self, name: str, policy=None):
+    def __init__(self, name: str, policy=None, cpu_ms: Optional[int] = None, mem_bytes: Optional[int] = None):
         super().__init__(name=name, daemon=True)
         self._inbox: "queue.Queue[str]" = queue.Queue()
         self._outbox: "queue.Queue[Any]" = queue.Queue()
         self._stop_event = threading.Event()
         self.policy = policy
+        self.cpu_quota_ms = cpu_ms
+        self.mem_quota_bytes = mem_bytes
+        self._cpu_time = 0.0
+        self._mem_peak = 0
+        self._start_time = None
 
     def exec(self, src: str) -> None:
         self._inbox.put(src)
@@ -41,17 +63,20 @@ class SandboxThread(threading.Thread):
             ]
         )
         self.exec(code)
-        result = self.recv()
-        if isinstance(result, Exception):
-            # Propagate sandbox exceptions to the caller
-            if isinstance(result, errors.SandboxError):
-                raise result
-            raise errors.SandboxError(str(result)) from result
+        try:
+            result = self.recv()
+        except Exception as exc:  # sandbox raised
+            if isinstance(exc, errors.SandboxError):
+                raise exc
+            raise errors.SandboxError(str(exc)) from exc
         return result
 
     def recv(self, timeout: Optional[float] = None):
         try:
-            return self._outbox.get(timeout=timeout)
+            result = self._outbox.get(timeout=timeout)
+            if isinstance(result, Exception):
+                raise result
+            return result
         except queue.Empty:
             raise errors.TimeoutError("no message received")
 
@@ -59,13 +84,20 @@ class SandboxThread(threading.Thread):
         self._stop_event.set()
         self.join(timeout)
 
-    # stats placeholder
     @property
     def stats(self):
-        return type("Stats", (), {"cpu_ms": 0, "mem_bytes": 0})()
+        cpu_ms = self._cpu_time
+        if self._start_time is not None:
+            cpu_ms += (time.monotonic() - self._start_time) * 1000
+        return Stats(cpu_ms=cpu_ms, mem_bytes=self._mem_peak)
 
     # internal thread run loop
     def run(self) -> None:
+        if not tracemalloc.is_tracing():
+            tracemalloc.start()
+        self._mem_base = tracemalloc.get_traced_memory()[0]
+        self._cpu_time = 0.0
+        self._start_time = None
         local_vars = {"post": self._outbox.put}
         while not self._stop_event.is_set():
             try:
@@ -73,6 +105,13 @@ class SandboxThread(threading.Thread):
             except queue.Empty:
                 continue
             try:
+                start_cpu = time.thread_time()
+                self._start_time = time.monotonic()
                 exec(src, local_vars, local_vars)
+                end_cpu = time.thread_time()
+                self._cpu_time += (end_cpu - start_cpu) * 1000
+                self._start_time = None
+                cur, peak = tracemalloc.get_traced_memory()
+                self._mem_peak = max(self._mem_peak, peak - self._mem_base)
             except Exception as exc:  # real impl would sanitize
                 self._outbox.put(exc)

--- a/pyisolate/watchdog.py
+++ b/pyisolate/watchdog.py
@@ -1,11 +1,52 @@
-"""ResourceWatchdog stub.
+"""ResourceWatchdog implementation.
 
-Counts CPU and memory usage for sandboxes. This simplified version only provides
-a method to simulate quota checks.
+Periodically polls per-sandbox counters and stops sandboxes when quotas are
+exceeded. The real project would use BPF perf events but this stub relies on
+the ``SandboxThread.stats`` values.
 """
 
+from __future__ import annotations
 
-class ResourceWatchdog:
-    def check(self, sandbox) -> None:
-        # Real implementation would read BPF counters.
-        pass
+import threading
+import time
+from typing import TYPE_CHECKING
+
+from . import errors
+
+if TYPE_CHECKING:  # pragma: no cover - circular import hints
+    from .supervisor import Supervisor
+    from .runtime.thread import SandboxThread
+
+
+class ResourceWatchdog(threading.Thread):
+    """Polls sandbox stats and enforces resource quotas."""
+
+    def __init__(self, supervisor: "Supervisor", interval: float = 0.05):
+        super().__init__(daemon=True)
+        self._supervisor = supervisor
+        self._interval = interval
+        self._stop_event = threading.Event()
+
+    def stop(self, timeout: float = 0.2) -> None:
+        self._stop_event.set()
+        self.join(timeout)
+
+    def run(self) -> None:
+        while not self._stop_event.is_set():
+            time.sleep(self._interval)
+            with self._supervisor._lock:
+                sandboxes = list(self._supervisor._sandboxes.values())
+            for sb in sandboxes:
+                if not sb.is_alive():
+                    continue
+                stats = sb.stats
+                if sb.cpu_quota_ms is not None and stats.cpu_ms >= sb.cpu_quota_ms:
+                    sb._outbox.put(errors.CPUExceeded())
+                    sb.stop()
+                    continue
+                if (
+                    sb.mem_quota_bytes is not None
+                    and stats.mem_bytes >= sb.mem_quota_bytes
+                ):
+                    sb._outbox.put(errors.MemoryExceeded())
+                    sb.stop()

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -51,3 +51,23 @@ def test_call_raises_exception():
             sb.call("math.sqrt", -1)
     finally:
         sb.close()
+
+
+def test_cpu_quota_exceeded():
+    sb = iso.spawn("tcpu", cpu_ms=10)
+    try:
+        sb.exec("while True: pass")
+        with pytest.raises(iso.CPUExceeded):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
+def test_memory_quota_exceeded():
+    sb = iso.spawn("tmem", mem_bytes=1024 * 1024)
+    try:
+        sb.exec("x = ' ' * (2 * 1024 * 1024)")
+        with pytest.raises(iso.MemoryExceeded):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- implement ResourceWatchdog thread polling sandbox stats
- track CPU and memory usage in `SandboxThread`
- expose quotas when spawning sandboxes
- enforce quotas by raising `CPUExceeded` or `MemoryExceeded`
- add tests exercising CPU and memory quota enforcement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c42c048f48328866598029655646c