### PR TITLE
Preserve NUMA and import policies in checkpoints

### DIFF
--- a/pyisolate/checkpoint.py
+++ b/pyisolate/checkpoint.py
@@ -49,6 +49,8 @@ def restore(blob: bytes, key: bytes) -> Sandbox:
         policy=state.get("policy"),
         cpu_ms=state.get("cpu_ms"),
         mem_bytes=state.get("mem_bytes"),
+        allowed_imports=state.get("allowed_imports"),
+        numa_node=state.get("numa_node"),
     )
 
 

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -228,6 +228,10 @@ class SandboxThread(threading.Thread):
             "policy": self.policy,
             "cpu_ms": self.cpu_quota_ms,
             "mem_bytes": self.mem_quota_bytes,
+            "allowed_imports": sorted(self.allowed_imports)
+            if self.allowed_imports is not None
+            else None,
+            "numa_node": self.numa_node,
         }
 
     def enable_tracing(self) -> None:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -74,3 +74,26 @@ def test_checkpoint_rejects_unserializable():
             iso.checkpoint(sb, key)
     finally:
         sb.close()
+
+
+def test_checkpoint_restores_imports_and_numa():
+    key = os.urandom(32)
+    allowed_imports = ["statistics", "math"]
+    numa_node = 0
+    sb = iso.spawn("custom", allowed_imports=allowed_imports, numa_node=numa_node)
+    try:
+        snap = sb.snapshot()
+        assert snap["allowed_imports"] == sorted(set(allowed_imports))
+        assert snap["numa_node"] == numa_node
+        blob = iso.checkpoint(sb, key)
+        sb2 = iso.restore(blob, key)
+        try:
+            restored = sb2.snapshot()
+            assert restored["allowed_imports"] == sorted(set(allowed_imports))
+            assert restored["numa_node"] == numa_node
+            sb2.exec("import math, statistics\npost(math.sqrt(16) + statistics.mean([0, 2]))")
+            assert pytest.approx(sb2.recv(timeout=0.5)) == 5.0
+        finally:
+            sb2.close()
+    finally:
+        pass


### PR DESCRIPTION
## Summary
- include allowed import lists and NUMA node assignments in sandbox snapshots
- pass the captured fields through checkpoint restore so respawned sandboxes retain them
- add a regression test covering custom import allowlists and NUMA affinity

## Testing
- pytest tests/test_checkpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68deea98c43083289e23b8cdfd130e4a