### PR TITLE
Fix CryptoBroker.unframe return

### DIFF
--- a/pyisolate/broker/crypto.py
+++ b/pyisolate/broker/crypto.py
@@ -116,7 +116,7 @@ class CryptoBroker:
             raise ValueError("decryption failed") from None
         self._rx_ctr += 1
 
-        return self._aead.decrypt(nonce, data[12:], b"")
+        return plaintext
 
 
 def handshake(peer_key: bytes, *, private_key: bytes | None = None, pq_secret: bytes | None = None) -> tuple[bytes, CryptoBroker]:


### PR DESCRIPTION
## Summary
- return the previously-decrypted plaintext in `CryptoBroker.unframe`

## Testing
- `PYTHONPATH=. pytest tests/test_crypto.py tests/test_crypto_extra.py tests/test_crypto_kyber.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688bfe7e3bec8328b97845c8a7a6150c