### PR TITLE
Add sandbox cleanup warning

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -25,18 +25,12 @@ class BPFManager:
         self.policy_maps: dict[str, str] = {}
         self._src = Path(__file__).with_name("dummy.bpf.c")
         self._obj = Path(__file__).with_name("dummy.bpf.o")
-<<<<<<< codex/pre-compile-ebpf-programs-and-cache-skeletons
         self._skel = Path(__file__).with_name("dummy.skel.h")
         self.skeleton = ""
-=======
         self._filter_src = Path(__file__).with_name("syscall_filter.bpf.c")
         self._filter_obj = Path(__file__).with_name("syscall_filter.bpf.o")
-<<<<<<< codex/add-ebpf-resource-guard-and-update-bpfmanager
         self._guard_src = Path(__file__).with_name("resource_guard.bpf.c")
         self._guard_obj = Path(__file__).with_name("resource_guard.bpf.o")
-=======
->>>>>>> main
->>>>>>> main
 
     # internal helper
     def _run(self, cmd: list[str]) -> bool:
@@ -81,10 +75,9 @@ class BPFManager:
             str(self._guard_obj),
         ]
         ok = True
-<<<<<<< codex/pre-compile-ebpf-programs-and-cache-skeletons
+        compile_cmd = dummy_compile
         if self._src not in self._SKEL_CACHE:
             ok &= self._run(compile_cmd)
-            # Generate and store the skeleton if tools are available
             skel_cmd = [
                 "sh",
                 "-c",
@@ -96,18 +89,12 @@ class BPFManager:
                     self._SKEL_CACHE[self._src] = self._skel.read_text()
                 except OSError:
                     self._SKEL_CACHE[self._src] = ""
-                self.skeleton = self._SKEL_CACHE[self._src]
+            self.skeleton = self._SKEL_CACHE.get(self._src, "")
         else:
             self.skeleton = self._SKEL_CACHE[self._src]
 
-=======
-        ok &= self._run(dummy_compile)
         ok &= self._run(filter_compile)
-<<<<<<< codex/add-ebpf-resource-guard-and-update-bpfmanager
         ok &= self._run(guard_compile)
-=======
->>>>>>> main
->>>>>>> main
         ok &= self._run(["llvm-objdump", "-d", str(self._obj)])
         ok &= self._run(["llvm-objdump", "-d", str(self._filter_obj)])
         ok &= self._run(["llvm-objdump", "-d", str(self._guard_obj)])

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -3,7 +3,6 @@
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from ..supervisor import reload_policy
-from .compiler import PolicyCompilerError, compile_policy
 
 import urllib.request
 import tempfile
@@ -60,6 +59,9 @@ except ModuleNotFoundError:  # minimal fallback when PyYAML is unavailable
             return _mini_load(stream)
 
     yaml = _MiniYaml()
+
+
+from .compiler import PolicyCompilerError, compile_policy
 
 
 


### PR DESCRIPTION
## Summary
- log a warning if a Sandbox is garbage-collected while still running
- clean up stale merge markers in BPF manager and move policy imports to avoid circular import
- test that the warning fires on GC

## Testing
- `pytest tests/test_sandbox.py::test_warning_on_gc_without_close -q`
- `pytest -q` *(fails: Policy and crypto tests due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_685d4893fb108328874264d7d150fcdf