### PR TITLE
Fix flake8 warnings

### DIFF
--- a/pyisolate/watchdog.py
+++ b/pyisolate/watchdog.py
@@ -35,7 +35,9 @@ class ResourceWatchdog(threading.Thread):
         while not self._stop_event.is_set():
             time.sleep(self._interval)
             with self._supervisor._lock:
-                sandboxes = list(self._supervisor._sandboxes.values())
+                sandboxes: list[SandboxThread] = list(
+                    self._supervisor._sandboxes.values()
+                )
             for sb in sandboxes:
                 if not sb.is_alive():
                     continue
@@ -44,9 +46,8 @@ class ResourceWatchdog(threading.Thread):
                     sb._outbox.put(errors.CPUExceeded())
                     sb.stop()
                     continue
-                if (
-                    sb.mem_quota_bytes is not None
-                    and stats.mem_bytes >= sb.mem_quota_bytes
+                if sb.mem_quota_bytes is not None and (
+                    stats.mem_bytes >= sb.mem_quota_bytes
                 ):
                     sb._outbox.put(errors.MemoryExceeded())
                     sb.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@ import types
 
 # Provide a minimal stub for the 'cryptography' package when it is missing.
 
+
 def pytest_configure(config):
     try:
         import cryptography  # pragma: no cover - real lib present
+        _ = cryptography
     except ModuleNotFoundError:  # pragma: no cover - fallback path
         crypto = types.ModuleType('cryptography')
         hazmat = types.ModuleType('cryptography.hazmat')

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -5,8 +5,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-import pytest
-
 from pyisolate.bpf.manager import BPFManager
 
 


### PR DESCRIPTION
## Summary
- fix various flake8 complaints about unused imports, W503, and missing blank lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4d6c8eb48328ba38b62c14acdaf0