### PR TITLE
Add structured logging helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ pytest -q          # run the test‑suite
 python examples/echo.py
 ```
 
+### Structured logging
+
+Enable JSON-formatted logs for easier parsing:
+
+```python
+from pyisolate.logging import setup_structured_logging
+
+setup_structured_logging()
+```
+
 ### Hello World
 
 ```python

--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -31,6 +31,7 @@ from .capabilities import ROOT, Capability, Token, RootCapability
 from .checkpoint import checkpoint, restore
 from .migration import migrate
 from .policy import refresh_remote
+from .logging import setup_structured_logging
 
 
 __all__ = [
@@ -63,4 +64,5 @@ __all__ = [
     "restore",
     "migrate",
     "refresh_remote",
+    "setup_structured_logging",
 ]

--- a/pyisolate/logging.py
+++ b/pyisolate/logging.py
@@ -1,0 +1,16 @@
+"""Logging helpers for PyIsolate."""
+
+from __future__ import annotations
+
+import logging
+
+
+def setup_structured_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger to emit JSON formatted messages."""
+
+    logging.basicConfig(
+        level=level,
+        format='{"timestamp": "%(asctime)s", "level": "%(levelname)s", '
+               '"component": "%(name)s", "message": "%(message)s"}',
+    )
+

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,13 @@
+import logging
+
+from pyisolate.logging import setup_structured_logging
+
+
+def test_setup_structured_logging():
+    root = logging.getLogger()
+    # Remove any existing handlers to ensure basicConfig configures one
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    setup_structured_logging()
+    assert root.level == logging.INFO
+    assert root.handlers


### PR DESCRIPTION
## Summary
- add `setup_structured_logging()` helper to configure JSON log format
- expose helper from package init
- document logging helper in README
- test that the helper configures the root logger

## Testing
- `pytest -k logging -q` *(fails: SyntaxError in unrelated bpf/manager.py)*

------
https://chatgpt.com/codex/tasks/task_e_685d4894e5e48328afbb5d54e811db0c