### PR TITLE
Add fuzzing and regression test suites

### DIFF
--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -1,0 +1,43 @@
+import sys
+import json
+import random
+import string
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate.policy as policy
+from pyisolate.bpf.manager import BPFManager
+
+
+def random_text(max_len=20):
+    letters = string.ascii_letters + string.digits + '\n: -'
+    return ''.join(random.choice(letters) for _ in range(random.randint(1, max_len)))
+
+
+def test_policy_parser_fuzz():
+    for _ in range(100):
+        data = random_text()
+        try:
+            policy.yaml.safe_load(data)
+        except Exception:
+            pass
+
+
+def test_bpf_hot_reload_fuzz(tmp_path, monkeypatch):
+    monkeypatch.setattr(BPFManager, "_run", lambda *a, **k: True)
+    mgr = BPFManager()
+    mgr.load()
+
+    for _ in range(50):
+        mapping = {random_text(5): random_text(5) for _ in range(3)}
+        p = tmp_path / "p.json"
+        p.write_text(json.dumps(mapping))
+        mgr.hot_reload(str(p))
+
+        p.write_text(random_text())
+        with pytest.raises((RuntimeError, AttributeError)):
+            mgr.hot_reload(str(p))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,12 @@
+import sys
+import runpy
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_echo_example(capsys):
+    runpy.run_path(str(ROOT / "examples" / "echo.py"), run_name="__main__")
+    out = capsys.readouterr().out
+    assert "Hello from sandbox" in out

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,17 @@
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+
+
+def test_spawn_speed():
+    start = time.perf_counter()
+    for i in range(5):
+        sb = iso.spawn(f"perf{i}")
+        sb.close()
+    duration = time.perf_counter() - start
+    assert duration < 5.0

--- a/tests/test_security_suite.py
+++ b/tests/test_security_suite.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+
+
+@pytest.mark.xfail(reason="Sandbox lacks real syscall filtering")
+def test_escape_attempt_file_read():
+    sb = iso.spawn("escape1")
+    try:
+        sb.exec("import pathlib; post(pathlib.Path('/etc/hosts').read_text())")
+        sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
+@pytest.mark.xfail(reason="Side channel protections not implemented")
+def test_time_side_channel():
+    sb = iso.spawn("escape2")
+    try:
+        sb.exec("import time; post(time.perf_counter())")
+        first = sb.recv(timeout=1)
+        sb.exec("import time; post(time.perf_counter())")
+        second = sb.recv(timeout=1)
+        assert abs(second - first) <= 0.001
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- add simple fuzzing tests for policy parser and BPF manager
- add security suite placeholders showing expected failures
- add performance regression test for spawning sandboxes
- add integration test running the echo example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d336de90483289ef40df504829528