### PR TITLE
Add counter overflow checks

### DIFF
--- a/pyisolate/broker/crypto.py
+++ b/pyisolate/broker/crypto.py
@@ -7,6 +7,8 @@ from cryptography.hazmat.primitives.asymmetric import x25519
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
+CTR_LIMIT = 0xFFFFFFFFFFFFFFFFFFFF  # 2^96 - 1
+
 
 class CryptoBroker:
     """Broker side of the authenticated channel."""
@@ -36,12 +38,16 @@ class CryptoBroker:
 
     def frame(self, data: bytes) -> bytes:
         """Encrypt and frame ``data`` using the send counter."""
+        if self._tx_ctr > CTR_LIMIT:
+            raise OverflowError("send counter overflow")
         nonce = self._nonce(self._tx_ctr)
         self._tx_ctr += 1
         return nonce + self._aead.encrypt(nonce, data, b"")
 
     def unframe(self, data: bytes) -> bytes:
         """Validate counter, decrypt, and return plaintext."""
+        if self._rx_ctr > CTR_LIMIT:
+            raise OverflowError("receive counter overflow")
         # Maintain constant-time failure handling by always invoking ``decrypt``
         # even when the frame is malformed or the counter is unexpected.
         if len(data) < 12:

--- a/tests/test_crypto_extra.py
+++ b/tests/test_crypto_extra.py
@@ -1,5 +1,5 @@
 import pytest
-from pyisolate.broker.crypto import CryptoBroker
+from pyisolate.broker.crypto import CryptoBroker, CTR_LIMIT
 from cryptography.hazmat.primitives.asymmetric import x25519
 from cryptography.hazmat.primitives import serialization
 
@@ -36,3 +36,27 @@ def test_unframe_short_frame():
     a, b = make_pair()
     with pytest.raises(ValueError):
         b.unframe(b"short")
+
+
+def test_tx_counter_overflow():
+    a, _ = make_pair()
+    a._tx_ctr = CTR_LIMIT
+    a.frame(b"final")
+    with pytest.raises(OverflowError):
+        a.frame(b"boom")
+
+
+def test_rx_counter_overflow():
+    a, b = make_pair()
+    b._rx_ctr = CTR_LIMIT + 1
+    frame = a.frame(b"hi")
+    with pytest.raises(OverflowError):
+        b.unframe(frame)
+
+
+def test_rx_final_frame_allowed():
+    a, b = make_pair()
+    a._tx_ctr = CTR_LIMIT
+    b._rx_ctr = CTR_LIMIT
+    frame = a.frame(b"edge")
+    assert b.unframe(frame) == b"edge"


### PR DESCRIPTION
## Summary
- enforce 96-bit counter limit in `CryptoBroker.frame` and `CryptoBroker.unframe`
- test send/receive counter overflow cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9c85f62c83289b5d15f5ac7f67c5