### PR TITLE
Require root capability for supervisor shutdown

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -198,8 +198,11 @@ class Supervisor:
         """Stop watchdog and terminate all running sandboxes.
 
         The ``cap`` argument models a privileged capability required to shut
-        down the supervisor.
+        down the supervisor. Raises ``PolicyAuthError`` if ``cap`` is not
+        ``ROOT``.
         """
+        if cap is not ROOT:
+            raise PolicyAuthError("invalid capability for shutdown")
         self._watchdog.stop()
         with self._lock:
             sandboxes = list(self._sandboxes.values())

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -61,6 +61,16 @@ def test_shutdown_clears_warm_pool():
     assert sup._warm_pool == []
 
 
+def test_shutdown_requires_root():
+    sup = iso.Supervisor()
+    try:
+        with pytest.raises(iso.PolicyAuthError):
+            sup.shutdown(cap=iso.Token(name="user"))
+    finally:
+        # ensure resources cleaned up for subsequent tests
+        sup.shutdown()
+
+
 def test_spawn_invalid_name_empty():
     with pytest.raises(ValueError):
         iso.spawn("")


### PR DESCRIPTION
## Summary
- enforce ROOT capability for Supervisor.shutdown and document failure path
- test unauthorized shutdown attempts

## Testing
- `pytest tests/test_supervisor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af0cdd5a8c8328a5b1df865a82274f