### PR TITLE
Specify package for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = ["pyyaml"]
 requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+include = ["pyisolate"]
+
 [project.optional-dependencies]
 dev = [
     "pytest",


### PR DESCRIPTION
## Summary
- limit setuptools package discovery to `pyisolate` to avoid accidental inclusion of `policy`

## Testing
- `python -m pip install -e .[dev]` (fails: Could not find a version that satisfies the requirement setuptools>=64)
- `pre-commit run --files pyproject.toml` (fails: command not found: pre-commit)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c406953bc8328a7bceacaacddb81d