### PR TITLE
Treat missing BPF tool executables as failed runs and add tests

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -52,10 +52,12 @@ class BPFManager:
             # Missing tools are expected in some environments; log and continue
             # in lenient mode so that sandboxing can still function without BPF
             # enforcement.
-            logger.error("command not found: %s", cmd[0])
+            logger.error("command not found while running %s: %s", cmd, cmd[0])
             if raise_on_error:
-                raise RuntimeError(f"Command not found: {cmd[0]}") from exc
-            return True
+                raise RuntimeError(
+                    f"Command not found: {cmd[0]} (full command: {' '.join(cmd)})"
+                ) from exc
+            return False
         except subprocess.CalledProcessError as exc:
             stderr = exc.stderr or ""
             logger.error("command failed %s: %s", cmd, stderr.strip())

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -235,3 +235,45 @@ def test_hot_reload_logs_updates(tmp_path, monkeypatch, caplog):
     caplog.set_level(logging.INFO)
     mgr.hot_reload(str(policy))
     assert any("cpu" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.parametrize("missing_tool", ["clang", "bpftool"])
+def test_load_lenient_missing_executable_keeps_unloaded(
+    monkeypatch, caplog, missing_tool
+):
+    def fake_run(cmd, check, capture_output, text):
+        if cmd[0] == missing_tool or (
+            missing_tool == "bpftool" and cmd[0] == "sh" and "bpftool" in cmd[2]
+        ):
+            raise FileNotFoundError(missing_tool)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    mgr = BPFManager()
+    caplog.set_level(logging.ERROR)
+
+    mgr.load(strict=False)
+
+    assert mgr.loaded is False
+    assert any("command not found while running" in rec.getMessage() for rec in caplog.records)
+    assert any(missing_tool in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.parametrize("missing_tool", ["clang", "bpftool"])
+def test_load_strict_missing_executable_raises_runtime_error(monkeypatch, missing_tool):
+    def fake_run(cmd, check, capture_output, text):
+        if cmd[0] == missing_tool or (
+            missing_tool == "bpftool" and cmd[0] == "sh" and "bpftool" in cmd[2]
+        ):
+            raise FileNotFoundError(missing_tool)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    mgr = BPFManager()
+
+    with pytest.raises(RuntimeError) as exc:
+        mgr.load(strict=True)
+
+    assert "Command not found" in str(exc.value)
+    assert missing_tool in str(exc.value)
+    assert mgr.loaded is False


### PR DESCRIPTION
### Motivation
- Ensure `BPFManager.load()` reflects actual command outcomes when tool binaries are absent so `self.loaded` is accurate in lenient mode. 
- Provide clearer operator diagnostics by logging the full command context when an executable is missing. 

### Description
- Change `_run` to return `False` (not `True`) on `FileNotFoundError` when called with `raise_on_error=False`, so missing executables count as failed runs in lenient mode. 
- Preserve and improve logging by including the full `cmd` context and the missing binary in the error message, and include the full command in the `RuntimeError` raised when `raise_on_error=True`. 
- Ensure `load()` continues to compute `self.loaded` from the aggregated command outcomes (`ok &= ...` then `self.loaded = ok`), so absent tools result in `self.loaded = False`. 
- Add unit tests in `tests/test_bpf_manager.py` that simulate `FileNotFoundError` for `clang` and `bpftool` and assert lenient-mode leaves `mgr.loaded is False` and strict-mode raises a clear `RuntimeError`. 

### Testing
- Ran `pytest -q tests/test_bpf_manager.py` and all tests passed (`13 passed`). 
- New tests cover both lenient and strict behaviors for missing `clang` and `bpftool` and assert logging and exception messages as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d176c465c883288904d1069cfe0d23)