### PR TITLE
Restrict additional builtins in sandbox

### DIFF
--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -92,3 +92,24 @@ def test_context_manager_closes():
         assert sb.recv(timeout=0.5) == 1
 
     assert not sb._thread.is_alive()
+
+
+def test_dangerous_builtins_removed():
+    sb = iso.spawn("builtins")
+    try:
+        sb.exec(
+            "try:\n    eval('1')\nexcept NameError:\n    post('missing')\nelse:\n    post('present')"
+        )
+        assert sb.recv(timeout=0.5) == "missing"
+
+        sb.exec(
+            "try:\n    compile('1', '<s>', 'eval')\nexcept NameError:\n    post('missing')\nelse:\n    post('present')"
+        )
+        assert sb.recv(timeout=0.5) == "missing"
+
+        sb.exec(
+            "try:\n    getattr(1, 'bit_length')\nexcept NameError:\n    post('missing')\nelse:\n    post('present')"
+        )
+        assert sb.recv(timeout=0.5) == "missing"
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- make a sanitized builtins dict in `SandboxThread`
- call functions via `object.__getattribute__` to avoid exposing `getattr`
- inject safe builtins when executing guest code
- test that eval/compile/getattr are absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d32de1dcc832888a57b68ca1a3a53