### PR TITLE
Implement policy-driven sandboxing

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -114,6 +114,13 @@ class Supervisor:
         if len(name) > 64:
             raise ValueError("Sandbox name too long")
         self._cleanup()
+
+        if policy is not None and getattr(policy, "imports", None):
+            imports = set(policy.imports)
+            if allowed_imports is not None:
+                imports.update(allowed_imports)
+            allowed_imports = list(imports)
+
         cg_path = cgroup.create(name, cpu_ms, mem_bytes)
         with self._lock:
             if self._warm_pool:
@@ -123,6 +130,7 @@ class Supervisor:
                     policy=policy,
                     cpu_ms=cpu_ms,
                     mem_bytes=mem_bytes,
+                    allowed_imports=allowed_imports,
                 )
                 thread._on_violation = self._alerts.notify
                 thread._tracer = self._tracer

--- a/tests/test_policy_enforcement.py
+++ b/tests/test_policy_enforcement.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+from pyisolate import policy
+
+
+def test_policy_import_and_fs(tmp_path):
+    p = (
+        policy.Policy()
+        .allow_import("math")
+        .allow_import("pathlib")
+        .allow_fs(str(tmp_path))
+    )
+    f = tmp_path / "data.txt"
+    f.write_text("ok")
+
+    sb = iso.spawn("pifs", policy=p)
+    try:
+        sb.exec("import math; post(math.sqrt(16))")
+        assert sb.recv(timeout=1) == 4.0
+
+        sb.exec(f"import pathlib; post(pathlib.Path({str(f)!r}).read_text())")
+        assert sb.recv(timeout=1) == "ok"
+
+        sb.exec("import random")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+
+        sb.exec("import pathlib; post(pathlib.Path('/etc/hosts').read_text())")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- Enforce filesystem access via policy-controlled allowlists and thread-local checks
- Merge policy-defined imports into sandbox configuration and reset allowed modules for reused threads
- Add integration test covering allowed imports and filesystem restrictions

## Testing
- `pytest -q`
- `pre-commit run --files pyisolate/runtime/thread.py pyisolate/supervisor.py tests/test_policy_enforcement.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e19d26e648328929078e30664a49f