### PR TITLE
Handle multi-field socket addresses

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -54,7 +54,10 @@ def _blocked_open(file, *args, **kwargs):
 def _guarded_connect(self_socket: socket.socket, address: Iterable[str]):
     allowed = getattr(_thread_local, "tcp", None)
     if allowed is not None:
-        host, port = address
+        if isinstance(address, tuple):
+            host, port, *_ = address
+        else:
+            host, port = address
         if f"{host}:{port}" not in allowed:
             raise errors.PolicyError(f"connect blocked: {host}:{port}")
     return _ORIG_SOCKET_CONNECT(self_socket, address)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -35,3 +35,54 @@ def test_connect_allowed():
     finally:
         sb.close()
         srv.close()
+
+
+@pytest.mark.parametrize(
+    "family, host, suffix",
+    [
+        (socket.AF_INET, "127.0.0.1", ""),
+        (socket.AF_INET6, "::1", ", 0, 0"),
+    ],
+)
+def test_connect_guard_handles_multi_field_addresses(family, host, suffix):
+    if family == socket.AF_INET6 and not socket.has_ipv6:
+        pytest.skip("IPv6 is not available")
+
+    srv = socket.socket(family)
+    try:
+        srv.bind((host, 0))
+    except OSError as exc:
+        srv.close()
+        pytest.skip(f"cannot bind to {host}: {exc}")
+    srv.listen(1)
+    sockname = srv.getsockname()
+    target_host, port = sockname[0], sockname[1]
+    connect_args = f"({target_host!r}, {port}{suffix})"
+
+    allowed_policy = policy.Policy().allow_tcp(f"{target_host}:{port}")
+    sb_allow = iso.spawn("netguard-allow", policy=allowed_policy)
+    try:
+        code = (
+            "import socket; "
+            f"s=socket.socket({family}, socket.SOCK_STREAM); "
+            f"s.connect({connect_args}); "
+            "post('ok')"
+        )
+        sb_allow.exec(code)
+        assert sb_allow.recv(timeout=1) == "ok"
+    finally:
+        sb_allow.close()
+
+    sb_block = iso.spawn("netguard-block", policy=policy.Policy())
+    try:
+        code = (
+            "import socket; "
+            f"s=socket.socket({family}, socket.SOCK_STREAM); "
+            f"s.connect({connect_args})"
+        )
+        sb_block.exec(code)
+        with pytest.raises(iso.PolicyError):
+            sb_block.recv(timeout=1)
+    finally:
+        sb_block.close()
+        srv.close()


### PR DESCRIPTION
## Summary
- allow the sandbox networking guard to handle address tuples longer than two fields while still enforcing host:port policies
- add a parametrized network test covering IPv4 and IPv6 endpoints to ensure allowed and blocked connections behave as expected

## Testing
- `pytest tests/test_network.py` *(fails: AttributeError: 'BPFManager' object has no attribute '_SKEL_CACHE' during import, existing limitation in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d166a3cbc4832899bd9a2ae4d3551f