### PR TITLE
Fix duplicate spawn import

### DIFF
--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -20,7 +20,6 @@ from .supervisor import (
     set_policy_token,
     spawn,
     shutdown,
-    spawn,
 )
 
 from .sdk import Pipeline, sandbox


### PR DESCRIPTION
## Summary
- drop redundant `spawn` from supervisor imports

## Testing
- `black --check pyisolate/__init__.py`
- `isort --check pyisolate/__init__.py` *(fails: Imports are incorrectly sorted)*
- `pytest -q` *(fails: SyntaxError in bpf/manager.py)*

------
https://chatgpt.com/codex/tasks/task_e_686d5aef62d08328a83c76f982ea4c45