### PR TITLE
Fix pylint attribute warning

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -51,6 +51,7 @@ class SandboxThread(threading.Thread):
         self.mem_quota_bytes = mem_bytes
         self._cpu_time = 0.0
         self._mem_peak = 0
+        self._mem_base = 0
         self._start_time = None
 
     def exec(self, src: str) -> None:


### PR DESCRIPTION
## Summary
- define `_mem_base` in `SandboxThread` initializer

## Testing
- `python -m compileall -q pyisolate`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685c4a31e41c83289794da2c3a475f7c