### PR TITLE
Modify pylint CI behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,13 @@ jobs:
           python -m pip install -e .[dev]
           pre-commit install-hooks
       - name: Run pylint
-        run: pre-commit run pylint --all-files
+        run: |
+          set +e
+          pre-commit run pylint --all-files
+          ret=$?
+          if [ $ret -gt 1 ]; then
+            exit $ret
+          fi
 
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- tweak the GitHub Actions workflow so pylint warnings don't fail CI

## Testing
- `pytest -q`
- (failed to run `pre-commit` due to missing dependency)

------
https://chatgpt.com/codex/tasks/task_e_685c4cb51a6c8328a02e352be1acc2f8