### PR TITLE
Escape sandbox names for Prometheus metrics

### DIFF
--- a/pyisolate/observability/metrics.py
+++ b/pyisolate/observability/metrics.py
@@ -7,6 +7,17 @@ useful for tests and examples.
 """
 
 
+def _escape_label(value: str) -> str:
+    """Escape a label value according to the Prometheus text exposition format.
+
+    Prometheus expects backslashes, double quotes and newlines within label
+    values to be escaped.  This helper normalizes sandbox names so that they
+    remain valid even if they contain such characters.
+    """
+
+    return value.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
 class MetricsExporter:
     def export(self) -> str:
         """Return metrics for all active sandboxes in Prometheus text format."""
@@ -18,21 +29,30 @@ class MetricsExporter:
         for name in sorted(active):
             sb = active[name]
             stats = sb.stats
-            lines.append(f'pyisolate_cpu_ms{{sandbox="{name}"}} {stats.cpu_ms:.0f}')
-            lines.append(f'pyisolate_mem_bytes{{sandbox="{name}"}} {stats.mem_bytes}')
-            lines.append(f'pyisolate_errors_total{{sandbox="{name}"}} {stats.errors}')
-            lines.append(f'pyisolate_cost{{sandbox="{name}"}} {stats.cost:.6f}')
+            label = _escape_label(name)
+            lines.append(
+                f'pyisolate_cpu_ms{{sandbox="{label}"}} {stats.cpu_ms:.0f}'
+            )
+            lines.append(
+                f'pyisolate_mem_bytes{{sandbox="{label}"}} {stats.mem_bytes}'
+            )
+            lines.append(
+                f'pyisolate_errors_total{{sandbox="{label}"}} {stats.errors}'
+            )
+            lines.append(
+                f'pyisolate_cost{{sandbox="{label}"}} {stats.cost:.6f}'
+            )
             cumul = 0
             for le, count in stats.latency.items():
                 cumul += count
                 lines.append(
-                    f'pyisolate_latency_ms_bucket{{sandbox="{name}",le="{le}"}} {cumul}'
+                    f'pyisolate_latency_ms_bucket{{sandbox="{label}",le="{le}"}} {cumul}'
                 )
             lines.append(
-                f'pyisolate_latency_ms_count{{sandbox="{name}"}} {stats.operations}'
+                f'pyisolate_latency_ms_count{{sandbox="{label}"}} {stats.operations}'
             )
             lines.append(
-                f'pyisolate_latency_ms_sum{{sandbox="{name}"}} {stats.latency_sum:.3f}'
+                f'pyisolate_latency_ms_sum{{sandbox="{label}"}} {stats.latency_sum:.3f}'
             )
 
         return "\n".join(lines) + ("\n" if lines else "")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -38,3 +38,17 @@ def test_export_sandbox_order_is_stable():
     finally:
         for sb in sbs:
             sb.close()
+
+
+def test_export_sanitizes_sandbox_name():
+    name = 'weird "sand\\box\nname'
+    sb = iso.spawn(name)
+    try:
+        sb.exec("post(1)")
+        sb.recv(timeout=0.5)
+        metrics = MetricsExporter().export()
+        escaped = name.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+        assert f'sandbox="{escaped}"' in metrics
+        assert f'sandbox="{name}"' not in metrics
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- Escape sandbox names in Prometheus metrics exporter to satisfy label rules
- Add regression test for metrics export with edge-case sandbox names

## Testing
- `pytest tests/test_metrics.py`
- `pre-commit run --files pyisolate/observability/metrics.py tests/test_metrics.py` *(fails: command not found; attempted installation but network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e57ddf348328a4473af15070bfb5