### PR TITLE
ci: auto-fix imports with isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,18 @@ jobs:
           python -m pip install -e .[dev]
           pre-commit install-hooks
       - name: Run isort
+        id: run_isort
+        continue-on-error: true
         run: pre-commit run isort --all-files
+      - name: Commit import sorting changes
+        if: steps.run_isort.outcome == 'failure'
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "chore: sort imports"
+            git push
+          fi
 
   flake8:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- automatically commit and push sorted imports when isort fails in CI

## Testing
- `pytest`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c44e855a483289d26eb160d76ad8b