### PR TITLE
Enforce canonical ROOT token for policy reload

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -179,10 +179,11 @@ class Supervisor:
     def reload_policy(self, policy_path: str, token: str | RootCapability) -> None:
         """Hot-reload policy via the BPF manager if *token* matches."""
 
-        if isinstance(token, RootCapability):
+        if token is ROOT:
             pass
         else:
             if self._policy_token is not None and token != self._policy_token:
+                logger.warning("policy reload rejected: invalid token")
                 raise PolicyAuthError("invalid policy token")
 
         if not Path(policy_path).is_file():


### PR DESCRIPTION
## Summary
- ensure `reload_policy` only accepts the canonical `ROOT` capability
- log and reject non-root or mismatched policy tokens
- test that only the canonical `ROOT` token bypasses policy token check

## Testing
- `pytest tests/test_policy.py::test_reload_policy_accepts_root_token tests/test_policy.py::test_reload_policy_rejects_non_canonical_root -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2694980148328b878513f974cb8ca