### PR TITLE
Add snapshot API for sandbox checkpointing

### DIFF
--- a/pyisolate/checkpoint.py
+++ b/pyisolate/checkpoint.py
@@ -15,12 +15,7 @@ def checkpoint(sandbox: Sandbox, key: bytes) -> bytes:
 
     The sandbox is closed after its state is captured.
     """
-    state = {
-        "name": sandbox._thread.name,
-        "policy": sandbox._thread.policy,
-        "cpu_ms": sandbox._thread.cpu_quota_ms,
-        "mem_bytes": sandbox._thread.mem_quota_bytes,
-    }
+    state = sandbox.snapshot()
     data = pickle.dumps(state)
     aead = ChaCha20Poly1305(key)
     nonce = os.urandom(12)
@@ -37,9 +32,9 @@ def restore(blob: bytes, key: bytes) -> Sandbox:
     state = pickle.loads(data)
     return spawn(
         state["name"],
-        policy=state["policy"],
-        cpu_ms=state["cpu_ms"],
-        mem_bytes=state["mem_bytes"],
+        policy=state.get("policy"),
+        cpu_ms=state.get("cpu_ms"),
+        mem_bytes=state.get("mem_bytes"),
     )
 
 

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -164,6 +164,15 @@ class SandboxThread(threading.Thread):
         self._trace_enabled = False
         self._syscall_log: list[str] = []
 
+    def snapshot(self) -> dict:
+        """Return serializable configuration state."""
+        return {
+            "name": self.name,
+            "policy": self.policy,
+            "cpu_ms": self.cpu_quota_ms,
+            "mem_bytes": self.mem_quota_bytes,
+        }
+
     def enable_tracing(self) -> None:
         """Start recording guest operations."""
         self._trace_enabled = True

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -53,6 +53,10 @@ class Sandbox:
     def profile(self):
         return self._thread.profile()
 
+    def snapshot(self) -> dict:
+        """Return serializable state for checkpointing."""
+        return self._thread.snapshot()
+
     # allow ``with spawn(...) as sb:`` usage
     def __enter__(self) -> "Sandbox":
         return self

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -15,9 +15,11 @@ def test_checkpoint_roundtrip():
     try:
         sb.exec("post(5)")
         assert sb.recv(timeout=0.5) == 5
+        snap = sb.snapshot()
         blob = iso.checkpoint(sb, key)
         sb2 = iso.restore(blob, key)
         try:
+            assert sb2.snapshot() == snap
             sb2.exec("post(6)")
             assert sb2.recv(timeout=0.5) == 6
         finally:


### PR DESCRIPTION
## Summary
- add `snapshot()` to `Sandbox`/`SandboxThread` for serializing state
- refactor checkpoint/restore to use snapshot data
- update checkpoint test to exercise new API

## Testing
- `pytest tests/test_checkpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_689d22ab9504832890e8df47f7e25d70