### PR TITLE
Add length check in constant_compare fallback

### DIFF
--- a/pyisolate/libsodium.py
+++ b/pyisolate/libsodium.py
@@ -17,4 +17,6 @@ except Exception:  # pragma: no cover - fallback when PyNaCl/libsodium missing
 
     def constant_compare(a: bytes, b: bytes) -> bool:
         """Fallback to ``hmac.compare_digest`` if libsodium is unavailable."""
+        if len(a) != len(b):
+            return False
         return hmac.compare_digest(a, b)

--- a/tests/test_crypto_extra.py
+++ b/tests/test_crypto_extra.py
@@ -3,6 +3,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import x25519
 
 from pyisolate.broker.crypto import CTR_LIMIT, CryptoBroker
+from pyisolate.libsodium import constant_compare
 
 
 def make_pair():
@@ -31,6 +32,10 @@ def make_pair():
         ),
     )
     return a, b
+
+
+def test_constant_compare_length_mismatch():
+    assert not constant_compare(b"a", b"ab")
 
 
 def test_unframe_short_frame():


### PR DESCRIPTION
## Summary
- add explicit length check before `hmac.compare_digest` in `constant_compare`
- test constant_compare with mismatched-length inputs

## Testing
- `PYTHONPATH=. pytest tests/test_crypto_extra.py`


------
https://chatgpt.com/codex/tasks/task_e_689d22ae181c83288c4773ec5b0a803a