### PR TITLE
Handle invalid sandbox call targets

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -403,7 +403,14 @@ class SandboxThread(threading.Thread):
                             kind, func, args, kwargs = payload
                             if kind == "call":
                                 importer = builtins_dict["__import__"]
-                                module_name, func_name = func.rsplit(".", 1)
+                                try:
+                                    module_name, func_name = func.rsplit(".", 1)
+                                except ValueError as exc:
+                                    raise errors.SandboxError(
+                                        "call target {!r} must include a module path (e.g. 'module.func')".format(
+                                            func
+                                        )
+                                    ) from exc
                                 mod = importer(module_name, fromlist=["_"])
                                 res = object.__getattribute__(mod, func_name)(
                                     *args, **kwargs

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -43,6 +43,19 @@ def test_call_returns_result():
         sb.close()
 
 
+def test_call_requires_dotted_path():
+    sb = iso.spawn("nodot")
+    try:
+        with pytest.raises(iso.SandboxError) as excinfo:
+            sb.call("sqrt", 4)
+        assert (
+            str(excinfo.value)
+            == "call target 'sqrt' must include a module path (e.g. 'module.func')"
+        )
+    finally:
+        sb.close()
+
+
 def test_allowed_imports_success():
     sb = iso.spawn("imp_ok", allowed_imports=["math"])
     try:


### PR DESCRIPTION
## Summary
- raise a descriptive SandboxError when sandbox call targets lack a module path
- add a regression test covering invalid call targets

## Testing
- pytest tests/test_sandbox.py::test_call_requires_dotted_path

------
https://chatgpt.com/codex/tasks/task_e_68deea9afa44832894d2b9d2f20bce99