### PR TITLE
Fix builtin injection and resolve merge markers

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -75,15 +75,9 @@ class BPFManager:
             str(self._guard_obj),
         ]
         ok = True
-<<<<<<< codex/refactor-bpf-manager-and-update-tests
 
         if self._src not in self._SKEL_CACHE:
             ok &= self._run(dummy_compile)
-=======
-        compile_cmd = dummy_compile
-        if self._src not in self._SKEL_CACHE:
-            ok &= self._run(compile_cmd)
->>>>>>> main
             skel_cmd = [
                 "sh",
                 "-c",

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -224,14 +224,13 @@ class SandboxThread(threading.Thread):
             builtins_dict = _builtins.__dict__.copy()
             builtins_dict["__import__"] = CapabilityImporter(self.allowed_imports)
             local_vars["__builtins__"] = builtins_dict
-
+        else:
+            local_vars["__builtins__"] = _SAFE_BUILTINS
 
         allowed_tcp = set()
         if self.policy is not None and getattr(self.policy, "tcp", None):
             allowed_tcp = set(self.policy.tcp)
         _thread_local.tcp = allowed_tcp
-
-        local_vars = {"post": self._outbox.put, "__builtins__": _SAFE_BUILTINS}
 
         if self.numa_node is not None:
             bind_current_thread(self.numa_node)


### PR DESCRIPTION
## Summary
- preserve capability importer builtins in `SandboxThread`
- remove merge conflict markers from `BPFManager`

## Testing
- `pre-commit run --files pyisolate/runtime/thread.py pyisolate/bpf/manager.py` *(fails: command not found)*
- `pytest -q tests/test_sandbox.py::test_call_returns_result` *(fails: NameError)*

------
https://chatgpt.com/codex/tasks/task_e_686d5aefaeb883288f00d2a9f3757692