### PR TITLE
Add bandwidth and IOPS quotas

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ import pyisolate as psi
 
 | Call | Description |
 |------|-------------|
-| `psi.spawn(name:str, policy:str|dict=None) → Sandbox` | Create sandbox thread, attach eBPF, return handle. |
+| `psi.spawn(name:str, policy:str|dict=None, cpu_ms:int=None, mem_bytes:int=None, bandwidth_bytes:int=None, iops:int=None) → Sandbox` | Create sandbox thread with optional quotas, attach eBPF, return handle. |
 | `sandbox.close(timeout=0.2)` | Graceful stop → SIGTERM; force‑kill after timeout. |
 | `with psi.spawn(name, policy)` | Context manager form; sandbox closes on exit. |
 | `psi.list_active() → Dict[str, Sandbox]` | Introspection. |
@@ -50,6 +50,8 @@ sb = psi.spawn("etl", policy=cust)
 |----------|---------|
 | `sb.stats.cpu_ms` | CPU consumed since launch. |
 | `sb.stats.mem_bytes` | Resident set size (live). |
+| `sb.stats.io_bytes` | Total bytes of I/O performed. |
+| `sb.stats.iops` | I/O operations performed. |
 | `psi.events` | Async iterator of `(ts, sandbox, event)` tuples. |
 
 Event types: `MEM_KILL`, `CPU_THROTTLE`, `POLICY_HOTLOAD`, `BROKER_ERROR`.
@@ -62,6 +64,8 @@ class PolicyError(SandboxError): pass
 class TimeoutError(SandboxError): pass
 class MemoryExceeded(SandboxError): pass
 class CPUExceeded(SandboxError): pass
+class BandwidthExceeded(SandboxError): pass
+class IOPSExceeded(SandboxError): pass
 ```
 
 All user‑facing errors inherit from `SandboxError`.

--- a/POLICY.md
+++ b/POLICY.md
@@ -32,6 +32,8 @@ sandboxes:
 | `net` | `none` \| list of rules | Hooked at `cgroup/connect*`; tuples `["ip:port", "tcp/udp"]`. |
 | `mem` | `<N>MiB` | Hard cap, checked in allocator; guest killed on exceed. |
 | `cpu` | `<N>ms` per 100 ms window | Perf‑event counter → SIGXCPU to offending thread. |
+| `bw` | `<N>bytes` per second | Cgroup I/O throttling of aggregate bandwidth. |
+| `iops` | `<N>` operations per second | Limit on I/O syscall count. |
 
 *Rule precedence:* first match wins. Unmatched operation → **deny**.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 * **True parallelism** — built on CPython 3.13 with the `--disable-gil` build.
 * **Kernel‑enforced security** — eBPF‑LSM & cgroup hooks gate filesystem, network, and high‑risk syscalls.
-* **Deterministic quotas** — per‑interpreter arenas cap RAM; perf‑event BPF guards CPU & bandwidth.
+* **Deterministic quotas** — per‑interpreter arenas cap RAM; perf‑event BPF guards CPU, bandwidth & IOPS.
 * **Authenticated broker** — X25519 + ChaCha20‑Poly1305 secure control channel with replay counters.
 * **Hot‑reload policy** — update YAML policies in micro‑seconds without restarting guests.
 * **Observability** — Prometheus metrics & eBPF perf‑events for every sandbox.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 | ----------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------- |
 | **Guest attacker**                              | Executes arbitrary Python bytecode inside a sandbox sub‑interpreter. | • Escalate into supervisor or host OS                |
 | • Read/modify data belonging to other sandboxes |                                                                      |                                                      |
-| • Exhaust shared resources (CPU / RAM / I/O)    |                                                                      |                                                      |
+| • Exhaust shared resources (CPU / RAM / I/O bandwidth & ops)    |                                                                      |                                                      |
 | **Network adversary**                           | Can capture, replay, or inject broker frames over IPC/TCP.           | Hijack privileged RPCs; tamper or spoof audit trails |
 | **Malicious extension author**                  | Crafts a wheel with native code to break isolation.                  | Load arbitrary ELF, bypass policies                  |
 
@@ -31,7 +31,7 @@ Anything not listed above is *not* guaranteed.
 ### 3.1 Kernel eBPF guards
 
 * **LSM hooks** (`file_open`, `inode_unlink`, `socket_connect`) — path‑aware FS & net gating.
-* **cgroup programs** — per‑sandbox memory (`cgroup/mem`), CPU (`perf‑event`) & bandwidth limits.
+* **cgroup programs** — per‑sandbox memory (`cgroup/mem`), CPU (`perf‑event`), bandwidth & IOPS limits.
 * **Tracepoint programs** — instant kill on `execve`, `ptrace`, `bpf()`, or other high‑risk syscalls.
 
 ### 3.2 CPython hardening

--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -4,7 +4,9 @@ This module exposes the high-level API described in API.md.
 """
 
 from .errors import (
+    BandwidthExceeded,
     CPUExceeded,
+    IOPSExceeded,
     MemoryExceeded,
     PolicyError,
     SandboxError,
@@ -31,4 +33,6 @@ __all__ = [
     "TimeoutError",
     "MemoryExceeded",
     "CPUExceeded",
+    "BandwidthExceeded",
+    "IOPSExceeded",
 ]

--- a/pyisolate/errors.py
+++ b/pyisolate/errors.py
@@ -23,3 +23,11 @@ class MemoryExceeded(SandboxError):
 
 class CPUExceeded(SandboxError):
     """Raised when a sandbox exceeds its CPU quota."""
+
+
+class BandwidthExceeded(SandboxError):
+    """Raised when a sandbox exceeds its bandwidth quota."""
+
+
+class IOPSExceeded(SandboxError):
+    """Raised when a sandbox exceeds its IOPS quota."""

--- a/pyisolate/observability/metrics.py
+++ b/pyisolate/observability/metrics.py
@@ -19,5 +19,7 @@ class MetricsExporter:
             stats = sb.stats
             lines.append(f'pyisolate_cpu_ms{{sandbox="{name}"}} {stats.cpu_ms:.0f}')
             lines.append(f'pyisolate_mem_bytes{{sandbox="{name}"}} {stats.mem_bytes}')
+            lines.append(f'pyisolate_io_bytes{{sandbox="{name}"}} {stats.io_bytes}')
+            lines.append(f'pyisolate_iops{{sandbox="{name}"}} {stats.iops}')
 
         return "\n".join(lines) + ("\n" if lines else "")

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -58,6 +58,8 @@ from ..supervisor import reload_policy
 @dataclass
 class Policy:
     mem: str | None = None
+    bw: str | None = None
+    iops: int | None = None
     fs: list[str] = field(default_factory=list)
     tcp: list[str] = field(default_factory=list)
 

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -65,6 +65,8 @@ class Supervisor:
         policy=None,
         cpu_ms: Optional[int] = None,
         mem_bytes: Optional[int] = None,
+        bandwidth_bytes: Optional[int] = None,
+        iops: Optional[int] = None,
     ) -> Sandbox:
         """Create and start a sandbox thread."""
         self._cleanup()
@@ -73,6 +75,8 @@ class Supervisor:
             policy=policy,
             cpu_ms=cpu_ms,
             mem_bytes=mem_bytes,
+            bandwidth_bytes=bandwidth_bytes,
+            iops=iops,
         )
         thread.start()
         with self._lock:

--- a/pyisolate/watchdog.py
+++ b/pyisolate/watchdog.py
@@ -46,3 +46,14 @@ class ResourceWatchdog(threading.Thread):
                 ):
                     sb._outbox.put(errors.MemoryExceeded())
                     sb.stop()
+                    continue
+                if sb.bandwidth_quota_bytes is not None and (
+                    stats.io_bytes >= sb.bandwidth_quota_bytes
+                ):
+                    sb._outbox.put(errors.BandwidthExceeded())
+                    sb.stop()
+                    continue
+                if sb.iops_quota is not None and stats.iops >= sb.iops_quota:
+                    sb._outbox.put(errors.IOPSExceeded())
+                    sb.stop()
+                    continue

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -16,5 +16,7 @@ def test_export_contains_metrics():
         metrics = MetricsExporter().export()
         assert "pyisolate_cpu_ms" in metrics
         assert "pyisolate_mem_bytes" in metrics
+        assert "pyisolate_io_bytes" in metrics
+        assert "pyisolate_iops" in metrics
     finally:
         sb.close()

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -73,6 +73,26 @@ def test_memory_quota_exceeded():
         sb.close()
 
 
+def test_bandwidth_quota_exceeded():
+    sb = iso.spawn("tbw", bandwidth_bytes=10)
+    try:
+        sb._thread.record_io(20)
+        with pytest.raises(iso.BandwidthExceeded):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
+def test_iops_quota_exceeded():
+    sb = iso.spawn("tiops", iops=1)
+    try:
+        sb._thread.record_io(1, ops=2)
+        with pytest.raises(iso.IOPSExceeded):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
 def test_policy_refresh_parses_yaml(tmp_path, monkeypatch):
     policy_file = tmp_path / "p.yml"
     policy_file.write_text("version: 0.1\n")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -15,5 +15,7 @@ def test_stats_property_updates():
         s = sb.stats
         assert s.cpu_ms >= 0
         assert s.mem_bytes >= 0
+        assert s.io_bytes >= 0
+        assert s.iops >= 0
     finally:
         sb.close()

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -33,6 +33,26 @@ def test_memory_quota_exceeded_via_watchdog():
         sb.close()
 
 
+def test_bandwidth_quota_exceeded_via_watchdog():
+    sb = iso.spawn("wdbw", bandwidth_bytes=10)
+    try:
+        sb._thread.record_io(20)
+        with pytest.raises(iso.BandwidthExceeded):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
+def test_iops_quota_exceeded_via_watchdog():
+    sb = iso.spawn("wdiops", iops=1)
+    try:
+        sb._thread.record_io(1, ops=2)
+        with pytest.raises(iso.IOPSExceeded):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
 def test_watchdog_thread_stops():
     sup = iso.supervisor._supervisor
     iso.shutdown()


### PR DESCRIPTION
## Summary
- add `BandwidthExceeded` and `IOPSExceeded` exceptions
- track IO usage in `SandboxThread` and export via metrics
- enforce bandwidth and IOPS quotas in `ResourceWatchdog`
- wire quotas through `Supervisor.spawn`
- support new keys in policy DSL and docs
- expand tests for bandwidth and IOPS limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d330cd1f483289153ca5c953c74e6