### PR TITLE
Handle BPF map update failures

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -7,8 +7,11 @@ available on the test system; any missing executables are therefore ignored.
 """
 
 import json
+import logging
 import subprocess
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class BPFManager:
@@ -135,7 +138,8 @@ class BPFManager:
         # Replace the active policy entirely to drop removed entries
         self.policy_maps = data
         for key, val in data.items():
-            self._run(
+            logger.info("updating map %s -> %s", key, val)
+            ok = self._run(
                 [
                     "bpftool",
                     "map",
@@ -149,6 +153,8 @@ class BPFManager:
                     "any",
                 ]
             )
+            if not ok:
+                raise RuntimeError(f"BPF map update failed for {key}")
 
     def open_ring_buffer(self):
         """Return an iterator over resource guard events."""


### PR DESCRIPTION
## Summary
- log each BPF map update and abort hot reload when an update command fails
- add regression tests covering map update failures and log emission

## Testing
- `black tests/test_bpf_manager.py pyisolate/bpf/manager.py`
- `isort tests/test_bpf_manager.py pyisolate/bpf/manager.py`
- `mypy pyisolate/bpf/manager.py tests/test_bpf_manager.py` *(fails: valid-type, call-overload, arg-type, etc.)*
- `flake8 pyisolate/bpf/manager.py tests/test_bpf_manager.py` *(fails: command not found)*
- `pylint pyisolate/bpf/manager.py tests/test_bpf_manager.py` *(fails: command not found)*
- `pytest -q` *(fails: TimeoutError, DID NOT RAISE)*
- `pytest tests/test_bpf_manager.py::test_hot_reload_failure_raises tests/test_bpf_manager.py::test_hot_reload_logs_updates -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2695d7cbc8328bfba8915cf929c6e