### PR TITLE
Add error handling for policy JSON

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -54,8 +54,13 @@ class BPFManager:
         """Refresh maps based on a policy JSON file."""
         if not self.loaded:
             raise RuntimeError("BPF not loaded")
-        with open(policy_path, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
+        try:
+            with open(policy_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Policy file not found: {policy_path}") from exc
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Invalid JSON in policy file {policy_path}") from exc
         # Replace the active policy entirely to drop removed entries
         self.policy_maps = data
         for key, val in data.items():

--- a/tests/test_bpf_manager_extra.py
+++ b/tests/test_bpf_manager_extra.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 from pyisolate.bpf.manager import BPFManager
 
 
@@ -9,3 +8,22 @@ def test_hot_reload_requires_load(tmp_path):
     policy.write_text("{}")
     with pytest.raises(RuntimeError):
         mgr.hot_reload(str(policy))
+
+
+def test_hot_reload_invalid_json(tmp_path, monkeypatch):
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
+    mgr = BPFManager()
+    mgr.load()
+    bad = tmp_path / "bad.json"
+    bad.write_text("{invalid}")
+    with pytest.raises(RuntimeError):
+        mgr.hot_reload(str(bad))
+
+
+def test_hot_reload_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
+    mgr = BPFManager()
+    mgr.load()
+    missing = tmp_path / "missing.json"
+    with pytest.raises(RuntimeError):
+        mgr.hot_reload(str(missing))


### PR DESCRIPTION
## Summary
- handle missing or invalid policy JSON in BPFManager
- add regression tests for invalid JSON and missing policy files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9c857354832896bb3dfa95fb956c