### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,15 @@ jobs:
         run: |
           python -m pip install -e .[dev]
           pre-commit install-hooks
-      - name: Run tests
-        run: pre-commit run pytest
+      - name: Run tests with coverage
+        run: coverage run -m pytest
+      - name: Generate coverage report
+        run: |
+          coverage xml -o coverage.xml
+          coverage-badge -f -o docs/coverage.svg
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            docs/coverage.svg

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Isort](https://github.com/your/pyisolate/actions/workflows/ci.yml/badge.svg?branch=main&label=isort)](https://github.com/seanwevans/pyisolate/actions/workflows/ci.yml)
 [![Flake8](https://github.com/your/pyisolate/actions/workflows/ci.yml/badge.svg?branch=main&label=flake8)](https://github.com/seanwevans/pyisolate/actions/workflows/ci.yml)
 [![Pylint](https://github.com/your/pyisolate/actions/workflows/ci.yml/badge.svg?branch=main&label=pylint)](https://github.com/seanwevans/pyisolate/actions/workflows/ci.yml)
+[![Coverage](docs/coverage.svg)](docs/coverage.svg)
 
 **Light‑weight, eBPF‑hardened sub‑interpreter sandbox for CPython 3.13 (no‑GIL)**
 

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="98" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="a">
+    <rect width="98" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#a)">
+    <rect width="63" height="20" fill="#555"/>
+    <rect x="63" width="35" height="20" fill="#4c1"/>
+    <rect width="98" height="20" fill="url(#b)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana" font-size="110">
+    <text x="32" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="530">coverage</text>
+    <text x="32" y="140" transform="scale(.1)" textLength="530">coverage</text>
+    <text x="80" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="250">0%</text>
+    <text x="80" y="140" transform="scale(.1)" textLength="250">0%</text>
+  </g>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dev = [
     "flake8",
     "pylint",
     "isort",
+    "coverage",
+    "coverage-badge",
 ]
 
 [tool.isort]


### PR DESCRIPTION
## Summary
- generate coverage report in CI
- publish `docs/coverage.svg` badge
- document coverage badge in README
- include coverage tools in dev extras

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md pyproject.toml docs/coverage.svg` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685c465172048328ae6e87471eb732f7