### PR TITLE
feat: add frame length limit

### DIFF
--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -10,6 +10,7 @@ from pyisolate.broker.crypto import CryptoBroker, handshake
 def make_pair():
     priv_a = x25519.X25519PrivateKey.generate()
     priv_b = x25519.X25519PrivateKey.generate()
+    max_len = 4096
     a = CryptoBroker(
         priv_a.private_bytes(
             encoding=serialization.Encoding.Raw,
@@ -20,6 +21,7 @@ def make_pair():
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
         ),
+        max_frame_len=max_len,
     )
     b = CryptoBroker(
         priv_b.private_bytes(
@@ -31,6 +33,7 @@ def make_pair():
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
         ),
+        max_frame_len=max_len,
     )
     return a, b
 
@@ -76,6 +79,7 @@ def test_handshake_helper():
             encryption_algorithm=serialization.NoEncryption(),
         ),
         pub_a,
+        max_frame_len=4096,
     )
 
     msg = b"hi"

--- a/tests/test_crypto_kyber.py
+++ b/tests/test_crypto_kyber.py
@@ -18,6 +18,7 @@ def make_pair():
     pk_a, sk_a = kyber_keypair()
     ct, ss_b = kyber_encapsulate(pk_a)
     ss_a = kyber_decapsulate(ct, sk_a)
+    max_len = 4096
     a = CryptoBroker(
         priv_a.private_bytes(
             encoding=serialization.Encoding.Raw,
@@ -29,6 +30,7 @@ def make_pair():
             format=serialization.PublicFormat.Raw,
         ),
         pq_secret=ss_a,
+        max_frame_len=max_len,
     )
     b = CryptoBroker(
         priv_b.private_bytes(
@@ -41,6 +43,7 @@ def make_pair():
             format=serialization.PublicFormat.Raw,
         ),
         pq_secret=ss_b,
+        max_frame_len=max_len,
     )
     return a, b
 


### PR DESCRIPTION
## Summary
- add optional `max_frame_len` bound for `CryptoBroker`
- reject frames exceeding limit
- update tests for new argument and add oversized frame test

## Testing
- `pytest` *(fails: AttributeError: 'BPFManager' object has no attribute '_SKEL_CACHE')*
- `PYTHONPATH=. pytest tests/test_crypto.py tests/test_crypto_extra.py tests/test_crypto_kyber.py` *(fails: AttributeError: 'BPFManager' object has no attribute '_SKEL_CACHE')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f857ab30832886b5f6f0f8e8adcc