### PR TITLE
Use sentinel to stop sandbox thread

### DIFF
--- a/tests/test_idle_thread.py
+++ b/tests/test_idle_thread.py
@@ -1,0 +1,21 @@
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+
+
+def test_idle_thread_cpu_and_shutdown():
+    sb = iso.spawn("idle-cpu")
+    thread = sb._thread
+    try:
+        start = time.process_time()
+        time.sleep(0.2)
+        cpu_used = time.process_time() - start
+    finally:
+        sb.close()
+    assert cpu_used < 0.05
+    assert not thread.is_alive()


### PR DESCRIPTION
## Summary
- avoid busy polling in SandboxThread by using a blocking queue get and stop sentinel
- test that an idle sandbox thread consumes little CPU and shuts down cleanly

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d22af45b48328b5e5171fc365dfb6