### PR TITLE
Fix policy reload import and enforce thread quotas

### DIFF
--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -4,7 +4,14 @@ This module exposes the high-level API described in API.md.
 """
 
 from .capabilities import ROOT, Capability, RootCapability, Token
-from .checkpoint import checkpoint, restore
+try:
+    from .checkpoint import checkpoint, restore
+except Exception:  # pragma: no cover - optional dependency
+    def checkpoint(*args, **kwargs):  # type: ignore[no-redef]
+        raise ModuleNotFoundError("cryptography is required for checkpoint support")
+
+    def restore(*args, **kwargs):  # type: ignore[no-redef]
+        raise ModuleNotFoundError("cryptography is required for checkpoint support")
 from .editor import PolicyEditor, check_fs, check_tcp, parse_policy
 from .errors import (
     CPUExceeded,
@@ -15,7 +22,11 @@ from .errors import (
     TimeoutError,
 )
 from .logging import setup_structured_logging
-from .migration import migrate
+try:
+    from .migration import migrate
+except Exception:  # pragma: no cover - optional dependency
+    def migrate(*args, **kwargs):  # type: ignore[no-redef]
+        raise ModuleNotFoundError("cryptography is required for migration support")
 from .policy import refresh_remote
 from .sdk import Pipeline, sandbox
 from .subset import OwnershipError, RestrictedExec

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -6,8 +6,6 @@ import urllib.request
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-from ..supervisor import reload_policy
-
 try:
     import yaml  # type: ignore
 except ModuleNotFoundError:  # minimal fallback when PyYAML is unavailable
@@ -126,6 +124,8 @@ def refresh(path: str, token: str) -> None:
 
     # Upon successful parse, swap the live maps via the supervisor
     try:
+        from ..supervisor import reload_policy
+
         reload_policy(str(json_path.resolve()), token)
     finally:
         try:

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -349,6 +349,16 @@ class SandboxThread(threading.Thread):
                         self._start_time = None
                         cur, peak = tracemalloc.get_traced_memory()
                         self._mem_peak = max(self._mem_peak, peak - self._mem_base)
+                        if (
+                            self.cpu_quota_ms is not None
+                            and self._cpu_time > self.cpu_quota_ms
+                        ):
+                            raise errors.CPUExceeded()
+                        if (
+                            self.mem_quota_bytes is not None
+                            and self._mem_peak > self.mem_quota_bytes
+                        ):
+                            raise errors.MemoryExceeded()
                     except Exception as exc:  # real impl would sanitize
                         self._errors += 1
                         self._start_time = None


### PR DESCRIPTION
## Summary
- defer `reload_policy` import until runtime to avoid unnecessary dependency loading
- raise CPU and memory quota errors directly in `SandboxThread`
- stub checkpoint and migration APIs when cryptography isn't available

## Testing
- `PYTHONPATH=. pytest tests/test_policy.py::test_policy_methods_chain tests/test_policy.py::test_compile_policy_ok tests/test_policy.py::test_reload_policy_missing_path tests/test_sandbox.py::test_policy_refresh_parses_yaml tests/test_thread_extra.py::test_globals_restored_after_sandbox_close -q`
- `PYTHONPATH=. pytest tests/test_thread_quota.py::test_cpu_quota_enforced_without_watchdog -q`
- `PYTHONPATH=. pytest tests/test_thread_quota.py::test_memory_quota_enforced_without_watchdog -q`


------
https://chatgpt.com/codex/tasks/task_e_689fb23bb1288328bd4b6241fcf33be7