### PR TITLE
Add eBPF contracts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * **Deterministic quotas** — per‑interpreter arenas cap RAM; perf‑event BPF guards CPU & bandwidth.
 * **Authenticated broker** — X25519 + ChaCha20‑Poly1305 secure control channel with replay counters.
 * **Hot‑reload policy** — update YAML policies in micro‑seconds without restarting guests.
+* **eBPF‑verified contracts** — runtime assertions compiled into BPF for extra safety.
 * **Observability** — Prometheus metrics & eBPF perf‑events for every sandbox.
 
 ---

--- a/pyisolate/bpf/dummy.bpf.c
+++ b/pyisolate/bpf/dummy.bpf.c
@@ -1,6 +1,19 @@
 #define SEC(NAME) __attribute__((section(NAME), used))
+
+/*
+ * Minimal assertion helper for demo contracts.
+ * The BPF verifier ensures the branch is safe.
+ */
+#define BPF_ASSERT(cond)              \
+    if (!(cond))                     \
+        return 0
+
+volatile const int contract_value = 1;
+
 SEC("xdp")
 int dummy_prog(void *ctx) {
+    BPF_ASSERT(ctx != (void *)0);
+    BPF_ASSERT(contract_value == 1);
     return 1;
 }
 char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
## Summary
- demonstrate eBPF-verified contract by adding assertion helper to `dummy.bpf.c`
- document eBPF contracts in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d334d79108328bb9aec0edfc8decb