### PR TITLE
Clarify execution cell vs authoritative security boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,11 @@ Use `pyisolate.policy.refresh("policy/<name>.yml", token="secret")` to hot‑loa
 
 ## Security model
 
-* **Process boundary** – single process; sub‑interpreter ≙ trust boundary.
+* **Execution cell** – each guest runs in its own sub‑interpreter, hosted by one sandbox thread.
+* **Security boundary (authoritative)** – enforcement lives at the kernel/process layer (cgroups + eBPF/LSM), not at the Python sub‑interpreter boundary.
 * **Kernel boundary** – every sandbox thread enters its own cgroup; CO‑RE eBPF programs enforce FS/net/syscall policy.
 * **Broker** – sole path to privileged syscalls, sealed with AEAD and strict replay protection.
+* **Fallback hardening** – for stronger blast‑radius isolation (or kernels with reduced features), run one sandbox per process and place that process inside a container or microVM.
 * **Verified eBPF modules** – bytecode is disassembled with `llvm-objdump -d` and must succeed `bpftool prog load` so the kernel verifier approves it before any sandbox runs.
 
 See **SECURITY.md** for a full threat‑model walkthrough.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,10 @@ We **assume** the kernel and hardware are trusted and un‑compromised.  Kernel 
 
 ## 2  Security guarantees
 
+### Authoritative boundary statement
+
+PyIsolate uses **sub‑interpreters as execution cells** for scheduling and lifecycle, while the **actual security boundary is kernel/process level enforcement** (cgroups, eBPF/LSM, and broker mediation). Sub‑interpreters alone are not treated as a hard isolation boundary in production.
+
 1. **Process containment** — Guest code cannot execute syscalls outside the eBPF allow‑list.
 2. **Memory safety** — Each interpreter is hard‑capped to its RAM quota at the allocator level; no guest can corrupt another’s heap.
 3. **Broker integrity & replay protection** — All control‑plane frames are AEAD‑sealed (X25519 → ChaCha20‑Poly1305) with strictly increasing counters; forged or replayed frames are dropped.
@@ -64,6 +68,15 @@ Anything not listed above is *not* guaranteed.
 | **Side‑channel leakage (L1/L3 cache, branch predictors)** | Use one process per tenant on highly sensitive workloads.                         |
 | **Cooperative multithreading abuse**                      | Scheduler starvation possible; employ cgroup CPU quotas.                          |
 | **Spectre v2**                                            | Mitigations inherit from host kernel; PyIsolate adds none.                        |
+
+---
+
+### Isolation hierarchy (recommended interpretation)
+
+1. **Sub‑interpreter**: execution cell only.
+2. **Thread**: scheduling/accounting unit.
+3. **Process + kernel policy**: primary production security boundary.
+4. **Container/microVM**: stronger boundary and recommended fallback for hostile multi‑tenant environments.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Remove ambiguity in the security model by stating that sub‑interpreters are execution cells used for scheduling/lifecycle while the authoritative security boundary is enforced at the kernel/process level (cgroups + eBPF/LSM), and provide guidance for stronger isolation via per‑process containers or microVMs.

### Description
- Documentation-only updates: clarified the security model and added fallback guidance in `README.md`, added an "Authoritative boundary statement" and an "Isolation hierarchy" in `SECURITY.md` to enumerate sub‑interpreter → thread → process+kernel → container/microVM.

### Testing
- Ran the targeted unit tests with `python -m pytest -q tests/test_supervisor.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7626c8ae88328816f2e2f5d5341f1)