### PR TITLE
ci: push formatting fixes to branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git commit -am "chore: format with black"
-            git push
+            BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+            git push origin HEAD:$BRANCH
           fi
 
   isort:
@@ -43,7 +44,19 @@ jobs:
           python -m pip install -e .[dev]
           pre-commit install-hooks
       - name: Run isort
+        id: run_isort
+        continue-on-error: true
         run: pre-commit run isort --all-files
+      - name: Commit import sorting changes
+        if: steps.run_isort.outcome == 'failure'
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "chore: sort imports"
+            BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+            git push origin HEAD:$BRANCH
+          fi
 
   flake8:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure black and isort jobs push formatting changes to the correct branch to avoid detached HEAD errors

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `python -m pip install .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=64)*

------
https://chatgpt.com/codex/tasks/task_e_688c460de498832880f87e144e1648e0