### PR TITLE
Ensure runtime patches are scoped to SandboxThread

### DIFF
--- a/tests/test_thread_extra.py
+++ b/tests/test_thread_extra.py
@@ -1,9 +1,35 @@
+import builtins
+import socket
+import sys
+from pathlib import Path
+
 import pytest
 
-from pyisolate import errors
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+from pyisolate import errors, policy
 from pyisolate.runtime.thread import _sigxcpu_handler
 
 
 def test_sigxcpu_handler_raises():
     with pytest.raises(errors.CPUExceeded):
         _sigxcpu_handler(None, None)
+
+
+def test_globals_restored_after_sandbox_close():
+    orig_open = builtins.open
+    orig_connect = socket.socket.connect
+
+    sb = iso.spawn("restore", policy=policy.Policy())
+    try:
+        sb.exec("post('ok')")
+        assert sb.recv(timeout=1) == "ok"
+        assert builtins.open is not orig_open
+        assert socket.socket.connect is not orig_connect
+    finally:
+        sb.close()
+
+    assert builtins.open is orig_open
+    assert socket.socket.connect is orig_connect


### PR DESCRIPTION
## Summary
- Limit `_blocked_open` and `_guarded_connect` monkey patches to `SandboxThread.run`
- Restore original `open` and `socket.connect` on thread exit
- Add regression test verifying globals are reset after sandbox closure

## Testing
- `python -m py_compile pyisolate/runtime/thread.py tests/test_thread_extra.py`
- `pytest tests/test_thread_extra.py -q`
- `pre-commit run --files pyisolate/runtime/thread.py tests/test_thread_extra.py` *(fails: command not found; package install blocked)*


------
https://chatgpt.com/codex/tasks/task_e_689f4c13f7e08328bce9b40ca49002b9