### PR TITLE
Fix types import placement in sandbox thread

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -18,6 +18,7 @@ import socket
 import threading
 import time
 import tracemalloc
+import types
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,8 +65,6 @@ def _sandbox_import(name, globals=None, locals=None, fromlist=(), level=0):
         module.perf_counter = _perf_counter
     return module
 
-
-import types
 
 # Precompute a sanitized builtins dict for sandbox execution.
 _FORBIDDEN = {


### PR DESCRIPTION
## Summary
- Move `types` import to top-level in `runtime/thread.py`
- Remove delayed `types` import after `_sandbox_import`

## Testing
- `isort pyisolate/runtime/thread.py`
- `flake8 pyisolate/runtime/thread.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0cdf8e708328a8b540dd97df1ca1