### PR TITLE
Implement eBPF skeleton caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
+.skel.h
 .env/

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -9,6 +9,7 @@ from pyisolate.bpf.manager import BPFManager
 
 
 def test_load_runs_toolchain(monkeypatch):
+    BPFManager._SKEL_CACHE = {}
     calls = []
 
     def fake_run(self, cmd):
@@ -30,12 +31,19 @@ def test_load_runs_toolchain(monkeypatch):
         str(mgr._obj),
     ]
     assert clang_call in calls
+    skel_cmd = [
+        "sh",
+        "-c",
+        f"bpftool gen skeleton {mgr._obj} > {mgr._skel}",
+    ]
+    assert skel_cmd in calls
     assert ["llvm-objdump", "-d", str(mgr._obj)] in calls
     assert ["bpftool", "prog", "load", str(mgr._obj), "/sys/fs/bpf/dummy"] in calls
     assert mgr.loaded
 
 
 def test_hot_reload_updates_maps(tmp_path, monkeypatch):
+    BPFManager._SKEL_CACHE = {}
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
     mgr = BPFManager()
     mgr.load()
@@ -51,6 +59,7 @@ def test_hot_reload_updates_maps(tmp_path, monkeypatch):
 
 
 def test_load_failure_keeps_unloaded(monkeypatch):
+    BPFManager._SKEL_CACHE = {}
     def fake_run(self, cmd):
         return False if "bpftool" in cmd else True
 
@@ -58,3 +67,38 @@ def test_load_failure_keeps_unloaded(monkeypatch):
     mgr = BPFManager()
     mgr.load()
     assert not mgr.loaded
+
+
+def test_load_skips_when_cached(monkeypatch):
+    BPFManager._SKEL_CACHE = {}
+    monkeypatch.setattr(BPFManager, "_run", lambda self, cmd: True)
+    mgr = BPFManager()
+    mgr.load()  # first load to populate cache
+
+    calls = []
+
+    def record(self, cmd):
+        calls.append(cmd)
+        return True
+
+    monkeypatch.setattr(BPFManager, "_run", record)
+    mgr.load()  # cached
+
+    compile_cmd = [
+        "clang",
+        "-target",
+        "bpf",
+        "-O2",
+        "-c",
+        str(mgr._src),
+        "-o",
+        str(mgr._obj),
+    ]
+    skel_cmd = [
+        "sh",
+        "-c",
+        f"bpftool gen skeleton {mgr._obj} > {mgr._skel}",
+    ]
+
+    assert compile_cmd not in calls
+    assert skel_cmd not in calls

--- a/tests/test_bpf_manager_extra.py
+++ b/tests/test_bpf_manager_extra.py
@@ -3,6 +3,7 @@ from pyisolate.bpf.manager import BPFManager
 
 
 def test_hot_reload_requires_load(tmp_path):
+    BPFManager._SKEL_CACHE = {}
     mgr = BPFManager()
     policy = tmp_path / "p.json"
     policy.write_text("{}")
@@ -11,6 +12,7 @@ def test_hot_reload_requires_load(tmp_path):
 
 
 def test_hot_reload_invalid_json(tmp_path, monkeypatch):
+    BPFManager._SKEL_CACHE = {}
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
     mgr = BPFManager()
     mgr.load()
@@ -21,6 +23,7 @@ def test_hot_reload_invalid_json(tmp_path, monkeypatch):
 
 
 def test_hot_reload_missing_file(tmp_path, monkeypatch):
+    BPFManager._SKEL_CACHE = {}
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
     mgr = BPFManager()
     mgr.load()


### PR DESCRIPTION
## Summary
- cache generated eBPF skeletons
- adjust BPF manager logic for cached skeleton reuse
- ignore skeleton headers in git
- update tests for skeleton caching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d32fb3fa48328b41bb5ca2ceb912f