### PR TITLE
Ensure deterministic metrics export

### DIFF
--- a/pyisolate/observability/metrics.py
+++ b/pyisolate/observability/metrics.py
@@ -15,7 +15,8 @@ class MetricsExporter:
 
         lines: list[str] = []
         active = list_active()
-        for name, sb in active.items():
+        for name in sorted(active):
+            sb = active[name]
             stats = sb.stats
             lines.append(f'pyisolate_cpu_ms{{sandbox="{name}"}} {stats.cpu_ms:.0f}')
             lines.append(f'pyisolate_mem_bytes{{sandbox="{name}"}} {stats.mem_bytes}')


### PR DESCRIPTION
## Summary
- iterate metrics export over sandboxes in sorted order for deterministic output
- test sandbox ordering to ensure stable metrics export

## Testing
- `pytest tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0ce116e48328b18d81601df6c0bb