### PR TITLE
Reject duplicate sandbox names

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -132,8 +132,12 @@ class Supervisor:
                 imports.update(allowed_imports)
             allowed_imports = list(imports)
 
-        cg_path = cgroup.create(name, cpu_ms, mem_bytes)
         with self._lock:
+            existing = self._sandboxes.get(name)
+            if existing is not None and existing.is_alive():
+                raise RuntimeError(f"sandbox '{name}' already exists")
+
+            cg_path = cgroup.create(name, cpu_ms, mem_bytes)
             if self._warm_pool:
                 thread = self._warm_pool.pop()
                 thread.reset(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -99,3 +99,17 @@ def test_spawn_valid_name_regex(name):
 def test_spawn_invalid_name_regex(name):
     with pytest.raises(ValueError):
         iso.spawn(name)
+
+
+def test_spawn_duplicate_name_rejected():
+    sup = iso.Supervisor()
+    try:
+        sb = sup.spawn("dup")
+        with pytest.raises(RuntimeError, match="sandbox 'dup' already exists"):
+            sup.spawn("dup")
+        active = sup.list_active()
+        assert "dup" in active
+        assert active["dup"]._thread is sb._thread
+    finally:
+        sb.close()
+        sup.shutdown()


### PR DESCRIPTION
## Summary
- prevent `Supervisor.spawn` from overwriting a live sandbox when the name is reused
- add a regression test that ensures duplicate spawns raise and the original sandbox remains tracked

## Testing
- `pytest tests/test_supervisor.py`


------
https://chatgpt.com/codex/tasks/task_e_68deea985ac88328bafb4575d04b8995