### PR TITLE
Add sandbox name validation

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -96,6 +96,10 @@ class Supervisor:
         numa_node: Optional[int] = None,
     ) -> Sandbox:
         """Create and start a sandbox thread."""
+        if not isinstance(name, str) or not name:
+            raise ValueError("Sandbox name must be non-empty string")
+        if len(name) > 64:
+            raise ValueError("Sandbox name too long")
         self._cleanup()
         cg_path = cgroup.create(name, cpu_ms, mem_bytes)
         thread = SandboxThread(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(ROOT))
 
 import pyisolate as iso
 from pyisolate.bpf.manager import BPFManager
+import pytest
 
 
 def test_list_active_contains_spawned():
@@ -57,3 +58,18 @@ def test_shutdown_clears_warm_pool():
     assert len(sup._warm_pool) == 1
     sup.shutdown()
     assert sup._warm_pool == []
+
+
+def test_spawn_invalid_name_empty():
+    with pytest.raises(ValueError):
+        iso.spawn("")
+
+
+def test_spawn_invalid_name_long():
+    with pytest.raises(ValueError):
+        iso.spawn("x" * 65)
+
+
+def test_spawn_invalid_name_type():
+    with pytest.raises(ValueError):
+        iso.spawn(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- validate the sandbox name in `Supervisor.spawn`
- raise `ValueError` for empty, non-string, or overly long names
- test invalid sandbox names

## Testing
- `pytest -q` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d48921e0083288c805fba23d35e06