### PR TITLE
Resolve merge markers in BPF manager

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -75,15 +75,9 @@ class BPFManager:
             str(self._guard_obj),
         ]
         ok = True
-<<<<<<< codex/refactor-bpf-manager-and-update-tests
 
         if self._src not in self._SKEL_CACHE:
             ok &= self._run(dummy_compile)
-=======
-        compile_cmd = dummy_compile
-        if self._src not in self._SKEL_CACHE:
-            ok &= self._run(compile_cmd)
->>>>>>> main
             skel_cmd = [
                 "sh",
                 "-c",


### PR DESCRIPTION
## Summary
- clean up leftover merge conflict markers in `BPFManager.load`
- keep the logic that always invokes `dummy_compile` when needed

## Testing
- `pytest -q` *(fails: PolicyCompilerError and SandboxError)*

------
https://chatgpt.com/codex/tasks/task_e_686d5aed34b48328b8b9621890b18578