### PR TITLE
Handle cgroup reassignment when reusing sandbox threads

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -131,6 +131,7 @@ class Supervisor:
                     cpu_ms=cpu_ms,
                     mem_bytes=mem_bytes,
                     allowed_imports=allowed_imports,
+                    cgroup_path=cg_path,
                 )
                 thread._on_violation = self._alerts.notify
                 thread._tracer = self._tracer


### PR DESCRIPTION
## Summary
- allow `SandboxThread.reset` to move a running thread to a new cgroup and clean up the old cgroup
- pass the new cgroup path when reusing warm pool threads in `Supervisor.spawn`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893c48bd4608328ad260be88024fa05