### PR TITLE
Extend Policy dataclass

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,6 +37,10 @@ cust = (Policy(mem="256MiB")
         .allow_fs("/srv/data/*.parquet")
         .allow_tcp("127.0.0.1:9200"))
 
+# Lists of accumulated permissions are available via `fs` and `tcp`:
+cust.fs  # ["/srv/data/*.parquet"]
+cust.tcp # ["127.0.0.1:9200"]
+
 sb = psi.spawn("etl", policy=cust)
 ```
 

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -1,6 +1,6 @@
 """Policy helpers stub."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 try:
@@ -58,11 +58,15 @@ from ..supervisor import reload_policy
 @dataclass
 class Policy:
     mem: str | None = None
+    fs: list[str] = field(default_factory=list)
+    tcp: list[str] = field(default_factory=list)
 
     def allow_fs(self, path: str) -> "Policy":
+        self.fs.append(path)
         return self
 
     def allow_tcp(self, addr: str) -> "Policy":
+        self.tcp.append(addr)
         return self
 
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -21,6 +21,8 @@ def test_policy_methods_chain():
     p = policy.Policy()
     assert p.allow_fs("/tmp") is p
     assert p.allow_tcp("127.0.0.1") is p
+    assert p.fs == ["/tmp"]
+    assert p.tcp == ["127.0.0.1"]
 
 
 def test_policy_refresh_invalid(tmp_path):


### PR DESCRIPTION
## Summary
- track permissions granted via allow_fs/allow_tcp
- expose the collected filesystem and TCP lists
- document new Policy fields
- test Policy permission lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9c862fbc832880b848a0253dc0d5