### PR TITLE
Fix formatting and update flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -6,7 +6,6 @@ concept used by the tests.  ``bpftool`` and ``llvm-objdump`` may not be
 available on the test system; any missing executables are therefore ignored.
 """
 
-
 import json
 import subprocess
 from pathlib import Path
@@ -68,4 +67,3 @@ class BPFManager:
                     "any",
                 ]
             )
-

--- a/pyisolate/broker/crypto.py
+++ b/pyisolate/broker/crypto.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import x25519
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 try:
     import yaml  # type: ignore
 except ModuleNotFoundError:  # minimal fallback when PyYAML is unavailable
+
     def _mini_load(text: str) -> dict:
         result = {}
         for line in text.splitlines():

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -35,7 +35,13 @@ class Stats:
 class SandboxThread(threading.Thread):
     """Thread that runs guest code and communicates via a queue."""
 
-    def __init__(self, name: str, policy=None, cpu_ms: Optional[int] = None, mem_bytes: Optional[int] = None):
+    def __init__(
+        self,
+        name: str,
+        policy=None,
+        cpu_ms: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
+    ):
         super().__init__(name=name, daemon=True)
         self._inbox: "queue.Queue[str]" = queue.Queue()
         self._outbox: "queue.Queue[Any]" = queue.Queue()

--- a/pyisolate/watchdog.py
+++ b/pyisolate/watchdog.py
@@ -14,8 +14,8 @@ from typing import TYPE_CHECKING
 from . import errors
 
 if TYPE_CHECKING:  # pragma: no cover - circular import hints
-    from .supervisor import Supervisor
     from .runtime.thread import SandboxThread
+    from .supervisor import Supervisor
 
 
 class ResourceWatchdog(threading.Thread):

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -1,6 +1,6 @@
 import json
-from pathlib import Path
 import sys
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -15,8 +15,10 @@ def test_load_runs_toolchain(monkeypatch):
 
     def fake_run(cmd, check=True, capture_output=True):
         calls.append(cmd)
+
         class R:
             returncode = 0
+
         return R()
 
     monkeypatch.setattr("subprocess.run", fake_run)
@@ -52,4 +54,3 @@ def test_hot_reload_updates_maps(tmp_path, monkeypatch):
     policy.write_text(json.dumps({"cpu": "200ms", "mem": "64MiB"}))
     mgr.hot_reload(str(policy))
     assert mgr.policy_maps == {"cpu": "200ms", "mem": "64MiB"}
-

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,6 +1,6 @@
 import pytest
-from cryptography.hazmat.primitives.asymmetric import x25519
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import x25519
 
 from pyisolate.broker.crypto import CryptoBroker
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -53,7 +53,6 @@ def test_call_raises_exception():
         sb.close()
 
 
-
 def test_cpu_quota_exceeded():
     sb = iso.spawn("tcpu", cpu_ms=10)
     try:
@@ -73,6 +72,7 @@ def test_memory_quota_exceeded():
     finally:
         sb.close()
 
+
 def test_policy_refresh_parses_yaml(tmp_path):
     policy_file = tmp_path / "p.yml"
     policy_file.write_text("version: 0.1\n")
@@ -81,4 +81,3 @@ def test_policy_refresh_parses_yaml(tmp_path):
     import pyisolate.policy as policy
 
     policy.refresh(str(policy_file))
-


### PR DESCRIPTION
## Summary
- run black on repo
- run isort on repo
- ignore line length errors in flake8

## Testing
- `black $(git ls-files '*.py')`
- `isort $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685c45897e6c8328ba9ac5f11c4d6117