### PR TITLE
Add warm pool for sandbox threads

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -91,6 +91,21 @@ class SandboxThread(threading.Thread):
         self._stop_event.set()
         self.join(timeout)
 
+    def reset(
+        self,
+        name: str,
+        policy=None,
+        cpu_ms: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
+    ) -> None:
+        """Reuse this thread for a new sandbox."""
+        self.name = name
+        self.policy = policy
+        self.cpu_quota_ms = cpu_ms
+        self.mem_quota_bytes = mem_bytes
+        self._cpu_time = 0.0
+        self._mem_peak = 0
+
     @property
     def stats(self):
         cpu_ms = self._cpu_time

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -51,11 +51,16 @@ class Sandbox:
 class Supervisor:
     """Main supervisor owning all sandboxes."""
 
-    def __init__(self):
+    def __init__(self, warm_pool: int = 0):
         self._sandboxes: Dict[str, SandboxThread] = {}
         self._lock = threading.Lock()
         self._bpf = BPFManager()
         self._bpf.load()
+        self._warm_pool: list[SandboxThread] = []
+        for i in range(warm_pool):
+            t = SandboxThread(name=f"warm-{i}")
+            t.start()
+            self._warm_pool.append(t)
         self._watchdog = ResourceWatchdog(self)
         self._watchdog.start()
 
@@ -68,14 +73,23 @@ class Supervisor:
     ) -> Sandbox:
         """Create and start a sandbox thread."""
         self._cleanup()
-        thread = SandboxThread(
-            name=name,
-            policy=policy,
-            cpu_ms=cpu_ms,
-            mem_bytes=mem_bytes,
-        )
-        thread.start()
         with self._lock:
+            if self._warm_pool:
+                thread = self._warm_pool.pop()
+                thread.reset(
+                    name,
+                    policy=policy,
+                    cpu_ms=cpu_ms,
+                    mem_bytes=mem_bytes,
+                )
+            else:
+                thread = SandboxThread(
+                    name=name,
+                    policy=policy,
+                    cpu_ms=cpu_ms,
+                    mem_bytes=mem_bytes,
+                )
+                thread.start()
             self._sandboxes[name] = thread
         # Remove references to any terminated sandboxes
         self._cleanup()
@@ -104,7 +118,9 @@ class Supervisor:
         self._watchdog.stop()
         with self._lock:
             sandboxes = list(self._sandboxes.values())
-        for sb in sandboxes:
+            warm = list(self._warm_pool)
+            self._warm_pool.clear()
+        for sb in sandboxes + warm:
             sb.stop()
         self._cleanup()
 
@@ -114,6 +130,7 @@ class Supervisor:
             dead = [n for n, t in self._sandboxes.items() if not t.is_alive()]
             for n in dead:
                 del self._sandboxes[n]
+            self._warm_pool = [t for t in self._warm_pool if t.is_alive()]
 
 
 _supervisor = Supervisor()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -37,3 +37,22 @@ def test_shutdown_joins_threads():
     sup.shutdown()
     assert not sup._watchdog.is_alive()
     assert not sb._thread.is_alive()
+
+
+def test_spawn_uses_warm_pool():
+    sup = iso.Supervisor(warm_pool=1)
+    try:
+        warm = sup._warm_pool[0]
+        sb = sup.spawn("warm")
+        assert sb._thread is warm
+        assert len(sup._warm_pool) == 0
+    finally:
+        sb.close()
+        sup.shutdown()
+
+
+def test_shutdown_clears_warm_pool():
+    sup = iso.Supervisor(warm_pool=1)
+    assert len(sup._warm_pool) == 1
+    sup.shutdown()
+    assert sup._warm_pool == []


### PR DESCRIPTION
## Summary
- enable initialization with pre-warmed sandbox threads
- use a warm pool in `spawn()`
- clean up warm pool in `shutdown()`
- expose a `reset()` method on `SandboxThread`
- test warm pool behaviour

## Testing
- `pytest -q`
- `pip install pre-commit` *(fails: Tunnel connection failed)*
- `pre-commit run --files pyisolate/runtime/thread.py pyisolate/supervisor.py tests/test_supervisor.py` *(fails: command not found)*
- `pip install flake8` *(fails: Tunnel connection failed)*
- `flake8 pyisolate/runtime/thread.py pyisolate/supervisor.py tests/test_supervisor.py` *(fails: command not found)*
- `pylint pyisolate/runtime/thread.py pyisolate/supervisor.py tests/test_supervisor.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d32fe91c483288946cfa78b8aa853