### PR TITLE
Enforce CPU/memory quotas within sandbox thread

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -337,6 +337,18 @@ class SandboxThread(threading.Thread):
                     self._start_time = None
                     cur, peak = tracemalloc.get_traced_memory()
                     self._mem_peak = max(self._mem_peak, peak - self._mem_base)
+                    if (
+                        self.cpu_quota_ms is not None
+                        and self._cpu_time > self.cpu_quota_ms
+                    ):
+                        self._outbox.put(errors.CPUExceeded())
+                        break
+                    if (
+                        self.mem_quota_bytes is not None
+                        and self._mem_peak > self.mem_quota_bytes
+                    ):
+                        self._outbox.put(errors.MemoryExceeded())
+                        break
                 except Exception as exc:  # real impl would sanitize
                     self._errors += 1
                     self._start_time = None

--- a/tests/test_thread_quota.py
+++ b/tests/test_thread_quota.py
@@ -1,0 +1,33 @@
+import pytest
+
+from pyisolate import errors
+from pyisolate.runtime import thread
+
+
+def test_cpu_quota_enforced_without_watchdog(monkeypatch):
+    def fake_thread_time():
+        fake_thread_time.current += 0.002
+        return fake_thread_time.current
+
+    fake_thread_time.current = 0.0
+    monkeypatch.setattr(thread.time, "thread_time", fake_thread_time)
+
+    sb = thread.SandboxThread("cpu", cpu_ms=1)
+    sb.start()
+    try:
+        sb.exec("pass")
+        with pytest.raises(errors.CPUExceeded):
+            sb.recv(timeout=1)
+    finally:
+        sb.stop()
+
+
+def test_memory_quota_enforced_without_watchdog():
+    sb = thread.SandboxThread("mem", mem_bytes=1024)
+    sb.start()
+    try:
+        sb.exec("x = ' ' * (2 * 1024 * 1024)")
+        with pytest.raises(errors.MemoryExceeded):
+            sb.recv(timeout=1)
+    finally:
+        sb.stop()


### PR DESCRIPTION
## Summary
- stop sandbox execution once CPU or memory quotas are exceeded
- test immediate CPU and memory quota enforcement without watchdog involvement

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'reload_policy' from 'pyisolate.supervisor')*

------
https://chatgpt.com/codex/tasks/task_e_689f4c11825c83289adf91960f739653