### PR TITLE
Fix policy templates loading

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -75,15 +75,9 @@ class BPFManager:
             str(self._guard_obj),
         ]
         ok = True
-<<<<<<< codex/refactor-bpf-manager-and-update-tests
-
-        if self._src not in self._SKEL_CACHE:
-            ok &= self._run(dummy_compile)
-=======
         compile_cmd = dummy_compile
         if self._src not in self._SKEL_CACHE:
             ok &= self._run(compile_cmd)
->>>>>>> main
             skel_cmd = [
                 "sh",
                 "-c",

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -108,6 +108,10 @@ def test_templates_parse(monkeypatch, name):
         "pyisolate.bpf.manager.BPFManager.hot_reload", lambda *a, **k: None
     )
     path = ROOT / "policy" / name
+    compiled = policy.compile_policy(str(path))
+    assert compiled.sandboxes
+    import pyisolate as iso
+    iso.set_policy_token("tok")
     policy.refresh(str(path), token="tok")
 
 


### PR DESCRIPTION
## Summary
- allow `compile_policy` to read single-sandbox templates
- ensure bpf manager doesn't include merge markers
- test that policy templates compile and refresh correctly

## Testing
- `pytest tests/test_policy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5af1ec5083289f5f2b0d04aa0613