### PR TITLE
Add tracing and profiling utilities

### DIFF
--- a/API.md
+++ b/API.md
@@ -27,6 +27,9 @@ result = sb.recv(timeout=0.1)      # 1.4142135623
 | `call(func, *args, **kw)` | Import‑free RPC: call dotted `func` inside guest. |
 | `recv(timeout=None)` | Blocking receive from guest channel. |
 | `post(obj)` *(guest side)* | Send picklable object to supervisor. |
+| `enable_tracing()` | Start recording guest operations. |
+| `get_syscall_log()` | Return recorded operations. |
+| `profile()` | Snapshot of current CPU and memory usage. |
 
 ## 3  Policy helpers
 

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -8,6 +8,7 @@ sub‑interpreters and eBPF enforcement as outlined in AGENTS.md.
 from __future__ import annotations
 
 import json
+import logging
 import queue
 import signal
 import threading
@@ -43,6 +44,7 @@ class SandboxThread(threading.Thread):
         mem_bytes: Optional[int] = None,
     ):
         super().__init__(name=name, daemon=True)
+        self._logger = logging.getLogger(f"pyisolate.{name}")
         self._inbox: "queue.Queue[str]" = queue.Queue()
         self._outbox: "queue.Queue[Any]" = queue.Queue()
         self._stop_event = threading.Event()
@@ -53,8 +55,26 @@ class SandboxThread(threading.Thread):
         self._mem_peak = 0
         self._mem_base = 0
         self._start_time = None
+        self._trace_enabled = False
+        self._syscall_log: list[str] = []
+
+    def enable_tracing(self) -> None:
+        """Start recording guest operations."""
+        self._trace_enabled = True
+        self._syscall_log = []
+
+    def get_syscall_log(self) -> list[str]:
+        """Return recorded guest operations."""
+        return list(self._syscall_log)
+
+    def profile(self) -> Stats:
+        """Return current CPU and memory usage."""
+        return self.stats
 
     def exec(self, src: str) -> None:
+        if self._trace_enabled:
+            self._syscall_log.append(src)
+        self._logger.debug("exec", extra={"code": src})
         self._inbox.put(src)
 
     def call(self, func: str, *args, **kwargs):
@@ -114,6 +134,9 @@ class SandboxThread(threading.Thread):
             try:
                 start_cpu = time.thread_time()
                 self._start_time = time.monotonic()
+                if self._trace_enabled:
+                    self._syscall_log.append(src)
+                self._logger.debug("run_exec", extra={"code": src})
                 exec(src, local_vars, local_vars)
                 end_cpu = time.thread_time()
                 self._cpu_time += (end_cpu - start_cpu) * 1000

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -36,6 +36,15 @@ class Sandbox:
     def close(self, timeout: float = 0.2) -> None:
         self._thread.stop(timeout)
 
+    def enable_tracing(self) -> None:
+        self._thread.enable_tracing()
+
+    def get_syscall_log(self) -> list[str]:
+        return self._thread.get_syscall_log()
+
+    def profile(self):
+        return self._thread.profile()
+
     # allow ``with spawn(...) as sb:`` usage
     def __enter__(self) -> "Sandbox":
         return self

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+
+
+def test_tracing_records_exec():
+    sb = iso.spawn("trace")
+    try:
+        sb.enable_tracing()
+        sb.exec("post('x')")
+        sb.recv(timeout=0.5)
+        log = sb.get_syscall_log()
+        assert any("post('x')" in entry for entry in log)
+    finally:
+        sb.close()
+
+
+def test_profile_returns_stats():
+    sb = iso.spawn("prof")
+    try:
+        sb.exec("post(1)")
+        sb.recv(timeout=0.5)
+        stats = sb.profile()
+        assert stats.cpu_ms >= 0
+        assert stats.mem_bytes >= 0
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- provide SandboxThread tracing and structured logging
- expose tracing/profile helpers on Sandbox class
- document debugging helpers in API docs
- add tests for tracing and profiling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d331e27a08328a46b937e02943868