### PR TITLE
Fix BPFManager skeleton cache typo and add regression test

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -101,7 +101,7 @@ class BPFManager:
         ]
         ok = True
         compile_cmd = dummy_compile
-        if self._src not in self._SKEL_CACHE:
+        if self._src not in self._skel_cache:
             ok &= self._run(compile_cmd, raise_on_error=strict)
             skel_cmd = [
                 "sh",


### PR DESCRIPTION
## Summary
- fix the BPFManager skeleton cache lookup to use the intended `_skel_cache`
- extend the bpf manager tests with a regression that exercises `load(strict=False)`
- clean up existing tests to stop touching the non-existent cache attribute and accept `caplog`

## Testing
- pytest tests/test_bpf_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d166a4f7bc8328beb150866e596711