### PR TITLE
Allow numeric policy versions

### DIFF
--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -93,8 +93,9 @@ def _validate(data: object) -> None:
     if "version" not in data:
         raise ValueError('policy missing "version" key')
 
-    if data.get("version") != "0.1":
-        raise ValueError(f"unsupported policy version: {data.get('version')}")
+    version = data.get("version")
+    if str(version) != "0.1":
+        raise ValueError(f"unsupported policy version: {version}")
 
     for section in ("defaults", "sandboxes"):
         if section in data and not isinstance(data[section], dict):


### PR DESCRIPTION
## Summary
- accept numeric policy versions by stringifying the value during validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c54632c2c8328b262873757f1726a