### PR TITLE
Add policy templates

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -73,3 +73,15 @@ class IpcLimiter(PolicyPlugin):
 
 register_plugin(IpcLimiter)
 ```
+
+## 6  Policy templates
+
+Several ready-to-use policies are included under the `policy/` directory:
+
+| File | Intended use |
+|------|--------------|
+| `ml.yml` | Machine learning jobs with outbound HTTPS and generous quotas |
+| `web_scraper.yml` | Basic web scraping with only HTTP/HTTPS access |
+
+Load any template with `pyisolate.policy.refresh("policy/<name>.yml")` and the
+new limits take effect instantly.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ with iso.spawn("demo", policy="stdlib.readonly") as sandbox:
     print("Result:", sandbox.recv())   # 1.4142135623730951
 ```
 
+### Policy templates
+
+Ready-made YAML policies live in the `policy/` directory.  The following
+templates cover common scenarios:
+
+* **`ml.yml`** – baseline for machine learning workloads with outbound HTTPS
+  access and generous CPU/memory limits.
+* **`web_scraper.yml`** – permits HTTP/HTTPS to the public internet while
+  restricting filesystem access to `/tmp`.
+
+Use `pyisolate.policy.refresh()` to hot‑load any of these files at runtime.
+
 ---
 
 ## Architecture

--- a/policy/ml.yml
+++ b/policy/ml.yml
@@ -1,0 +1,8 @@
+# Machine Learning workload
+version: 0.1
+fs:
+  - allow: "/srv/data/**"
+net:
+  - connect: "0.0.0.0:443"
+mem: 4096MiB
+cpu: 10000ms

--- a/policy/web_scraper.yml
+++ b/policy/web_scraper.yml
@@ -1,0 +1,9 @@
+# Web scraper workload
+version: 0.1
+fs:
+  - allow: "/tmp/**"
+net:
+  - connect: "0.0.0.0:80"
+  - connect: "0.0.0.0:443"
+mem: 256MiB
+cpu: 1000ms

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -38,3 +38,13 @@ def test_list_parsing_without_pyyaml():
     doc = 'net:\n  - connect: "127.0.0.1:6379"'
     result = policy.yaml.safe_load(doc)
     assert result == {"net": [{"connect": "127.0.0.1:6379"}]}
+
+
+@pytest.mark.parametrize("name", ["ml.yml", "web_scraper.yml"])
+def test_templates_parse(monkeypatch, name):
+    policy = load_policy()
+    monkeypatch.setattr(
+        "pyisolate.bpf.manager.BPFManager.hot_reload", lambda *a, **k: None
+    )
+    path = ROOT / "policy" / name
+    policy.refresh(str(path))


### PR DESCRIPTION
## Summary
- add `ml.yml` and `web_scraper.yml` policy templates
- document templates in README and POLICY docs
- test that bundled policies parse correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d332a9aa0832885027d942e0d5502