### PR TITLE
Validate policy schema before compile/reload in policy.refresh

### DIFF
--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -110,7 +110,16 @@ def _validate(data: object) -> None:
 def refresh(path: str, token: str) -> None:
     """Parse *path* and atomically update eBPF policy maps."""
 
-    # Compile and validate the YAML policy first
+    # Fail fast if the YAML is malformed/schema-invalid before compiling/reloading.
+    with open(path, "r", encoding="utf-8") as fh:
+        try:
+            data = yaml.safe_load(fh)
+        except Exception as exc:  # broad due to optional parser
+            raise ValueError(f"invalid YAML: {exc}") from None
+
+    _validate(data)
+
+    # Compile only after schema/version validation passes.
     compiled = compile_policy(path)
 
     import json
@@ -119,15 +128,6 @@ def refresh(path: str, token: str) -> None:
     with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
         json.dump(asdict(compiled), tmp)
         json_path = Path(tmp.name)
-
-    # Fail fast if the YAML is malformed before touching BPF maps
-    with open(path, "r", encoding="utf-8") as fh:
-        try:
-            data = yaml.safe_load(fh)
-        except Exception as exc:  # broad due to optional parser
-            raise ValueError(f"invalid YAML: {exc}") from None
-
-    _validate(data)
 
     # Upon successful parse, swap the live maps via the supervisor
     try:

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -162,6 +162,45 @@ def test_validation_bad_section_type(tmp_path):
         policy.refresh(str(p), token="tok")
 
 
+@pytest.mark.parametrize(
+    ("doc", "msg"),
+    [
+        ("defaults: {}\n", "version"),
+        ("version: 9\n", "unsupported policy version"),
+        ("version: 0.1\nsandboxes: []\n", "sandboxes"),
+    ],
+)
+def test_refresh_validation_fails_before_compile_or_reload(monkeypatch, tmp_path, doc, msg):
+    policy = load_policy(no_yaml=True)
+    import pyisolate as iso
+
+    iso.set_policy_token("tok")
+    path = tmp_path / "bad.yml"
+    path.write_text(doc)
+
+    compile_calls = 0
+    reload_calls = 0
+
+    def fake_compile(_path):
+        nonlocal compile_calls
+        compile_calls += 1
+        raise AssertionError("compile_policy must not run for invalid schema/version")
+
+    def fake_reload(*_args, **_kwargs):
+        nonlocal reload_calls
+        reload_calls += 1
+        raise AssertionError("reload_policy must not run for invalid schema/version")
+
+    monkeypatch.setattr(policy, "compile_policy", fake_compile)
+    monkeypatch.setattr("pyisolate.supervisor.reload_policy", fake_reload)
+
+    with pytest.raises(ValueError, match=msg):
+        policy.refresh(str(path), token="tok")
+
+    assert compile_calls == 0
+    assert reload_calls == 0
+
+
 @pytest.mark.parametrize("name", ["ml.yml", "web_scraper.yml"])
 def test_templates_parse(monkeypatch, name):
     policy = load_policy()


### PR DESCRIPTION
### Motivation
- Ensure `refresh` fails fast on malformed YAML or unsupported `version`/schema so compilation and BPF reload are not attempted for invalid documents.
- Avoid unnecessary/unsafe calls into the compiler or supervisor when the document is clearly invalid, and preserve clear `ValueError` semantics for YAML/schema problems.

### Description
- Parse the YAML and run `_validate(data)` at the start of `pyisolate/policy/__init__.py::refresh` before calling `compile_policy(path)`.
- Compile only after validation succeeds and continue to serialize the compiled `CompiledPolicy` to a temporary JSON file for the atomic handoff to `reload_policy`.
- Invoke `reload_policy` with the temporary JSON path and retain the existing temp-file cleanup in the `finally` block to preserve atomicity.
- Kept exception mapping unchanged so malformed YAML/schema errors surface as `ValueError` while reload/auth errors still originate from supervisor reload logic.

### Testing
- Added `test_refresh_validation_fails_before_compile_or_reload` in `tests/test_policy.py` to assert invalid docs raise `ValueError` and that neither `compile_policy` nor `reload_policy` are called for those cases.
- Ran `pytest -q tests/test_policy.py` and the test suite passed with `21 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d176c9e0a88328b45352f5c6471512)