### PR TITLE
Use JSON serialization for checkpoints

### DIFF
--- a/pyisolate/checkpoint.py
+++ b/pyisolate/checkpoint.py
@@ -1,9 +1,13 @@
-"""Encrypted checkpoint helpers."""
+"""Encrypted checkpoint helpers using JSON serialization.
+
+State snapshots are encoded as JSON and sealed with ChaCha20‑Poly1305.
+Keys must be exactly 32 bytes long.
+"""
 
 from __future__ import annotations
 
+import json
 import os
-import pickle
 
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
@@ -15,8 +19,13 @@ def checkpoint(sandbox: Sandbox, key: bytes) -> bytes:
 
     The sandbox is closed after its state is captured.
     """
+    if len(key) != 32:
+        raise ValueError("key must be 32 bytes")
     state = sandbox.snapshot()
-    data = pickle.dumps(state)
+    try:
+        data = json.dumps(state).encode("utf-8")
+    except (TypeError, ValueError) as exc:  # json raises ValueError on NaN
+        raise ValueError("sandbox state is not JSON serializable") from exc
     aead = ChaCha20Poly1305(key)
     nonce = os.urandom(12)
     blob = nonce + aead.encrypt(nonce, data, b"")
@@ -26,10 +35,15 @@ def checkpoint(sandbox: Sandbox, key: bytes) -> bytes:
 
 def restore(blob: bytes, key: bytes) -> Sandbox:
     """Decrypt *blob* with *key* and spawn a new sandbox."""
+    if len(key) != 32:
+        raise ValueError("key must be 32 bytes")
     nonce, ct = blob[:12], blob[12:]
     aead = ChaCha20Poly1305(key)
     data = aead.decrypt(nonce, ct, b"")
-    state = pickle.loads(data)
+    try:
+        state = json.loads(data.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("invalid checkpoint data") from exc
     return spawn(
         state["name"],
         policy=state.get("policy"),

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -6,7 +6,29 @@ sys.path.insert(0, str(ROOT))
 
 import os
 
+import types
+
+bpf_manager = types.ModuleType("pyisolate.bpf.manager")
+
+
+class DummyBPFManager:
+    def load(self, *a, **k):
+        pass
+
+    def hot_reload(self, *a, **k):
+        pass
+
+    def open_ring_buffer(self):
+        return iter(())
+
+
+sys.modules["pyisolate.bpf.manager"] = bpf_manager
+bpf_manager.BPFManager = DummyBPFManager
+
+import pytest
+
 import pyisolate as iso
+import pyisolate.policy as policy
 
 
 def test_checkpoint_roundtrip():
@@ -26,3 +48,30 @@ def test_checkpoint_roundtrip():
             sb2.close()
     finally:
         pass
+
+
+def test_checkpoint_requires_32_byte_key():
+    sb = iso.spawn("cp")
+    try:
+        with pytest.raises(ValueError, match="32 bytes"):
+            iso.checkpoint(sb, b"short")
+    finally:
+        sb.close()
+
+
+def test_restore_requires_32_byte_key():
+    key = os.urandom(32)
+    sb = iso.spawn("cp")
+    blob = iso.checkpoint(sb, key)
+    with pytest.raises(ValueError, match="32 bytes"):
+        iso.restore(blob, b"1" * 16)
+
+
+def test_checkpoint_rejects_unserializable():
+    key = os.urandom(32)
+    sb = iso.spawn("cp", policy=policy.Policy())
+    try:
+        with pytest.raises(ValueError, match="JSON serializable"):
+            iso.checkpoint(sb, key)
+    finally:
+        sb.close()


### PR DESCRIPTION
## Summary
- switch checkpoint serialization from pickle to JSON
- validate that ChaCha20-Poly1305 keys are exactly 32 bytes
- test key length enforcement and rejection of non-JSON state

## Testing
- `pytest tests/test_checkpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1f856f4f48328b9a518a5d591b573