### PR TITLE
Add NUMA-aware scheduling

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ import pyisolate as psi
 
 | Call | Description |
 |------|-------------|
-| `psi.spawn(name:str, policy:str|dict=None) → Sandbox` | Create sandbox thread, attach eBPF, return handle. |
+| `psi.spawn(name:str, policy:str|dict=None, numa_node:int|None=None) → Sandbox` | Create sandbox thread, attach eBPF, return handle. |
 | `sandbox.close(timeout=0.2)` | Graceful stop → SIGTERM; force‑kill after timeout. |
 | `with psi.spawn(name, policy)` | Context manager form; sandbox closes on exit. |
 | `psi.list_active() → Dict[str, Sandbox]` | Introspection. |
@@ -16,7 +16,7 @@ import pyisolate as psi
 ## 2  Executing code
 
 ```python
-sb = psi.spawn("guest42", policy="defaults")
+sb = psi.spawn("guest42", policy="defaults", numa_node=0)
 sb.exec("from math import sqrt; post(sqrt(2))")
 result = sb.recv(timeout=0.1)      # 1.4142135623
 ```
@@ -41,7 +41,7 @@ cust = (Policy(mem="256MiB")
 cust.fs  # ["/srv/data/*.parquet"]
 cust.tcp # ["127.0.0.1:9200"]
 
-sb = psi.spawn("etl", policy=cust)
+sb = psi.spawn("etl", policy=cust, numa_node=1)
 ```
 
 ## 4  Metrics & events

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * **Authenticated broker** — X25519 + ChaCha20‑Poly1305 secure control channel with replay counters.
 * **Hot‑reload policy** — update YAML policies in micro‑seconds without restarting guests.
 * **Observability** — Prometheus metrics & eBPF perf‑events for every sandbox.
+* **NUMA‑aware scheduling** — bind sandboxes to the CPUs of a chosen node on multi‑socket hosts.
 
 ---
 

--- a/pyisolate/numa.py
+++ b/pyisolate/numa.py
@@ -1,0 +1,43 @@
+"""NUMA affinity helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Set
+
+
+def _parse_cpu_list(text: str) -> set[int]:
+    """Parse Linux cpulist format like ``0-3,8``."""
+    cpus: set[int] = set()
+    for part in text.strip().split(','):
+        if not part:
+            continue
+        if '-' in part:
+            start_str, end_str = part.split('-')
+            start, end = int(start_str), int(end_str)
+            cpus.update(range(start, end + 1))
+        else:
+            cpus.add(int(part))
+    return cpus
+
+
+def get_numa_cpus(node: int) -> Set[int]:
+    """Return a set of CPU ids for the given NUMA node."""
+    path = f"/sys/devices/system/node/node{node}/cpulist"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = fh.read()
+    except OSError:
+        return set()
+    return _parse_cpu_list(data)
+
+
+def bind_current_thread(node: int) -> None:
+    """Attempt to bind the current thread to the CPUs of ``node``."""
+    cpus = get_numa_cpus(node)
+    if not cpus:
+        return
+    try:
+        os.sched_setaffinity(0, cpus)
+    except (AttributeError, OSError):
+        pass

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -65,6 +65,7 @@ class Supervisor:
         policy=None,
         cpu_ms: Optional[int] = None,
         mem_bytes: Optional[int] = None,
+        numa_node: Optional[int] = None,
     ) -> Sandbox:
         """Create and start a sandbox thread."""
         self._cleanup()
@@ -73,6 +74,7 @@ class Supervisor:
             policy=policy,
             cpu_ms=cpu_ms,
             mem_bytes=mem_bytes,
+            numa_node=numa_node,
         )
         thread.start()
         with self._lock:

--- a/tests/test_numa.py
+++ b/tests/test_numa.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+from pyisolate import numa
+
+
+def test_spawn_calls_bind(monkeypatch):
+    called = {}
+
+    def fake_bind(node):
+        called['node'] = node
+
+    monkeypatch.setattr('pyisolate.runtime.thread.bind_current_thread', fake_bind)
+    sb = iso.spawn('n0', numa_node=0)
+    try:
+        sb.exec('post(1)')
+        assert sb.recv(timeout=0.5) == 1
+    finally:
+        sb.close()
+    assert called['node'] == 0
+
+
+def test_parse_cpu_list():
+    assert numa._parse_cpu_list('0-2,4,6-7') == {0, 1, 2, 4, 6, 7}


### PR DESCRIPTION
## Summary
- support binding sandbox threads to a NUMA node
- expose new `numa_node` parameter in `spawn`
- document NUMA scheduling in the API and README
- test NUMA helper logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d331381f8832896fc2a3e8bd20ae2