### PR TITLE
Improve coverage

### DIFF
--- a/tests/test_bpf_manager_extra.py
+++ b/tests/test_bpf_manager_extra.py
@@ -1,0 +1,11 @@
+import pytest
+from pathlib import Path
+from pyisolate.bpf.manager import BPFManager
+
+
+def test_hot_reload_requires_load(tmp_path):
+    mgr = BPFManager()
+    policy = tmp_path / "p.json"
+    policy.write_text("{}")
+    with pytest.raises(RuntimeError):
+        mgr.hot_reload(str(policy))

--- a/tests/test_crypto_extra.py
+++ b/tests/test_crypto_extra.py
@@ -1,0 +1,38 @@
+import pytest
+from pyisolate.broker.crypto import CryptoBroker
+from cryptography.hazmat.primitives.asymmetric import x25519
+from cryptography.hazmat.primitives import serialization
+
+
+def make_pair():
+    priv_a = x25519.X25519PrivateKey.generate()
+    priv_b = x25519.X25519PrivateKey.generate()
+    a = CryptoBroker(
+        priv_a.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        priv_b.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ),
+    )
+    b = CryptoBroker(
+        priv_b.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        priv_a.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ),
+    )
+    return a, b
+
+
+def test_unframe_short_frame():
+    a, b = make_pair()
+    with pytest.raises(ValueError):
+        b.unframe(b"short")

--- a/tests/test_thread_extra.py
+++ b/tests/test_thread_extra.py
@@ -1,0 +1,8 @@
+import pytest
+from pyisolate.runtime.thread import _sigxcpu_handler
+from pyisolate import errors
+
+
+def test_sigxcpu_handler_raises():
+    with pytest.raises(errors.CPUExceeded):
+        _sigxcpu_handler(None, None)


### PR DESCRIPTION
## Summary
- test error handling paths for BPF, crypto, and signal handlers

## Testing
- `pytest -q`
- `python -m coverage run -m pytest -q` *(fails: No module named coverage)*

------
https://chatgpt.com/codex/tasks/task_e_685c5347a1bc83288ceb6043daf2d426