### PR TITLE
Fix sandbox import hooks when imports unrestricted

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -225,8 +225,8 @@ class SandboxThread(threading.Thread):
             builtins_dict["__import__"] = CapabilityImporter(self.allowed_imports)
             local_vars["__builtins__"] = builtins_dict
         else:
-            local_vars["__builtins__"] = _SAFE_BUILTINS
-            local_vars["__builtins__"]["__import__"] = CapabilityImporter(self.allowed_imports)
+            # use sanitized builtins without import restrictions
+            local_vars["__builtins__"] = _SAFE_BUILTINS.copy()
 
         allowed_tcp = set()
         if self.policy is not None and getattr(self.policy, "tcp", None):


### PR DESCRIPTION
## Summary
- correct CapabilityImporter usage in SandboxThread when no import list is provided

## Testing
- `pytest tests/test_sandbox.py -q`
- `pre-commit run --files pyisolate/runtime/thread.py tests/test_sandbox.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688bfe7bb4f0832882f20d9bf1a6d780