### PR TITLE
Add tracing and alerting support

### DIFF
--- a/pyisolate/observability/alerts.py
+++ b/pyisolate/observability/alerts.py
@@ -1,0 +1,12 @@
+class AlertManager:
+    """Dispatch callbacks on policy violations."""
+
+    def __init__(self) -> None:
+        self._subs: list[callable] = []
+
+    def register(self, callback) -> None:
+        self._subs.append(callback)
+
+    def notify(self, sandbox: str, error: Exception) -> None:
+        for cb in list(self._subs):
+            cb(sandbox, error)

--- a/pyisolate/observability/metrics.py
+++ b/pyisolate/observability/metrics.py
@@ -19,5 +19,21 @@ class MetricsExporter:
             stats = sb.stats
             lines.append(f'pyisolate_cpu_ms{{sandbox="{name}"}} {stats.cpu_ms:.0f}')
             lines.append(f'pyisolate_mem_bytes{{sandbox="{name}"}} {stats.mem_bytes}')
+            lines.append(
+                f'pyisolate_errors_total{{sandbox="{name}"}} {stats.errors}'
+            )
+            lines.append(f'pyisolate_cost{{sandbox="{name}"}} {stats.cost:.6f}')
+            cumul = 0
+            for le, count in stats.latency.items():
+                cumul += count
+                lines.append(
+                    f'pyisolate_latency_ms_bucket{{sandbox="{name}",le="{le}"}} {cumul}'
+                )
+            lines.append(
+                f'pyisolate_latency_ms_count{{sandbox="{name}"}} {stats.operations}'
+            )
+            lines.append(
+                f'pyisolate_latency_ms_sum{{sandbox="{name}"}} {stats.latency_sum:.3f}'
+            )
 
         return "\n".join(lines) + ("\n" if lines else "")

--- a/pyisolate/observability/trace.py
+++ b/pyisolate/observability/trace.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+
+try:
+    from opentelemetry import trace as _otel_trace
+except Exception:  # pragma: no cover - optional dep
+    _otel_trace = None
+
+
+class Tracer:
+    """Light wrapper around OpenTelemetry tracer."""
+
+    def __init__(self, name: str = "pyisolate") -> None:
+        self._tracer = _otel_trace.get_tracer(name) if _otel_trace else None
+
+    @contextmanager
+    def start_span(self, name: str):
+        if self._tracer:
+            with self._tracer.start_as_current_span(name):
+                yield
+        else:
+            with nullcontext():
+                yield

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -14,7 +14,7 @@ import threading
 import time
 import tracemalloc
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from .. import errors
 
@@ -30,6 +30,11 @@ signal.signal(signal.SIGXCPU, _sigxcpu_handler)
 class Stats:
     cpu_ms: float
     mem_bytes: int
+    latency: dict[str, int]
+    latency_sum: float
+    errors: int
+    operations: int
+    cost: float
 
 
 class SandboxThread(threading.Thread):
@@ -41,6 +46,8 @@ class SandboxThread(threading.Thread):
         policy=None,
         cpu_ms: Optional[int] = None,
         mem_bytes: Optional[int] = None,
+        on_violation: Optional[Callable[[str, Exception], None]] = None,
+        tracer: Optional["Tracer"] = None,
     ):
         super().__init__(name=name, daemon=True)
         self._inbox: "queue.Queue[str]" = queue.Queue()
@@ -53,6 +60,14 @@ class SandboxThread(threading.Thread):
         self._mem_peak = 0
         self._mem_base = 0
         self._start_time = None
+        self._on_violation = on_violation
+        from ..observability.trace import Tracer
+
+        self._tracer = tracer or Tracer()
+        self._ops = 0
+        self._errors = 0
+        self._latency = {"0.5": 0, "1": 0, "5": 0, "10": 0, "inf": 0}
+        self._latency_sum = 0.0
 
     def exec(self, src: str) -> None:
         self._inbox.put(src)
@@ -96,7 +111,16 @@ class SandboxThread(threading.Thread):
         cpu_ms = self._cpu_time
         if self._start_time is not None:
             cpu_ms += (time.monotonic() - self._start_time) * 1000
-        return Stats(cpu_ms=cpu_ms, mem_bytes=self._mem_peak)
+        cost = cpu_ms * 0.0001 + self._mem_peak * 1e-9
+        return Stats(
+            cpu_ms=cpu_ms,
+            mem_bytes=self._mem_peak,
+            latency=dict(self._latency),
+            latency_sum=self._latency_sum,
+            errors=self._errors,
+            operations=self._ops,
+            cost=cost,
+        )
 
     # internal thread run loop
     def run(self) -> None:
@@ -111,14 +135,33 @@ class SandboxThread(threading.Thread):
                 src = self._inbox.get(timeout=0.1)
             except queue.Empty:
                 continue
-            try:
-                start_cpu = time.thread_time()
-                self._start_time = time.monotonic()
-                exec(src, local_vars, local_vars)
-                end_cpu = time.thread_time()
-                self._cpu_time += (end_cpu - start_cpu) * 1000
-                self._start_time = None
-                cur, peak = tracemalloc.get_traced_memory()
-                self._mem_peak = max(self._mem_peak, peak - self._mem_base)
-            except Exception as exc:  # real impl would sanitize
-                self._outbox.put(exc)
+            self._ops += 1
+            op_start = time.monotonic()
+            with self._tracer.start_span(f"sandbox:{self.name}"):
+                try:
+                    start_cpu = time.thread_time()
+                    self._start_time = time.monotonic()
+                    exec(src, local_vars, local_vars)
+                    end_cpu = time.thread_time()
+                    self._cpu_time += (end_cpu - start_cpu) * 1000
+                    self._start_time = None
+                    cur, peak = tracemalloc.get_traced_memory()
+                    self._mem_peak = max(self._mem_peak, peak - self._mem_base)
+                except Exception as exc:  # real impl would sanitize
+                    self._errors += 1
+                    if self._on_violation and isinstance(exc, errors.PolicyError):
+                        self._on_violation(self.name, exc)
+                    self._outbox.put(exc)
+                finally:
+                    duration = (time.monotonic() - op_start) * 1000
+                    self._latency_sum += duration
+                    if duration <= 0.5:
+                        self._latency["0.5"] += 1
+                    elif duration <= 1:
+                        self._latency["1"] += 1
+                    elif duration <= 5:
+                        self._latency["5"] += 1
+                    elif duration <= 10:
+                        self._latency["10"] += 1
+                    else:
+                        self._latency["inf"] += 1

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+
+
+def test_alert_on_policy_violation():
+    called = {}
+    sup = iso.Supervisor()
+    sup.register_alert_handler(lambda sb, err: called.setdefault(sb, err))
+    sb = sup.spawn("alert")
+    try:
+        sb.exec("import pyisolate as iso; raise iso.PolicyError('boom')")
+        with assert_policy_error():
+            sb.recv(timeout=0.5)
+    finally:
+        sb.close()
+        sup.shutdown()
+    assert "alert" in called
+
+
+from contextlib import contextmanager
+
+@contextmanager
+def assert_policy_error():
+    try:
+        yield
+    except iso.PolicyError:
+        pass
+    else:
+        raise AssertionError("PolicyError not raised")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -16,5 +16,7 @@ def test_export_contains_metrics():
         metrics = MetricsExporter().export()
         assert "pyisolate_cpu_ms" in metrics
         assert "pyisolate_mem_bytes" in metrics
+        assert "pyisolate_errors_total" in metrics
+        assert "pyisolate_latency_ms_bucket" in metrics
     finally:
         sb.close()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -15,5 +15,6 @@ def test_stats_property_updates():
         s = sb.stats
         assert s.cpu_ms >= 0
         assert s.mem_bytes >= 0
+        assert s.cost >= 0
     finally:
         sb.close()

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from pyisolate.observability.trace import Tracer
+
+
+def test_tracer_noop_span():
+    tracer = Tracer("test")
+    with tracer.start_span("demo"):
+        pass


### PR DESCRIPTION
## Summary
- integrate OpenTelemetry tracer if available
- export more Prometheus metrics (latency histogram, error count, cost)
- add alert manager for policy violations
- track cost and latency inside sandbox threads
- test new tracing, metrics, cost and alert features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3365a68c8328a73df6b9a55046a1