### PR TITLE
Implement Supervisor shutdown

### DIFF
--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -10,7 +10,14 @@ from .errors import (
     SandboxError,
     TimeoutError,
 )
-from .supervisor import Sandbox, Supervisor, list_active, reload_policy, spawn
+from .supervisor import (
+    Sandbox,
+    Supervisor,
+    list_active,
+    reload_policy,
+    shutdown,
+    spawn,
+)
 
 __all__ = [
     "spawn",
@@ -18,6 +25,7 @@ __all__ = [
     "Sandbox",
     "Supervisor",
     "reload_policy",
+    "shutdown",
     "SandboxError",
     "PolicyError",
     "TimeoutError",

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -93,6 +93,15 @@ class Supervisor:
         """Hot-reload policy via the BPF manager."""
         self._bpf.hot_reload(policy_path)
 
+    def shutdown(self) -> None:
+        """Stop watchdog and terminate all running sandboxes."""
+        self._watchdog.stop()
+        with self._lock:
+            sandboxes = list(self._sandboxes.values())
+        for sb in sandboxes:
+            sb.stop()
+        self._cleanup()
+
     def _cleanup(self) -> None:
         """Remove dead sandboxes from the registry."""
         with self._lock:
@@ -108,3 +117,4 @@ _supervisor = Supervisor()
 spawn = _supervisor.spawn
 list_active = _supervisor.list_active
 reload_policy = _supervisor.reload_policy
+shutdown = _supervisor.shutdown

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -29,3 +29,11 @@ def test_reload_policy_delegates(tmp_path, monkeypatch):
     p.write_text("{}")
     iso.reload_policy(str(p))
     assert called["path"] == str(p)
+
+
+def test_shutdown_joins_threads():
+    sup = iso.Supervisor()
+    sb = sup.spawn("sd")
+    sup.shutdown()
+    assert not sup._watchdog.is_alive()
+    assert not sb._thread.is_alive()


### PR DESCRIPTION
## Summary
- allow the supervisor to stop the watchdog and running sandboxes
- export `shutdown` from `pyisolate`
- test shutting down the supervisor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c53be85d08328ba6a7d17d3bf58d5