### PR TITLE
Add eBPF-LSM file access hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Features
 
 * **True parallelism** — built on CPython 3.13 with the `--disable-gil` build.
-* **Kernel‑enforced security** — eBPF‑LSM & cgroup hooks gate filesystem, network, and high‑risk syscalls.
+* **Kernel‑enforced security** — path filtering via an eBPF‑LSM `file_open` hook plus cgroup guards for network and syscalls.
 * **Deterministic quotas** — per‑interpreter arenas cap RAM; perf‑event BPF guards CPU & bandwidth.
 * **Authenticated broker** — X25519 + ChaCha20‑Poly1305 secure control channel with replay counters.
 * **Hot‑reload policy** — update YAML policies in micro‑seconds without restarting guests.

--- a/pyisolate/bpf/dummy.bpf.c
+++ b/pyisolate/bpf/dummy.bpf.c
@@ -1,7 +1,0 @@
-#define SEC(NAME) __attribute__((section(NAME), used))
-SEC("xdp")
-int dummy_prog(void *ctx) {
-    return 1;
-}
-char _license[] SEC("license") = "GPL";
-

--- a/pyisolate/bpf/fs_filter.bpf.c
+++ b/pyisolate/bpf/fs_filter.bpf.c
@@ -1,0 +1,43 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include <linux/limits.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 16);
+    __type(key, __u32);
+    __type(value, char[PATH_MAX]);
+} allowed_paths SEC(".maps");
+
+SEC("lsm/file_open")
+int BPF_PROG(check_file_open, struct file *file, int mask)
+{
+    char path[PATH_MAX];
+    if (bpf_d_path(&file->f_path, path, sizeof(path)) < 0)
+        return 0;
+
+    __u32 idx;
+#pragma unroll
+    for (int i = 0; i < 16; i++) {
+        idx = i;
+        const char *allowed = bpf_map_lookup_elem(&allowed_paths, &idx);
+        if (!allowed)
+            break;
+        int match = 1;
+#pragma unroll
+        for (int j = 0; j < PATH_MAX; j++) {
+            char c = allowed[j];
+            if (!c)
+                break;
+            if (c != path[j]) {
+                match = 0;
+                break;
+            }
+        }
+        if (match)
+            return 0;
+    }
+    return -13; /* -EACCES */
+}
+
+char _license[] SEC("license") = "GPL";

--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -16,9 +16,9 @@ class BPFManager:
 
     def __init__(self):
         self.loaded = False
-        self.policy_maps: dict[str, str] = {}
-        self._src = Path(__file__).with_name("dummy.bpf.c")
-        self._obj = Path(__file__).with_name("dummy.bpf.o")
+        self.policy_maps: dict[str, object] = {}
+        self._src = Path(__file__).with_name("fs_filter.bpf.c")
+        self._obj = Path(__file__).with_name("fs_filter.bpf.o")
 
     # internal helper
     def _run(self, cmd: list[str]) -> bool:
@@ -46,7 +46,7 @@ class BPFManager:
         ok &= self._run(compile_cmd)
         ok &= self._run(["llvm-objdump", "-d", str(self._obj)])
         ok &= self._run(
-            ["bpftool", "prog", "load", str(self._obj), "/sys/fs/bpf/dummy"]
+            ["bpftool", "prog", "load", str(self._obj), "/sys/fs/bpf/fs_filter", "type", "lsm"]
         )
         self.loaded = ok
 

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -31,7 +31,15 @@ def test_load_runs_toolchain(monkeypatch):
     ]
     assert clang_call in calls
     assert ["llvm-objdump", "-d", str(mgr._obj)] in calls
-    assert ["bpftool", "prog", "load", str(mgr._obj), "/sys/fs/bpf/dummy"] in calls
+    assert [
+        "bpftool",
+        "prog",
+        "load",
+        str(mgr._obj),
+        "/sys/fs/bpf/fs_filter",
+        "type",
+        "lsm",
+    ] in calls
     assert mgr.loaded
 
 
@@ -41,13 +49,13 @@ def test_hot_reload_updates_maps(tmp_path, monkeypatch):
     mgr.load()
 
     policy = tmp_path / "policy.json"
-    policy.write_text(json.dumps({"cpu": "100ms"}))
+    policy.write_text(json.dumps({"allowed_paths": "/tmp"}))
     mgr.hot_reload(str(policy))
-    assert mgr.policy_maps["cpu"] == "100ms"
+    assert mgr.policy_maps["allowed_paths"] == "/tmp"
 
-    policy.write_text(json.dumps({"cpu": "200ms", "mem": "64MiB"}))
+    policy.write_text(json.dumps({"allowed_paths": "/var", "extra": "1"}))
     mgr.hot_reload(str(policy))
-    assert mgr.policy_maps == {"cpu": "200ms", "mem": "64MiB"}
+    assert mgr.policy_maps == {"allowed_paths": "/var", "extra": "1"}
 
 
 def test_load_failure_keeps_unloaded(monkeypatch):


### PR DESCRIPTION
## Summary
- implement an LSM `file_open` hook in `fs_filter.bpf.c`
- compile and load the new program via `BPFManager`
- update toolchain tests for new program
- document path filtering in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d32b30d58832887362574d36a080b