### PR TITLE
ci: consolidate lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,33 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  black:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install -e .[dev]
-          pre-commit install-hooks
-      - name: Run black
-        id: run_black
-        continue-on-error: true
-        run: pre-commit run black --all-files
-      - name: Commit formatting changes
-        if: steps.run_black.outcome == 'failure'
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -am "chore: format with black"
-            BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-            git push origin HEAD:$BRANCH
-          fi
-
-  isort:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -57,32 +31,20 @@ jobs:
             BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
             git push origin HEAD:$BRANCH
           fi
-
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
+      - name: Run black
+        id: run_black
+        continue-on-error: true
+        run: pre-commit run black --all-files
+      - name: Commit formatting changes
+        if: steps.run_black.outcome == 'failure'
         run: |
-          python -m pip install -e .[dev]
-          pre-commit install-hooks
-      - name: Run flake8
-        run: pre-commit run flake8 --all-files
-
-  pylint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Install dependencies
-        run: |
-          python -m pip install -e .[dev]
-          pre-commit install-hooks
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "chore: format with black"
+            BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+            git push origin HEAD:$BRANCH
+          fi
       - name: Run pylint
         id: pylint
         run: |
@@ -109,6 +71,8 @@ jobs:
             git commit -m "docs: update pylint badge" || true
             git push
           fi
+      - name: Run flake8
+        run: pre-commit run flake8 --all-files
 
   tests:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
     hooks:
-      - id: flake8
+      - id: black
   - repo: https://github.com/PyCQA/pylint
     rev: v3.2.2
     hooks:
       - id: pylint
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.0
     hooks:


### PR DESCRIPTION
## Summary
- combine formatting and linting into one CI job that runs isort, black, pylint, and flake8
- reorder pre-commit hooks to match lint order

## Testing
- `pre-commit run --files .pre-commit-config.yaml .github/workflows/ci.yml` *(fails: command not found)*
- `python -m pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools>=64)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c4d9a3b088328b3a1720712549d67