### PR TITLE
Order latency histogram buckets deterministically in metrics export

### DIFF
--- a/pyisolate/observability/metrics.py
+++ b/pyisolate/observability/metrics.py
@@ -6,6 +6,8 @@ them as standard Prometheus ``Gauge`` metrics.  It is intentionally minimal but
 useful for tests and examples.
 """
 
+LATENCY_BUCKET_ORDER = ["0.5", "1", "5", "10", "inf"]
+
 
 def _escape_label(value: str) -> str:
     """Escape a label value according to the Prometheus text exposition format.
@@ -64,8 +66,15 @@ class MetricsExporter:
                 f'pyisolate_cost{{sandbox="{label}"}} {stats.cost:.6f}',
             )
             cumul = 0
-            for le, count in stats.latency.items():
+            for bucket in LATENCY_BUCKET_ORDER:
+                if bucket == "inf":
+                    count = stats.latency.get("inf", stats.latency.get("+Inf", 0))
+                else:
+                    count = stats.latency.get(bucket, 0)
                 cumul += count
+                # Emit Prometheus canonical +Inf label while still accepting
+                # either "inf" (legacy/internal) or "+Inf" in source stats.
+                le = "+Inf" if bucket == "inf" else bucket
                 emit(
                     "pyisolate_latency_ms",
                     "Sandbox operation latency in milliseconds",

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -103,3 +103,69 @@ def test_export_sanitizes_sandbox_name():
         assert f'sandbox="{name}"' not in metrics
     finally:
         sb.close()
+
+
+def test_export_latency_bucket_order_and_cumulative_values(monkeypatch):
+    import pyisolate.supervisor as supervisor
+
+    class _FakeSandbox:
+        def __init__(self):
+            # Intentionally shuffled input ordering to ensure exporter order is
+            # dictated by canonical bucket sequence.
+            self.stats = types.SimpleNamespace(
+                cpu_ms=1.0,
+                mem_bytes=64,
+                errors=0,
+                operations=9,
+                cost=0.1,
+                latency={"10": 4, "0.5": 1, "inf": 5, "1": 2, "5": 3},
+                latency_sum=17.5,
+            )
+
+    monkeypatch.setattr(supervisor, "list_active", lambda: {"sandbox-z": _FakeSandbox()})
+    metrics = MetricsExporter().export()
+    bucket_lines = [
+        line
+        for line in metrics.splitlines()
+        if line.startswith('pyisolate_latency_ms_bucket{sandbox="sandbox-z"')
+    ]
+    assert bucket_lines == [
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-z",le="0.5"} 1',
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-z",le="1"} 3',
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-z",le="5"} 6',
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-z",le="10"} 10',
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-z",le="+Inf"} 15',
+    ]
+
+
+def test_export_latency_missing_buckets_default_to_zero(monkeypatch):
+    import pyisolate.supervisor as supervisor
+
+    class _FakeSandbox:
+        def __init__(self):
+            self.stats = types.SimpleNamespace(
+                cpu_ms=1.0,
+                mem_bytes=64,
+                errors=0,
+                operations=1,
+                cost=0.1,
+                latency={"5": 1},
+                latency_sum=5.0,
+            )
+
+    monkeypatch.setattr(
+        supervisor, "list_active", lambda: {"sandbox-missing": _FakeSandbox()}
+    )
+    metrics = MetricsExporter().export()
+    bucket_lines = [
+        line
+        for line in metrics.splitlines()
+        if line.startswith('pyisolate_latency_ms_bucket{sandbox="sandbox-missing"')
+    ]
+    assert bucket_lines == [
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-missing",le="0.5"} 0',
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-missing",le="1"} 0',
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-missing",le="5"} 1',
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-missing",le="10"} 1',
+        'pyisolate_latency_ms_bucket{sandbox="sandbox-missing",le="+Inf"} 1',
+    ]


### PR DESCRIPTION
### Motivation

- Ensure histogram bucket lines are emitted in a deterministic, canonical order rather than depending on dict insertion order. 
- Make the exported infinite bucket Prometheus-compatible while preserving compatibility with existing internal keys and preserving cumulative `_bucket` semantics.

### Description

- Add `LATENCY_BUCKET_ORDER = ["0.5", "1", "5", "10", "inf"]` to `pyisolate/observability/metrics.py`. 
- Iterate latency buckets using the canonical order and default missing bucket counts to `0` so cumulative `_bucket` values are correct. 
- Emit the infinite bucket label as `+Inf` while accepting either `"inf"` or `"+Inf"` in source stats. 
- Add tests `test_export_latency_bucket_order_and_cumulative_values` and `test_export_latency_missing_buckets_default_to_zero` to verify exact line ordering and cumulative semantics when input latency dict order is shuffled or missing buckets.

### Testing

- Ran `pytest -q tests/test_metrics.py` which executed the metrics tests and reported `5 passed`.
- The new tests explicitly assert bucket line ordering and cumulative counts for both shuffled and partial latency inputs and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d176cc725883289d0abcb28f8fd3b0)