### PR TITLE
Update policy.refresh API

### DIFF
--- a/API.md
+++ b/API.md
@@ -83,7 +83,7 @@ Event types: `MEM_KILL`, `CPU_THROTTLE`, `POLICY_HOTLOAD`, `BROKER_ERROR`.
 | `psi.checkpoint(sb, key:bytes) -> bytes` | Serialize and encrypt sandbox state. |
 | `psi.restore(blob:bytes, key:bytes) -> Sandbox` | Spawn sandbox from encrypted state. |
 | `psi.migrate(sb, host:str, key:bytes) -> Sandbox` | Send checkpoint to `host` and restore there. |
-| `policy.refresh_remote(url:str)` | Fetch YAML policy over HTTP and apply. |
+| `policy.refresh_remote(url:str, token:str)` | Fetch YAML policy over HTTP and apply. |
 
 
 ## 6  Exceptions hierarchy

--- a/POLICY.md
+++ b/POLICY.md
@@ -84,5 +84,5 @@ Several ready-to-use policies are included under the `policy/` directory:
 | `ml.yml` | Machine learning jobs with outbound HTTPS and generous quotas |
 | `web_scraper.yml` | Basic web scraping with only HTTP/HTTPS access |
 
-Load any template with `pyisolate.policy.refresh("policy/<name>.yml")` and the
+Load any template with `pyisolate.policy.refresh("policy/<name>.yml", token)` and the
 new limits take effect instantly.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ templates cover common scenarios:
 * **`web_scraper.yml`** – permits HTTP/HTTPS to the public internet while
   restricting filesystem access to `/tmp`.
 
-Use `pyisolate.policy.refresh()` to hot‑load any of these files at runtime.
+Use `pyisolate.policy.refresh("policy/<name>.yml", token="secret")` to hot‑load any of these files at runtime.
 
 
 

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -99,7 +99,7 @@ def _validate(data: object) -> None:
             raise ValueError(f'"{section}" must be a mapping')
 
 
-def refresh(path: str) -> None:
+def refresh(path: str, token: str) -> None:
     """Parse *path* and atomically update eBPF policy maps."""
 
     # Compile and validate the YAML policy first
@@ -112,10 +112,6 @@ def refresh(path: str) -> None:
 
         json.dump(asdict(compiled), fh)
 
-    # Upon successful parse, swap the live maps via the supervisor
-    reload_policy(str(json_path.resolve()))
-
-
     # Fail fast if the YAML is malformed before touching BPF maps
     with open(path, "r", encoding="utf-8") as fh:
         try:
@@ -126,10 +122,10 @@ def refresh(path: str) -> None:
     _validate(data)
 
     # Upon successful parse, swap the live maps via the supervisor
-    reload_policy(str(Path(path).resolve()), token)
+    reload_policy(str(json_path.resolve()), token)
 
 
-def refresh_remote(url: str) -> None:
+def refresh_remote(url: str, token: str) -> None:
     """Fetch policy YAML from *url* and apply it."""
     with urllib.request.urlopen(url) as fh:
         text = fh.read().decode("utf-8")
@@ -139,7 +135,7 @@ def refresh_remote(url: str) -> None:
         tmp_path = tmp.name
 
     try:
-        refresh(tmp_path)
+        refresh(tmp_path, token)
     finally:
         os.unlink(tmp_path)
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -91,7 +91,7 @@ def test_validation_missing_version(tmp_path):
     p = tmp_path / "p.yml"
     p.write_text("defaults: {}\n")
     with pytest.raises(ValueError, match="version"):
-        policy.refresh(str(p))
+        policy.refresh(str(p), token="tok")
 
 
 def test_validation_bad_section_type(tmp_path):
@@ -99,7 +99,7 @@ def test_validation_bad_section_type(tmp_path):
     p = tmp_path / "p.yml"
     p.write_text("version: 0.1\nsandboxes: []\n")
     with pytest.raises(ValueError, match="sandboxes"):
-        policy.refresh(str(p))
+        policy.refresh(str(p), token="tok")
 
 @pytest.mark.parametrize("name", ["ml.yml", "web_scraper.yml"])
 def test_templates_parse(monkeypatch, name):
@@ -108,6 +108,6 @@ def test_templates_parse(monkeypatch, name):
         "pyisolate.bpf.manager.BPFManager.hot_reload", lambda *a, **k: None
     )
     path = ROOT / "policy" / name
-    policy.refresh(str(path))
+    policy.refresh(str(path), token="tok")
 
 

--- a/tests/test_remote_policy.py
+++ b/tests/test_remote_policy.py
@@ -31,7 +31,7 @@ def test_refresh_remote(tmp_path):
         orig = mgr.BPFManager.hot_reload
         mgr.BPFManager.hot_reload = lambda *a, **k: None
         try:
-            policy.refresh_remote(f"http://127.0.0.1:{port}")
+            policy.refresh_remote(f"http://127.0.0.1:{port}", token="tok")
         finally:
             mgr.BPFManager.hot_reload = orig
     finally:


### PR DESCRIPTION
## Summary
- add token parameter to `policy.refresh` and to `refresh_remote`
- fix policy docs and README examples for the new signature
- update tests to supply the token

## Testing
- `pytest -q` *(fails: SyntaxError in `pyisolate/bpf/manager.py`)*

------
https://chatgpt.com/codex/tasks/task_e_685d488eb728832892170f83b423e7c4