### PR TITLE
Add restricted Python subset with ownership semantics

### DIFF
--- a/API.md
+++ b/API.md
@@ -65,3 +65,14 @@ class CPUExceeded(SandboxError): pass
 ```
 
 All user‑facing errors inherit from `SandboxError`.
+
+## 6  Restricted subset
+
+```python
+from pyisolate import RestrictedExec
+
+r = RestrictedExec()
+r.exec("a = 1\nb = move(a)")
+```
+
+Using `a` after it is moved raises `OwnershipError`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * **Authenticated broker** — X25519 + ChaCha20‑Poly1305 secure control channel with replay counters.
 * **Hot‑reload policy** — update YAML policies in micro‑seconds without restarting guests.
 * **Observability** — Prometheus metrics & eBPF perf‑events for every sandbox.
+* **Restricted subset** — optional interpreter with move-only ownership semantics.
 
 ---
 

--- a/docs/subset.md
+++ b/docs/subset.md
@@ -1,0 +1,16 @@
+# Restricted Subset
+
+`pyisolate.subset.RestrictedExec` evaluates a very small dialect of Python.
+Variables are move-only: once a name is passed to `move()` it can no longer be used.
+Only simple assignments, expressions, and the binary operators `+`, `-`, `*`, and `/` are accepted.
+
+Example:
+
+```python
+from pyisolate import RestrictedExec
+
+r = RestrictedExec()
+r.exec("a = 1\nb = move(a)\n")
+```
+
+Attempting to use `a` again would raise `OwnershipError`.

--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -18,6 +18,7 @@ from .supervisor import (
     spawn,
     shutdown,
 )
+from .subset import OwnershipError, RestrictedExec
 
 __all__ = [
     "spawn",
@@ -31,4 +32,6 @@ __all__ = [
     "TimeoutError",
     "MemoryExceeded",
     "CPUExceeded",
+    "RestrictedExec",
+    "OwnershipError",
 ]

--- a/pyisolate/errors.py
+++ b/pyisolate/errors.py
@@ -23,3 +23,7 @@ class MemoryExceeded(SandboxError):
 
 class CPUExceeded(SandboxError):
     """Raised when a sandbox exceeds its CPU quota."""
+
+
+class OwnershipError(SandboxError):
+    """Raised when a moved value is accessed."""

--- a/pyisolate/subset.py
+++ b/pyisolate/subset.py
@@ -1,0 +1,81 @@
+"""Minimal restricted Python subset with move-only semantics."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from .errors import SandboxError
+
+
+class OwnershipError(SandboxError):
+    """Raised when using a moved value."""
+
+
+@dataclass
+class _Owned:
+    value: Any
+    moved: bool = False
+
+
+class RestrictedExec:
+    """Evaluate a tiny Python subset tracking ownership."""
+
+    def __init__(self) -> None:
+        self._env: Dict[str, _Owned] = {}
+
+    _binops = {
+        ast.Add: lambda a, b: a + b,
+        ast.Sub: lambda a, b: a - b,
+        ast.Mult: lambda a, b: a * b,
+        ast.Div: lambda a, b: a / b,
+    }
+
+    def _eval_expr(self, node: ast.AST) -> Any:
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.Name):
+            if node.id not in self._env:
+                raise NameError(node.id)
+            slot = self._env[node.id]
+            if slot.moved:
+                raise OwnershipError(f"{node.id} has been moved")
+            return slot.value
+        if isinstance(node, ast.BinOp) and type(node.op) in self._binops:
+            left = self._eval_expr(node.left)
+            right = self._eval_expr(node.right)
+            return self._binops[type(node.op)](left, right)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == "move":
+                if len(node.args) != 1 or not isinstance(node.args[0], ast.Name):
+                    raise SyntaxError("move() expects a variable")
+                name = node.args[0].id
+                if name not in self._env:
+                    raise NameError(name)
+                slot = self._env[name]
+                if slot.moved:
+                    raise OwnershipError(f"{name} has been moved")
+                slot.moved = True
+                return slot.value
+            raise SyntaxError("function calls not allowed")
+        raise SyntaxError("unsupported expression")
+
+    def exec(self, src: str) -> Any:
+        """Execute source code. Returns last expression value."""
+        tree = ast.parse(src, mode="exec")
+        last_val = None
+        for stmt in tree.body:
+            if isinstance(stmt, ast.Assign):
+                if len(stmt.targets) != 1 or not isinstance(stmt.targets[0], ast.Name):
+                    raise SyntaxError("only simple assignments allowed")
+                val = self._eval_expr(stmt.value)
+                self._env[stmt.targets[0].id] = _Owned(val)
+            elif isinstance(stmt, ast.Expr):
+                last_val = self._eval_expr(stmt.value)
+            else:
+                raise SyntaxError("only assignments and expressions allowed")
+        return last_val
+
+
+__all__ = ["RestrictedExec", "OwnershipError"]

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pyisolate import RestrictedExec, OwnershipError
+
+
+def test_basic_arithmetic():
+    r = RestrictedExec()
+    r.exec("a = 1\nb = 2\nc = a + b")
+    assert r.exec("c") == 3
+
+
+def test_move_blocks_reuse():
+    r = RestrictedExec()
+    r.exec("x = 5\ny = move(x)")
+    with pytest.raises(OwnershipError):
+        r.exec("z = x")


### PR DESCRIPTION
## Summary
- create `RestrictedExec` to evaluate a tiny Python dialect
- raise `OwnershipError` when a moved value is reused
- document the subset and expose it via the package
- add pytest coverage for the new interpreter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3341475c83288e9fede3c450b315