### PR TITLE
Add stack canary and CFI notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * **Authenticated broker** — X25519 + ChaCha20‑Poly1305 secure control channel with replay counters.
 * **Hot‑reload policy** — update YAML policies in micro‑seconds without restarting guests.
 * **Observability** — Prometheus metrics & eBPF perf‑events for every sandbox.
+* **Stack canaries & CFI** — sub‑interpreter compiled with `-fstack-protector-strong` and `-fsanitize=cfi`.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,8 @@ Anything not listed above is *not* guaranteed.
 
 * **No‑GIL build** — removes the global interpreter lock; each sandbox runs on its own OS thread.
 * **Per‑interpreter arenas** — allocator instances are never shared; freelists are local.
+* **Stack canaries** — CPython compiled with `-fstack-protector-strong`.
+* **Control‑flow integrity** — built with `-fsanitize=cfi` to detect code‑reuse attacks.
 * **Builtin shrink‑wrap** — `__import__`, `open`, `ctypes`, `cffi`, `dlopen`, `mmap`, and `pickle` removed unless explicitly re‑enabled via policy.
 
 ### 3.3 Crypto‑sealed broker


### PR DESCRIPTION
## Summary
- document stack canary and CFI hardening for the sub-interpreter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3354d7fc8328b0feea6d66896db4