### PR TITLE
Fix policy map replacement

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -51,7 +51,8 @@ class BPFManager:
             raise RuntimeError("BPF not loaded")
         with open(policy_path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
-        self.policy_maps.update(data)
+        # Replace the active policy entirely to drop removed entries
+        self.policy_maps = data
         for key, val in data.items():
             self._run(
                 [


### PR DESCRIPTION
## Summary
- ensure BPFManager replaces policy maps when hot reloading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4ed83ef08328bb7b908e12446712