### PR TITLE
Implement syscall filter stub

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -19,6 +19,8 @@ class BPFManager:
         self.policy_maps: dict[str, str] = {}
         self._src = Path(__file__).with_name("dummy.bpf.c")
         self._obj = Path(__file__).with_name("dummy.bpf.o")
+        self._filter_src = Path(__file__).with_name("syscall_filter.bpf.c")
+        self._filter_obj = Path(__file__).with_name("syscall_filter.bpf.o")
 
     # internal helper
     def _run(self, cmd: list[str]) -> bool:
@@ -31,8 +33,8 @@ class BPFManager:
             return False
 
     def load(self) -> None:
-        """Compile and attempt to attach the eBPF program."""
-        compile_cmd = [
+        """Compile and attempt to attach the eBPF programs."""
+        dummy_compile = [
             "clang",
             "-target",
             "bpf",
@@ -42,11 +44,26 @@ class BPFManager:
             "-o",
             str(self._obj),
         ]
+        filter_compile = [
+            "clang",
+            "-target",
+            "bpf",
+            "-O2",
+            "-c",
+            str(self._filter_src),
+            "-o",
+            str(self._filter_obj),
+        ]
         ok = True
-        ok &= self._run(compile_cmd)
+        ok &= self._run(dummy_compile)
+        ok &= self._run(filter_compile)
         ok &= self._run(["llvm-objdump", "-d", str(self._obj)])
+        ok &= self._run(["llvm-objdump", "-d", str(self._filter_obj)])
         ok &= self._run(
             ["bpftool", "prog", "load", str(self._obj), "/sys/fs/bpf/dummy"]
+        )
+        ok &= self._run(
+            ["bpftool", "prog", "load", str(self._filter_obj), "/sys/fs/bpf/syscall_filter"]
         )
         self.loaded = ok
 

--- a/pyisolate/bpf/syscall_filter.bpf.c
+++ b/pyisolate/bpf/syscall_filter.bpf.c
@@ -1,0 +1,13 @@
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+/* Minimal syscall filter program. Returns 0 to allow all syscalls.
+ * Real implementation would inspect arguments and decide.
+ */
+
+SEC("lsm/file_open")
+int filter_file_open(void *ctx)
+{
+    return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -19,7 +19,7 @@ def test_load_runs_toolchain(monkeypatch):
     mgr = BPFManager()
     mgr.load()
 
-    clang_call = [
+    clang_dummy = [
         "clang",
         "-target",
         "bpf",
@@ -29,9 +29,28 @@ def test_load_runs_toolchain(monkeypatch):
         "-o",
         str(mgr._obj),
     ]
-    assert clang_call in calls
+    clang_filter = [
+        "clang",
+        "-target",
+        "bpf",
+        "-O2",
+        "-c",
+        str(mgr._filter_src),
+        "-o",
+        str(mgr._filter_obj),
+    ]
+    assert clang_dummy in calls
+    assert clang_filter in calls
     assert ["llvm-objdump", "-d", str(mgr._obj)] in calls
+    assert ["llvm-objdump", "-d", str(mgr._filter_obj)] in calls
     assert ["bpftool", "prog", "load", str(mgr._obj), "/sys/fs/bpf/dummy"] in calls
+    assert [
+        "bpftool",
+        "prog",
+        "load",
+        str(mgr._filter_obj),
+        "/sys/fs/bpf/syscall_filter",
+    ] in calls
     assert mgr.loaded
 
 


### PR DESCRIPTION
## Summary
- add a syscall filter eBPF program
- update `BPFManager` to compile and load the filter
- expand `test_bpf_manager` to expect the new toolchain calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d32ba353c8328852d7b5960f9ec26