### PR TITLE
Add capability-based import system

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ import pyisolate as psi
 
 | Call | Description |
 |------|-------------|
-| `psi.spawn(name:str, policy:str|dict=None) → Sandbox` | Create sandbox thread, attach eBPF, return handle. |
+| `psi.spawn(name:str, policy:str|dict=None, allowed_imports:list[str]|None=None) → Sandbox` | Create sandbox thread, attach eBPF, return handle with module whitelist. |
 | `sandbox.close(timeout=0.2)` | Graceful stop → SIGTERM; force‑kill after timeout. |
 | `with psi.spawn(name, policy)` | Context manager form; sandbox closes on exit. |
 | `psi.list_active() → Dict[str, Sandbox]` | Introspection. |
@@ -35,7 +35,8 @@ from pyisolate.policy import Policy
 
 cust = (Policy(mem="256MiB")
         .allow_fs("/srv/data/*.parquet")
-        .allow_tcp("127.0.0.1:9200"))
+        .allow_tcp("127.0.0.1:9200")
+        .allow_import("math"))
 
 # Lists of accumulated permissions are available via `fs` and `tcp`:
 cust.fs  # ["/srv/data/*.parquet"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * **Authenticated broker** — X25519 + ChaCha20‑Poly1305 secure control channel with replay counters.
 * **Hot‑reload policy** — update YAML policies in micro‑seconds without restarting guests.
 * **Observability** — Prometheus metrics & eBPF perf‑events for every sandbox.
+* **Capability imports** — restrict module access per sandbox via `allowed_imports`.
 
 ---
 
@@ -42,6 +43,14 @@ post(sqrt(2))
 with iso.spawn("demo", policy="stdlib.readonly") as sandbox:
     sandbox.exec(code)
     print("Result:", sandbox.recv())   # 1.4142135623730951
+```
+
+### Restricting imports
+
+```python
+sb = iso.spawn("safe", allowed_imports=["math"])
+sb.exec("from math import sqrt; post(sqrt(9))")
+print(sb.recv())  # 3.0
 ```
 
 ---

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -60,6 +60,7 @@ class Policy:
     mem: str | None = None
     fs: list[str] = field(default_factory=list)
     tcp: list[str] = field(default_factory=list)
+    imports: list[str] = field(default_factory=list)
 
     def allow_fs(self, path: str) -> "Policy":
         self.fs.append(path)
@@ -67,6 +68,10 @@ class Policy:
 
     def allow_tcp(self, addr: str) -> "Policy":
         self.tcp.append(addr)
+        return self
+
+    def allow_import(self, module: str) -> "Policy":
+        self.imports.append(module)
         return self
 
 

--- a/pyisolate/runtime/imports.py
+++ b/pyisolate/runtime/imports.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Capability-based import hook."""
+
+from typing import Iterable
+
+import builtins as _builtins
+
+from .. import errors
+
+
+class CapabilityImporter:
+    """Restrict module imports to an allowed set."""
+
+    def __init__(self, allowed: Iterable[str]):
+        self._allowed = {name.split(".")[0] for name in allowed}
+        self._orig_import = _builtins.__import__
+
+    def __call__(self, name, globals=None, locals=None, fromlist=(), level=0):
+        base = name.split(".")[0]
+        if base not in self._allowed:
+            raise errors.PolicyError(f"import of {name!r} is not permitted")
+        return self._orig_import(name, globals, locals, fromlist, level)

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -65,6 +65,7 @@ class Supervisor:
         policy=None,
         cpu_ms: Optional[int] = None,
         mem_bytes: Optional[int] = None,
+        allowed_imports: Optional[list[str]] = None,
     ) -> Sandbox:
         """Create and start a sandbox thread."""
         self._cleanup()
@@ -73,6 +74,7 @@ class Supervisor:
             policy=policy,
             cpu_ms=cpu_ms,
             mem_bytes=mem_bytes,
+            allowed_imports=allowed_imports,
         )
         thread.start()
         with self._lock:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -35,6 +35,23 @@ def test_call_returns_result():
         sb.close()
 
 
+def test_allowed_imports_success():
+    sb = iso.spawn("imp_ok", allowed_imports=["math"])
+    try:
+        assert sb.call("math.sqrt", 16) == 4.0
+    finally:
+        sb.close()
+
+
+def test_allowed_imports_blocked():
+    sb = iso.spawn("imp_no", allowed_imports=["json"])
+    try:
+        with pytest.raises(iso.PolicyError):
+            sb.call("math.sqrt", 4)
+    finally:
+        sb.close()
+
+
 def test_recv_timeout_raises():
     sb = iso.spawn("t4")
     try:


### PR DESCRIPTION
## Summary
- allow policy-based import capabilities
- document new `allowed_imports` spawn option
- test import capabilities

## Testing
- `pytest -q`
- `pre-commit run --files README.md API.md pyisolate/runtime/imports.py pyisolate/runtime/thread.py pyisolate/policy/__init__.py pyisolate/supervisor.py tests/test_sandbox.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d32e446d08328b8d829def3363b91