### PR TITLE
Add timeout support for sandbox calls

### DIFF
--- a/pyisolate/sdk.py
+++ b/pyisolate/sdk.py
@@ -8,15 +8,29 @@ from .supervisor import spawn
 
 
 def sandbox(
-    policy: str | None = None, timeout: str | None = None
+    policy: str | None = None, timeout: float | None = None
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Decorate a function to run inside a sandbox when called."""
+    """Decorate a function to run inside a sandbox when called.
+
+    Parameters
+    ----------
+    policy:
+        Name of the policy to apply to the sandbox.
+    timeout:
+        Seconds to wait for the sandboxed call to complete before raising
+        :class:`pyisolate.errors.TimeoutError`.
+    """
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             sb = spawn(func.__name__, policy=policy)
             try:
-                return sb.call(f"{func.__module__}.{func.__name__}", *args, **kwargs)
+                return sb.call(
+                    f"{func.__module__}.{func.__name__}",
+                    *args,
+                    timeout=timeout,
+                    **kwargs,
+                )
             finally:
                 sb.close()
 

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -34,9 +34,9 @@ class Sandbox:
         """Execute Python source inside the sandbox."""
         self._thread.exec(src)
 
-    def call(self, func: str, *args, **kwargs):
+    def call(self, func: str, *args, timeout: float | None = None, **kwargs):
         """Call a dotted function inside the sandbox."""
-        return self._thread.call(func, *args, **kwargs)
+        return self._thread.call(func, *args, timeout=timeout, **kwargs)
 
     def recv(self, timeout: Optional[float] = None):
         """Receive a posted object from the sandbox."""

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -9,7 +9,7 @@ from helper_module import stage_one, stage_two
 
 import pyisolate as iso
 
-add = iso.sandbox()(plain_add)
+add = iso.sandbox(timeout=0.1)(plain_add)
 
 
 def test_sandbox_decorator():


### PR DESCRIPTION
## Summary
- allow setting timeouts when invoking sandbox functions
- propagate timeout through Supervisor and SDK helpers
- update SDK test to exercise timeout-aware decorator

## Testing
- `isort pyisolate/runtime/thread.py pyisolate/sdk.py pyisolate/supervisor.py tests/test_sdk.py --check --verbose`
- `black pyisolate/runtime/thread.py pyisolate/sdk.py pyisolate/supervisor.py tests/test_sdk.py --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a269432e5c8328922e30ec40dcde8b