### PR TITLE
Validate sandbox names with regex

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -8,6 +8,7 @@ requires eBPF enforcement which is not implemented here.
 from __future__ import annotations
 
 import logging
+import re
 import threading
 from pathlib import Path
 from typing import Dict, Optional
@@ -22,6 +23,9 @@ from .runtime.thread import SandboxThread
 from .watchdog import ResourceWatchdog
 
 logger = logging.getLogger(__name__)
+
+# Allowed sandbox name pattern: alphanumerics, hyphen, underscore
+NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 class Sandbox:
@@ -118,6 +122,8 @@ class Supervisor:
             raise ValueError("Sandbox name must be non-empty string")
         if len(name) > 64:
             raise ValueError("Sandbox name too long")
+        if not NAME_PATTERN.fullmatch(name):
+            raise ValueError("Sandbox name contains invalid characters")
         self._cleanup()
 
         if policy is not None and getattr(policy, "imports", None):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -84,3 +84,18 @@ def test_spawn_invalid_name_long():
 def test_spawn_invalid_name_type():
     with pytest.raises(ValueError):
         iso.spawn(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("name", ["valid-123", "under_score", "A-B_C"])
+def test_spawn_valid_name_regex(name):
+    sb = iso.spawn(name)
+    try:
+        assert sb._thread.name == name
+    finally:
+        sb.close()
+
+
+@pytest.mark.parametrize("name", ["bad name", "name!", "foo/bar"])
+def test_spawn_invalid_name_regex(name):
+    with pytest.raises(ValueError):
+        iso.spawn(name)


### PR DESCRIPTION
## Summary
- enforce sandbox name allowlist via regex
- test accepted and rejected sandbox names

## Testing
- `pytest tests/test_supervisor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e57f3b888328bec499c4c9989d4e