### PR TITLE
Implement simple metrics exporter

### DIFF
--- a/pyisolate/observability/metrics.py
+++ b/pyisolate/observability/metrics.py
@@ -1,6 +1,27 @@
-"""Metrics exporter stub."""
+"""Simple Prometheus text exporter for sandbox metrics.
+
+The real project would export statistics gathered from eBPF maps.  This
+implementation gathers ``SandboxThread.stats`` from the supervisor and formats
+them as standard Prometheus ``Gauge`` metrics.  It is intentionally minimal but
+useful for tests and examples.
+"""
 
 
 class MetricsExporter:
-    def export(self) -> None:
-        pass
+    def export(self) -> str:
+        """Return metrics for all active sandboxes in Prometheus text format."""
+
+        from ..supervisor import list_active
+
+        lines: list[str] = []
+        active = list_active()
+        for name, sb in active.items():
+            stats = sb.stats
+            lines.append(
+                f'pyisolate_cpu_ms{{sandbox="{name}"}} {stats.cpu_ms:.0f}'
+            )
+            lines.append(
+                f'pyisolate_mem_bytes{{sandbox="{name}"}} {stats.mem_bytes}'
+            )
+
+        return "\n".join(lines) + ("\n" if lines else "")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -4,8 +4,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import pyisolate as iso
 from pyisolate.observability.metrics import MetricsExporter
 
 
-def test_export_noop():
-    MetricsExporter().export()
+def test_export_contains_metrics():
+    sb = iso.spawn("metrics")
+    try:
+        sb.exec("post(1)")
+        sb.recv(timeout=0.5)
+        metrics = MetricsExporter().export()
+        assert "pyisolate_cpu_ms" in metrics
+        assert "pyisolate_mem_bytes" in metrics
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- implement a basic MetricsExporter that returns Prometheus-formatted text
- extend metrics test to check exported metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c51fbb3dc8328b1cfe4cd7223852c