### PR TITLE
Harden watchdog polling loop against iterator and event failures

### DIFF
--- a/pyisolate/watchdog.py
+++ b/pyisolate/watchdog.py
@@ -7,14 +7,18 @@ breached. Events are dictionaries with the sandbox ``name`` and current
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from . import errors
 
 if TYPE_CHECKING:
     from .supervisor import Supervisor
+
+logger = logging.getLogger(__name__)
 
 
 class ResourceWatchdog(threading.Thread):
@@ -41,6 +45,15 @@ class ResourceWatchdog(threading.Thread):
                 self._rb_iter = None
                 time.sleep(self._interval)
                 continue
+            except Exception:
+                logger.exception("watchdog ring-buffer iterator failed; resetting")
+                self._rb_iter = None
+                time.sleep(self._interval)
+                continue
+
+            if not isinstance(event, Mapping):
+                logger.warning("watchdog ignored non-mapping event payload: %r", event)
+                continue
 
             name = event.get("name")
             cpu_ms = event.get("cpu_ms", 0)
@@ -50,9 +63,19 @@ class ResourceWatchdog(threading.Thread):
             if not sb:
                 continue
             if sb.cpu_quota_ms is not None and cpu_ms >= sb.cpu_quota_ms:
-                sb._outbox.put(errors.CPUExceeded())
-                sb.stop()
+                try:
+                    sb._outbox.put(errors.CPUExceeded())
+                    sb.stop()
+                except Exception:
+                    logger.exception(
+                        "watchdog failed to stop sandbox %r after CPU quota breach", name
+                    )
                 continue
             if sb.mem_quota_bytes is not None and rss >= sb.mem_quota_bytes:
-                sb._outbox.put(errors.MemoryExceeded())
-                sb.stop()
+                try:
+                    sb._outbox.put(errors.MemoryExceeded())
+                    sb.stop()
+                except Exception:
+                    logger.exception(
+                        "watchdog failed to stop sandbox %r after memory quota breach", name
+                    )

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -65,3 +65,60 @@ def test_watchdog_thread_stops():
     sup = iso.supervisor._supervisor
     iso.shutdown()
     assert not sup._watchdog.is_alive()
+
+
+class _FakeBPF:
+    def __init__(self, iterator_factory):
+        self._iterator_factory = iterator_factory
+
+    def open_ring_buffer(self):
+        return self._iterator_factory()
+
+
+class _FakeSupervisor:
+    def __init__(self, iterator_factory):
+        self._bpf = _FakeBPF(iterator_factory)
+
+    def get_active_threads(self):
+        return []
+
+
+def test_watchdog_ignores_malformed_event_payloads(caplog):
+    from pyisolate.watchdog import ResourceWatchdog
+
+    def fake_iter():
+        for event in ["bad-event", 123, None]:
+            yield event
+        while True:
+            time.sleep(0.01)
+            yield {"name": "noop", "cpu_ms": 0, "rss_bytes": 0}
+
+    caplog.set_level("WARNING")
+    wd = ResourceWatchdog(_FakeSupervisor(fake_iter), interval=0.01)
+    wd.start()
+    try:
+        time.sleep(0.08)
+        assert wd.is_alive()
+    finally:
+        wd.stop()
+
+    assert "watchdog ignored non-mapping event payload" in caplog.text
+
+
+def test_watchdog_survives_ring_buffer_iterator_exceptions(caplog):
+    from pyisolate.watchdog import ResourceWatchdog
+
+    class BoomIter:
+        def __next__(self):
+            raise RuntimeError("boom")
+
+    caplog.set_level("ERROR")
+    wd = ResourceWatchdog(_FakeSupervisor(BoomIter), interval=0.01)
+    wd.start()
+    try:
+        time.sleep(0.08)
+        assert wd.is_alive()
+    finally:
+        wd.stop()
+
+    assert "watchdog ring-buffer iterator failed; resetting" in caplog.text


### PR DESCRIPTION
### Motivation
- Prevent the `ResourceWatchdog` thread from terminating on ring-buffer iterator failures or malformed event payloads by making the polling loop more defensive.
- Ensure a single broken sandbox state or bad event does not stop quota enforcement for other sandboxes.

### Description
- Surround `next(self._rb_iter)` with a broad `except Exception` handler that logs the exception via `logger.exception`, resets `_rb_iter = None`, and applies an interval backoff before retrying to reopen the iterator.
- Validate ring-buffer events are mapping-like with `isinstance(event, Mapping)` before calling `.get(...)`, and log a warning for non-mapping payloads so they are ignored safely.
- Wrap sandbox notification/stop operations (`sb._outbox.put(...)` and `sb.stop()`) in `try/except` blocks that log failures to avoid crashing the watchdog loop on one sandbox error.
- Add imports for `logging` and `collections.abc.Mapping`, and update `pyisolate/watchdog.py` and `tests/test_watchdog.py` with tests exercising malformed payloads and iterator exceptions.

### Testing
- Ran `pytest -q tests/test_watchdog.py` and the suite passed (`5 passed`).
- New tests `test_watchdog_ignores_malformed_event_payloads` and `test_watchdog_survives_ring_buffer_iterator_exceptions` verify the watchdog thread remains alive and logs expected diagnostics when encountering bad events or iterator exceptions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d176c6ec7483288768eca6f5760b9d)