### PR TITLE
Add Supervisor.get_active_threads

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -89,6 +89,12 @@ class Supervisor:
                 name: Sandbox(t) for name, t in self._sandboxes.items() if t.is_alive()
             }
 
+    def get_active_threads(self) -> list[SandboxThread]:
+        """Return active sandbox threads for internal consumers."""
+        self._cleanup()
+        with self._lock:
+            return [t for t in self._sandboxes.values() if t.is_alive()]
+
     def reload_policy(self, policy_path: str) -> None:
         """Hot-reload policy via the BPF manager."""
         self._bpf.hot_reload(policy_path)

--- a/pyisolate/watchdog.py
+++ b/pyisolate/watchdog.py
@@ -34,13 +34,8 @@ class ResourceWatchdog(threading.Thread):
     def run(self) -> None:
         while not self._stop_event.is_set():
             time.sleep(self._interval)
-            with self._supervisor._lock:
-                sandboxes: list[SandboxThread] = list(
-                    self._supervisor._sandboxes.values()
-                )
+            sandboxes: list[SandboxThread] = self._supervisor.get_active_threads()
             for sb in sandboxes:
-                if not sb.is_alive():
-                    continue
                 stats = sb.stats
                 if sb.cpu_quota_ms is not None and stats.cpu_ms >= sb.cpu_quota_ms:
                     sb._outbox.put(errors.CPUExceeded())


### PR DESCRIPTION
## Summary
- add `get_active_threads()` helper on `Supervisor`
- use the new helper inside `ResourceWatchdog`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9c84f81c83289d037eb2b7f68ba7