### PR TITLE
docs: formalize the canonical cell execution model

### DIFF
--- a/API.md
+++ b/API.md
@@ -6,6 +6,12 @@ import pyisolate as psi
 
 ## 1  Spawning & lifecycle
 
+### Canonical cell execution model
+
+PyIsolate supports exactly seven cell operations: `exec source`, `call dotted function`, `import module`, `post messages`, `stream logs`, `emit metrics`, and `request broker actions`.
+
+The canonical contract lives in [docs/execution-model.md](docs/execution-model.md). Keep this surface small; production systems win by refusing extra features.
+
 | Call | Description |
 |------|-------------|
 | `psi.spawn(name:str, policy:str|dict=None, allowed_imports:list[str]|None=None) → Sandbox` | Create sandbox thread, attach eBPF, return handle with module whitelist. |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ Use `pyisolate.policy.refresh("policy/<name>.yml", token="secret")` to hot‑loa
 
 ---
 
+## Canonical execution model
+
+A cell is intentionally limited to seven operations: execute source, call a dotted function, import allowed modules, post messages, stream logs, emit metrics, and request broker actions.
+
+See [docs/execution-model.md](docs/execution-model.md). We keep this model small on purpose: production systems are safer when they refuse features outside a single contract.
+
+---
+
 ## Security model
 
 * **Process boundary** – single process; sub‑interpreter ≙ trust boundary.

--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -1,0 +1,37 @@
+# Execution model (canonical)
+
+A sandboxed cell has exactly **one** execution contract.
+
+## Allowed operations
+
+1. **`exec(source)`**
+   Execute source text inside the cell runtime.
+2. **`call(dotted_function, *args, **kwargs)`**
+   Invoke a fully-qualified function path (`module.func`) inside the cell.
+3. **`import module`**
+   Import only modules allowed by policy (`allowed_imports` + policy imports).
+4. **`post(message)`**
+   Send a single picklable message to the supervisor channel.
+5. **`stream logs`**
+   Emit structured log events as messages on the same channel (log envelope).
+6. **`emit metrics`**
+   Emit metric datapoints as messages on the same channel (metric envelope).
+7. **`request broker actions`**
+   Ask the supervisor/broker to perform privileged actions by posting broker request envelopes.
+
+## Non-goals (intentionally refused)
+
+Anything outside the seven operations above is out of model and should be rejected.
+In particular, we do **not** add ad-hoc host RPC, shared mutable globals, direct privileged syscalls,
+or extra control planes.
+
+## Why this stays small
+
+Production safety improves when the surface area is fixed:
+
+- policy is auditable,
+- tracing is uniform,
+- failure modes are bounded,
+- compatibility is easier to preserve.
+
+If a new feature cannot be expressed as one of the seven operations, it is not a cell feature.


### PR DESCRIPTION
### Motivation

- Provide one small, auditable contract for what a sandboxed cell may do by naming the exact allowed operations and intentionally refusing other capabilities.

### Description

- Add `docs/execution-model.md` which enumerates the seven allowed operations (`exec`, dotted `call`, `import`, `post`, stream logs, emit metrics, and request broker actions`) and documents explicit non‑goals.
- Link the canonical model from the public reference in `API.md` and surface the same summary in `README.md` so the contract is visible to users and integrators.

### Testing

- Ran `pytest -q tests/test_sdk.py` and the suite passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e762b26414832886499eff1ec29f4a)