### PR TITLE
Track eBPF load success

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -21,12 +21,14 @@ class BPFManager:
         self._obj = Path(__file__).with_name("dummy.bpf.o")
 
     # internal helper
-    def _run(self, cmd: list[str]) -> None:
+    def _run(self, cmd: list[str]) -> bool:
+        """Run a subprocess command and report success."""
         try:
             subprocess.run(cmd, check=True, capture_output=True)
+            return True
         except (subprocess.CalledProcessError, FileNotFoundError):
             # Missing tools or kernel permissions are ignored in the stub
-            pass
+            return False
 
     def load(self) -> None:
         """Compile and attempt to attach the eBPF program."""
@@ -40,10 +42,11 @@ class BPFManager:
             "-o",
             str(self._obj),
         ]
-        self._run(compile_cmd)
-        self._run(["llvm-objdump", "-d", str(self._obj)])
-        self._run(["bpftool", "prog", "load", str(self._obj), "/sys/fs/bpf/dummy"])
-        self.loaded = True
+        ok = True
+        ok &= self._run(compile_cmd)
+        ok &= self._run(["llvm-objdump", "-d", str(self._obj)])
+        ok &= self._run(["bpftool", "prog", "load", str(self._obj), "/sys/fs/bpf/dummy"])
+        self.loaded = ok
 
     def hot_reload(self, policy_path: str) -> None:
         """Refresh maps based on a policy JSON file."""

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -11,15 +11,11 @@ from pyisolate.bpf.manager import BPFManager
 def test_load_runs_toolchain(monkeypatch):
     calls = []
 
-    def fake_run(cmd, check=True, capture_output=True):
+    def fake_run(self, cmd):
         calls.append(cmd)
+        return True
 
-        class R:
-            returncode = 0
-
-        return R()
-
-    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr(BPFManager, "_run", fake_run)
     mgr = BPFManager()
     mgr.load()
 
@@ -52,3 +48,13 @@ def test_hot_reload_updates_maps(tmp_path, monkeypatch):
     policy.write_text(json.dumps({"cpu": "200ms", "mem": "64MiB"}))
     mgr.hot_reload(str(policy))
     assert mgr.policy_maps == {"cpu": "200ms", "mem": "64MiB"}
+
+
+def test_load_failure_keeps_unloaded(monkeypatch):
+    def fake_run(self, cmd):
+        return False if "bpftool" in cmd else True
+
+    monkeypatch.setattr(BPFManager, "_run", fake_run)
+    mgr = BPFManager()
+    mgr.load()
+    assert not mgr.loaded


### PR DESCRIPTION
## Summary
- return a boolean from the BPF manager `_run` helper
- only mark the eBPF manager as loaded if all commands succeed
- test that a failed tool invocation keeps the manager unloaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c53bfd7b48328ba865bae2a3fef58