### PR TITLE
Fix BPF manager load logic

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -25,18 +25,12 @@ class BPFManager:
         self.policy_maps: dict[str, str] = {}
         self._src = Path(__file__).with_name("dummy.bpf.c")
         self._obj = Path(__file__).with_name("dummy.bpf.o")
-<<<<<<< codex/pre-compile-ebpf-programs-and-cache-skeletons
         self._skel = Path(__file__).with_name("dummy.skel.h")
         self.skeleton = ""
-=======
         self._filter_src = Path(__file__).with_name("syscall_filter.bpf.c")
         self._filter_obj = Path(__file__).with_name("syscall_filter.bpf.o")
-<<<<<<< codex/add-ebpf-resource-guard-and-update-bpfmanager
         self._guard_src = Path(__file__).with_name("resource_guard.bpf.c")
         self._guard_obj = Path(__file__).with_name("resource_guard.bpf.o")
-=======
->>>>>>> main
->>>>>>> main
 
     # internal helper
     def _run(self, cmd: list[str]) -> bool:
@@ -81,10 +75,9 @@ class BPFManager:
             str(self._guard_obj),
         ]
         ok = True
-<<<<<<< codex/pre-compile-ebpf-programs-and-cache-skeletons
+
         if self._src not in self._SKEL_CACHE:
-            ok &= self._run(compile_cmd)
-            # Generate and store the skeleton if tools are available
+            ok &= self._run(dummy_compile)
             skel_cmd = [
                 "sh",
                 "-c",
@@ -96,18 +89,12 @@ class BPFManager:
                     self._SKEL_CACHE[self._src] = self._skel.read_text()
                 except OSError:
                     self._SKEL_CACHE[self._src] = ""
-                self.skeleton = self._SKEL_CACHE[self._src]
+            self.skeleton = self._SKEL_CACHE.get(self._src, "")
         else:
             self.skeleton = self._SKEL_CACHE[self._src]
 
-=======
-        ok &= self._run(dummy_compile)
         ok &= self._run(filter_compile)
-<<<<<<< codex/add-ebpf-resource-guard-and-update-bpfmanager
         ok &= self._run(guard_compile)
-=======
->>>>>>> main
->>>>>>> main
         ok &= self._run(["llvm-objdump", "-d", str(self._obj)])
         ok &= self._run(["llvm-objdump", "-d", str(self._filter_obj)])
         ok &= self._run(["llvm-objdump", "-d", str(self._guard_obj)])

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -31,7 +31,7 @@ def test_load_runs_toolchain(monkeypatch):
         str(mgr._obj),
     ]
 
-    assert clang_call in calls
+    assert clang_dummy in calls
     skel_cmd = [
         "sh",
         "-c",


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in BPF manager
- compile and cache skeleton for dummy program
- load syscall filter and resource guard programs
- adapt tests for new command lists

## Testing
- `pytest tests/test_bpf_manager.py tests/test_bpf_manager_extra.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685d488d99ec8328adf540a580159e46