### PR TITLE
Reset start time after sandbox exec failure

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -314,10 +314,12 @@ class SandboxThread(threading.Thread):
                     self._mem_peak = max(self._mem_peak, peak - self._mem_base)
                 except Exception as exc:  # real impl would sanitize
                     self._errors += 1
+                    self._start_time = None
                     if self._on_violation and isinstance(exc, errors.PolicyError):
                         self._on_violation(self.name, exc)
                     self._outbox.put(exc)
                 finally:
+                    self._start_time = None
                     duration = (time.monotonic() - op_start) * 1000
                     self._latency_sum += duration
                     if duration <= 0.5:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,5 +1,7 @@
 import sys
 from pathlib import Path
+import time
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -16,5 +18,19 @@ def test_stats_property_updates():
         assert s.cpu_ms >= 0
         assert s.mem_bytes >= 0
         assert s.cost >= 0
+    finally:
+        sb.close()
+
+
+def test_cpu_ms_stops_after_failed_exec():
+    sb = iso.spawn("stats-fail")
+    try:
+        sb.exec("raise ValueError('boom')")
+        with pytest.raises(ValueError):
+            sb.recv(timeout=0.5)
+        first = sb.stats.cpu_ms
+        time.sleep(0.05)
+        second = sb.stats.cpu_ms
+        assert second == pytest.approx(first, abs=0.1)
     finally:
         sb.close()


### PR DESCRIPTION
## Summary
- Clear SandboxThread's start time when exec raises and in final cleanup to prevent CPU stats drift
- Add regression test ensuring `stats.cpu_ms` stops increasing after a failed exec

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c48d88188328ab690932c797cffd