### PR TITLE
Fix duplicate shutdown method

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -59,15 +59,6 @@ class Supervisor:
         self._watchdog = ResourceWatchdog(self)
         self._watchdog.start()
 
-    def shutdown(self) -> None:
-        """Stop all sandboxes and the watchdog thread."""
-        with self._lock:
-            sandboxes = list(self._sandboxes.values())
-            self._sandboxes.clear()
-        for sb in sandboxes:
-            sb.stop()
-        if self._watchdog.is_alive():
-            self._watchdog.stop()
 
     def spawn(
         self,


### PR DESCRIPTION
## Summary
- remove duplicate `shutdown` method from `Supervisor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c556c02dc8328bdfd845774c3c68c