### PR TITLE
Handle alert callback errors

### DIFF
--- a/pyisolate/observability/alerts.py
+++ b/pyisolate/observability/alerts.py
@@ -1,3 +1,9 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
 class AlertManager:
     """Dispatch callbacks on policy violations."""
 
@@ -7,6 +13,14 @@ class AlertManager:
     def register(self, callback) -> None:
         self._subs.append(callback)
 
-    def notify(self, sandbox: str, error: Exception) -> None:
+    def notify(self, sandbox: str, error: Exception) -> list[Exception]:
+        errors: list[Exception] = []
         for cb in list(self._subs):
-            cb(sandbox, error)
+            try:
+                cb(sandbox, error)
+            except Exception as exc:  # pragma: no cover - exercised in tests
+                errors.append(exc)
+                logger.exception(
+                    "alert callback %r failed for sandbox %s", cb, sandbox
+                )
+        return errors

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -22,6 +22,43 @@ def test_alert_on_policy_violation():
     assert "alert" in called
 
 
+def test_alert_handler_failure_does_not_stop_others():
+    from pyisolate.observability.alerts import AlertManager
+    import logging
+
+    manager = AlertManager()
+    calls: list[str] = []
+
+    def bad(sb, err):
+        calls.append("bad")
+        raise RuntimeError("boom")
+
+    def good(sb, err):
+        calls.append("good")
+
+    manager.register(bad)
+    manager.register(good)
+
+    logs: list[logging.LogRecord] = []
+
+    class ListHandler(logging.Handler):
+        def emit(self, record):
+            logs.append(record)
+
+    logger = logging.getLogger("pyisolate.observability.alerts")
+    handler = ListHandler()
+    logger.addHandler(handler)
+    try:
+        errors = manager.notify("sb", Exception("policy"))
+    finally:
+        logger.removeHandler(handler)
+
+    assert calls == ["bad", "good"]
+    assert len(errors) == 1
+    assert len(logs) == 1
+    assert "alert callback" in logs[0].getMessage()
+
+
 from contextlib import contextmanager
 
 


### PR DESCRIPTION
## Summary
- ensure alert callbacks run independently and log failures
- test that a failing handler doesn't stop others

## Testing
- `pytest tests/test_alerts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1e58037708328b465c2d8be90b198