### PR TITLE
Add Sandbox context manager

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,6 +10,7 @@ import pyisolate as psi
 |------|-------------|
 | `psi.spawn(name:str, policy:str|dict=None) → Sandbox` | Create sandbox thread, attach eBPF, return handle. |
 | `sandbox.close(timeout=0.2)` | Graceful stop → SIGTERM; force‑kill after timeout. |
+| `with psi.spawn(name, policy)` | Context manager form; sandbox closes on exit. |
 | `psi.list_active() → Dict[str, Sandbox]` | Introspection. |
 
 ## 2  Executing code

--- a/README.md
+++ b/README.md
@@ -36,16 +36,14 @@ python examples/echo.py
 ```python
 import pyisolate as iso
 
-sandbox = iso.spawn("demo", policy="stdlib.readonly")
-
 code = """
 from math import sqrt
 post(sqrt(2))
 """
 
-sandbox.exec(code)
-print("Result:", sandbox.recv())   # 1.4142135623730951
-sandbox.close()
+with iso.spawn("demo", policy="stdlib.readonly") as sandbox:
+    sandbox.exec(code)
+    print("Result:", sandbox.recv())   # 1.4142135623730951
 ```
 
 ---

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -36,6 +36,13 @@ class Sandbox:
     def close(self, timeout: float = 0.2) -> None:
         self._thread.stop(timeout)
 
+    # allow ``with spawn(...) as sb:`` usage
+    def __enter__(self) -> "Sandbox":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
     @property
     def stats(self):
         return self._thread.stats

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -81,3 +81,11 @@ def test_policy_refresh_parses_yaml(tmp_path):
     import pyisolate.policy as policy
 
     policy.refresh(str(policy_file))
+
+
+def test_context_manager_closes():
+    with iso.spawn("ctx") as sb:
+        sb.exec("post(1)")
+        assert sb.recv(timeout=0.5) == 1
+
+    assert not sb._thread.is_alive()


### PR DESCRIPTION
## Summary
- allow using Sandbox in a `with` statement
- document the context manager in README and API docs
- add regression test for context manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685c47f8debc8328b1801caa828346a1