### PR TITLE
Fix isort compliance

### DIFF
--- a/pyisolate/errors.py
+++ b/pyisolate/errors.py
@@ -1,5 +1,7 @@
 """Exception hierarchy for PyIsolate."""
 
+import builtins as _builtins
+
 
 class SandboxError(Exception):
     """Base class for all sandbox related errors."""
@@ -7,9 +9,6 @@ class SandboxError(Exception):
 
 class PolicyError(SandboxError):
     """Raised when a policy violation occurs."""
-
-
-import builtins as _builtins
 
 
 class TimeoutError(SandboxError, _builtins.TimeoutError):


### PR DESCRIPTION
## Summary
- reorder imports in `pyisolate/errors.py`

## Testing
- `isort --check-only $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_685c4a3d308c8328820d5cfc18f9bff7