### PR TITLE
Handle invalid policy paths in reload

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -111,3 +111,20 @@ def test_templates_parse(monkeypatch, name):
 
     iso.set_policy_token("tok")
     policy.refresh(str(path), token="tok")
+
+
+def test_reload_policy_missing_path(tmp_path):
+    import pyisolate as iso
+
+    missing = tmp_path / "nope.json"
+    with pytest.raises(FileNotFoundError):
+        iso.reload_policy(str(missing))
+
+
+def test_reload_policy_malformed_json(tmp_path):
+    import pyisolate as iso
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("not-json")
+    with pytest.raises(iso.PolicyAuthError, match="failed to reload policy"):
+        iso.reload_policy(str(bad))


### PR DESCRIPTION
## Summary
- validate policy path existence before reloading
- surface BPF reload failures as PolicyAuthError
- test missing and malformed policy paths

## Testing
- `pytest tests/test_policy.py::test_reload_policy_missing_path tests/test_policy.py::test_reload_policy_malformed_json -q`
- `pre-commit run --files pyisolate/supervisor.py tests/test_policy.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c15d7b48328ab1b6036471a65ae