### PR TITLE
Fix sandbox builtins when using import whitelist

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -10,6 +10,7 @@ import json
 import logging
 import subprocess
 from pathlib import Path
+from typing import ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,8 @@ class BPFManager:
     Compilation and skeleton generation are cached per instance so that
     repeated loads can reuse the pre-built object.
     """
+
+    _SKEL_CACHE: ClassVar[dict[Path, str]] = {}
 
     def __init__(self):
         self.loaded = False
@@ -32,7 +35,7 @@ class BPFManager:
         self._filter_obj = Path(__file__).with_name("syscall_filter.bpf.o")
         self._guard_src = Path(__file__).with_name("resource_guard.bpf.c")
         self._guard_obj = Path(__file__).with_name("resource_guard.bpf.o")
-        self._skel_cache: dict[Path, str] = {}
+        self._skel_cache = self._SKEL_CACHE
 
     # internal helper
     def _run(self, cmd: list[str], *, raise_on_error: bool = False) -> bool:

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -370,10 +370,7 @@ class SandboxThread(threading.Thread):
                 _thread_local.tcp = allowed_tcp
                 _thread_local.fs = allowed_fs
 
-                if self.allowed_imports is not None:
-                    builtins_dict = builtins.__dict__.copy()
-                else:
-                    builtins_dict = _SAFE_BUILTINS.copy()
+                builtins_dict = _SAFE_BUILTINS.copy()
                 builtins_dict["open"] = _blocked_open
                 builtins_dict["__import__"] = _make_importer(self.allowed_imports)
                 local_vars["__builtins__"] = builtins_dict


### PR DESCRIPTION
## Summary
- ensure sandbox threads always start from the sanitized builtins and wire in the proper importer
- make the BPF skeleton cache a class-level dictionary so repeated loads reuse it without AttributeError
- extend sandbox tests to cover eval/exec removal with import whitelists and prime the cache for test execution

## Testing
- pytest tests/test_sandbox.py::test_dangerous_builtins_removed tests/test_sandbox.py::test_dangerous_builtins_removed_with_allowed_imports

------
https://chatgpt.com/codex/tasks/task_e_68d166aa54708328978a55add2741ab9