### PR TITLE
refactor: localize BPF skeleton cache

### DIFF
--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -12,7 +12,6 @@ from pyisolate.bpf.manager import BPFManager
 
 
 def test_load_runs_toolchain(monkeypatch):
-    BPFManager._SKEL_CACHE = {}
     calls = []
 
     def fake_run(self, cmd):
@@ -87,7 +86,6 @@ def test_load_runs_toolchain(monkeypatch):
 
 
 def test_hot_reload_updates_maps(tmp_path, monkeypatch):
-    BPFManager._SKEL_CACHE = {}
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
     mgr = BPFManager()
     mgr.load()
@@ -103,7 +101,6 @@ def test_hot_reload_updates_maps(tmp_path, monkeypatch):
 
 
 def test_load_failure_keeps_unloaded(monkeypatch):
-    BPFManager._SKEL_CACHE = {}
 
     def fake_run(self, cmd):
         return False if "bpftool" in cmd else True
@@ -115,7 +112,6 @@ def test_load_failure_keeps_unloaded(monkeypatch):
 
 
 def test_load_skips_when_cached(monkeypatch):
-    BPFManager._SKEL_CACHE = {}
     monkeypatch.setattr(BPFManager, "_run", lambda self, cmd: True)
     mgr = BPFManager()
     mgr.load()  # first load to populate cache
@@ -150,7 +146,6 @@ def test_load_skips_when_cached(monkeypatch):
 
 
 def test_hot_reload_failure_raises(monkeypatch, tmp_path):
-    BPFManager._SKEL_CACHE = {}
     mgr = BPFManager()
     mgr.loaded = True
     policy = tmp_path / "policy.json"
@@ -166,7 +161,6 @@ def test_hot_reload_failure_raises(monkeypatch, tmp_path):
 
 
 def test_hot_reload_logs_updates(tmp_path, monkeypatch, caplog):
-    BPFManager._SKEL_CACHE = {}
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
     mgr = BPFManager()
     mgr.load()

--- a/tests/test_bpf_manager_extra.py
+++ b/tests/test_bpf_manager_extra.py
@@ -4,7 +4,6 @@ from pyisolate.bpf.manager import BPFManager
 
 
 def test_hot_reload_requires_load(tmp_path):
-    BPFManager._SKEL_CACHE = {}
     mgr = BPFManager()
     policy = tmp_path / "p.json"
     policy.write_text("{}")
@@ -13,7 +12,6 @@ def test_hot_reload_requires_load(tmp_path):
 
 
 def test_hot_reload_invalid_json(tmp_path, monkeypatch):
-    BPFManager._SKEL_CACHE = {}
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
     mgr = BPFManager()
     mgr.load()
@@ -24,7 +22,6 @@ def test_hot_reload_invalid_json(tmp_path, monkeypatch):
 
 
 def test_hot_reload_missing_file(tmp_path, monkeypatch):
-    BPFManager._SKEL_CACHE = {}
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
     mgr = BPFManager()
     mgr.load()


### PR DESCRIPTION
## Summary
- avoid shared mutable state in BPFManager by moving `_SKEL_CACHE` to an instance attribute
- update tests to work with instance-level cache

## Testing
- `pytest`
- ⚠️ `pre-commit run --files pyisolate/bpf/manager.py tests/test_bpf_manager.py tests/test_bpf_manager_extra.py` *(missing pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e57ac2648328a256449b1680831d