### PR TITLE
Lazy-initialize module-level Supervisor singleton

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -245,28 +245,35 @@ class Supervisor:
             self._warm_pool = [t for t in self._warm_pool if t.is_alive()]
 
 
-_supervisor = Supervisor()
+_supervisor: Supervisor | None = None
+
+
+def _get_supervisor() -> Supervisor:
+    global _supervisor
+    if _supervisor is None:
+        _supervisor = Supervisor()
+    return _supervisor
 
 
 # Public API
 def spawn(*args, **kwargs):
-    return _supervisor.spawn(*args, **kwargs)
+    return _get_supervisor().spawn(*args, **kwargs)
 
 
 def list_active() -> Dict[str, Sandbox]:
-    return _supervisor.list_active()
+    return _get_supervisor().list_active()
 
 
 def reload_policy(policy_path: str, token: str | RootCapability = ROOT) -> None:
-    _supervisor.reload_policy(policy_path, token)
+    _get_supervisor().reload_policy(policy_path, token)
 
 
 def set_policy_token(token: str) -> None:
-    _supervisor.set_policy_token(token)
+    _get_supervisor().set_policy_token(token)
 
 
 def shutdown(cap: RootCapability = ROOT) -> None:
     global _supervisor
-    old = _supervisor
-    old.shutdown(cap)
-    _supervisor = Supervisor()
+    supervisor = _get_supervisor()
+    supervisor.shutdown(cap)
+    _supervisor = None

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -105,7 +105,7 @@ def test_cpu_quota_exceeded(monkeypatch):
     monkeypatch.setattr(BPFManager, "_run", lambda *a, **k: True)
     iso.shutdown()
 
-    sb = iso.supervisor._supervisor.spawn("tcpu", cpu_ms=10)
+    sb = iso.supervisor._get_supervisor().spawn("tcpu", cpu_ms=10)
     try:
         sb.exec("while True: pass")
         with pytest.raises(iso.CPUExceeded):
@@ -128,7 +128,7 @@ def test_memory_quota_exceeded(monkeypatch):
     monkeypatch.setattr(BPFManager, "_run", lambda *a, **k: True)
     iso.shutdown()
 
-    sb = iso.supervisor._supervisor.spawn("tmem", mem_bytes=1024 * 1024)
+    sb = iso.supervisor._get_supervisor().spawn("tmem", mem_bytes=1024 * 1024)
     try:
         sb.exec("x = ' ' * (2 * 1024 * 1024)")
         with pytest.raises(iso.MemoryExceeded):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -10,6 +10,30 @@ import pyisolate as iso
 from pyisolate.bpf.manager import BPFManager
 
 
+def test_module_import_is_lazy(monkeypatch):
+    calls: list[str] = []
+
+    def fake_load(self):
+        calls.append("load")
+
+    def fake_watchdog_start(self):
+        calls.append("watchdog")
+
+    monkeypatch.setattr(BPFManager, "load", fake_load)
+    monkeypatch.setattr("pyisolate.watchdog.ResourceWatchdog.start", fake_watchdog_start)
+
+    sup_mod = iso.supervisor
+    sup_mod._supervisor = None
+
+    assert sup_mod._supervisor is None
+    assert calls == []
+
+    sup_mod.list_active()
+
+    assert calls == ["load", "watchdog"]
+    sup_mod._supervisor = None
+
+
 def test_list_active_contains_spawned():
     sb = iso.spawn("active")
     try:

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -30,7 +30,7 @@ def test_cpu_quota_exceeded_via_watchdog(monkeypatch):
     monkeypatch.setattr(BPFManager, "_run", lambda *a, **k: True)
     iso.shutdown()
 
-    sb = iso.supervisor._supervisor.spawn("wdcpu", cpu_ms=10)
+    sb = iso.supervisor._get_supervisor().spawn("wdcpu", cpu_ms=10)
     try:
         with pytest.raises(iso.CPUExceeded):
             sb.recv(timeout=1)
@@ -52,7 +52,7 @@ def test_memory_quota_exceeded_via_watchdog(monkeypatch):
     monkeypatch.setattr(BPFManager, "_run", lambda *a, **k: True)
     iso.shutdown()
 
-    sb = iso.supervisor._supervisor.spawn("wdmem", mem_bytes=1024 * 1024)
+    sb = iso.supervisor._get_supervisor().spawn("wdmem", mem_bytes=1024 * 1024)
     try:
         sb.exec("x = ' ' * (2 * 1024 * 1024)")
         with pytest.raises(iso.MemoryExceeded):
@@ -62,6 +62,6 @@ def test_memory_quota_exceeded_via_watchdog(monkeypatch):
 
 
 def test_watchdog_thread_stops():
-    sup = iso.supervisor._supervisor
+    sup = iso.supervisor._get_supervisor()
     iso.shutdown()
     assert not sup._watchdog.is_alive()


### PR DESCRIPTION
### Motivation
- Avoid side-effects at import-time by preventing the `Supervisor()` from being constructed and starting threads/BPF on module import. 
- Make supervisor lifecycle recreation lazy so `shutdown()` does not eagerly create a new `Supervisor` instance. 
- Ensure tests and internal consumers that previously reached into the module-level instance continue to work with the nullable cached reference.

### Description
- Replace eager `_supervisor = Supervisor()` with `_supervisor: Supervisor | None = None` and add an internal helper `def _get_supervisor() -> Supervisor:` that constructs and caches a `Supervisor` on first use. 
- Route public APIs (`spawn`, `list_active`, `reload_policy`, `set_policy_token`, `shutdown`) to resolve the supervisor via `_get_supervisor()`. 
- Update `shutdown()` to call `shutdown` on the current supervisor and then set the cached reference to `None` so a fresh supervisor will be created lazily on next API call. 
- Add a regression test `test_module_import_is_lazy` that patches `BPFManager.load` and `ResourceWatchdog.start` to assert that importing `pyisolate.supervisor` does not trigger BPF load or watchdog start until an API call; and update tests that accessed the module-level `_supervisor` directly to use `_get_supervisor()`.

### Testing
- Ran `pytest -q tests/test_supervisor.py tests/test_watchdog.py tests/test_sandbox.py` and all tests passed (`35 passed`). 
- Added `test_module_import_is_lazy` to verify import-time laziness and updated existing tests to use `_get_supervisor()` where appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d176c2efb88328aff54c1cf30ddc91)