### PR TITLE
Make policy first-class with schema versioning, inheritance, and dry-run

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -1,39 +1,38 @@
-# POLICY.md — Sandbox Policy DSL (v 0.1)
+# POLICY.md — Sandbox Policy DSL (v1.0)
 
 > *Declarative, hot‑reloadable, kernel‑enforced.*
 
 ## 1  File layout
 ```yaml
-version: 0.1
+version: 1.0
 defaults:
-  fs: readonly
-  net: none
-  mem: 64MiB
-  cpu: 200ms
+  imports: [math]
 sandboxes:
-  myguest:
+  base:
     fs:
       - allow: "/srv/data/**/*.csv"
       - deny:  "/srv/data/private/**"
     net:
       - connect: ["127.0.0.1:6379"]     # redis
-    mem: 128MiB
-    cpu: 500ms
+  myguest:
+    extends: base
+    imports: [json]
 ```
 
-* **Top‑level `defaults`** apply to every sandbox unless overridden.  
+* **Top‑level `defaults`** apply to every sandbox.  
+* **`extends` inheritance** lets sandboxes layer on top of base policies.  
 * **`sandboxes.*`** keys are user‑visible names (become `cgroup`s).
 
 ## 2  Fields
 
 | Key | Type / unit | Semantics (enforced by eBPF) |
 |-----|-------------|------------------------------|
-| `fs`  | `readonly` \| `none` \| list of rules | Path globbing via **BPF‑LSM** `file_open` hook. Wildcards use `**/`. |
-| `net` | `none` \| list of rules | Hooked at `cgroup/connect*`; tuples `["ip:port", "tcp/udp"]`. |
-| `mem` | `<N>MiB` | Hard cap, checked in allocator; guest killed on exceed. |
-| `cpu` | `<N>ms` per 100 ms window | Perf‑event counter → SIGXCPU to offending thread. |
+| `fs`  | list of rules | Path globbing via **BPF‑LSM** `file_open` hook. |
+| `net` | list of rules | Hooked at `cgroup/connect*`. |
+| `imports` | list of module names | Import allow-list merged into sandbox runtime builtins. |
+| `extends` | sandbox name | Inherit parent sandbox rules before applying local rules. |
 
-*Rule precedence:* first match wins. Unmatched operation → **deny**.
+*Rule precedence:* inherited/default rules are evaluated before child rules. Unmatched operation → **deny**.
 
 ## 3  Live reloading
 `pyisolate.policy.refresh(path, token)` calls `bpftool map update` for every
@@ -43,6 +42,12 @@ The file is parsed and validated first.  Only after a successful parse
 does `BPFManager.hot_reload()` install a new set of maps.  The previous
 policy remains active until the swap completes so running sandboxes
 never observe partial state.
+
+Use `pyisolate.policy.refresh(path, token, dry_run=True)` to compile and validate
+without touching live policy maps. Compiled output includes:
+- `schema_version` (normalized, versioned policy schema)
+- `semantics_version` (stable evaluation semantics across releases)
+- `deny_log` (explicit deny entries for auditing and rollout checks)
 
 ## 4  Fallback YAML parser
 If the optional **PyYAML** dependency is missing, `pyisolate.policy` falls

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -4,6 +4,7 @@ import os
 import socket
 import tempfile
 import urllib.request
+import logging
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from urllib.error import URLError
@@ -68,6 +69,7 @@ except ModuleNotFoundError:  # minimal fallback when PyYAML is unavailable
 
 
 from .compiler import PolicyCompilerError, compile_policy  # noqa: F401
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -98,8 +100,8 @@ def _validate(data: object) -> None:
     if "version" not in data:
         raise ValueError('policy missing "version" key')
 
-    version = data.get("version")
-    if str(version) != "0.1":
+    version = str(data.get("version"))
+    if version not in {"0.1", "1", "1.0"}:
         raise ValueError(f"unsupported policy version: {version}")
 
     for section in ("defaults", "sandboxes"):
@@ -107,7 +109,7 @@ def _validate(data: object) -> None:
             raise ValueError(f'"{section}" must be a mapping')
 
 
-def refresh(path: str, token: str) -> None:
+def refresh(path: str, token: str, *, dry_run: bool = False):
     """Parse *path* and atomically update eBPF policy maps."""
 
     # Fail fast if the YAML is malformed/schema-invalid before compiling/reloading.
@@ -123,6 +125,13 @@ def refresh(path: str, token: str) -> None:
     compiled = compile_policy(path)
 
     import json
+
+    if compiled.deny_log:
+        for line in compiled.deny_log:
+            logger.warning("policy deny rule active: %s", line)
+
+    if dry_run:
+        return compiled
 
     # Write the compiled representation for the BPF manager
     with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
@@ -150,8 +159,13 @@ def _is_timeout_error(exc: Exception) -> bool:
 
 
 def refresh_remote(
-    url: str, token: str, timeout: float | None = None, max_retries: int = 0
-) -> None:
+    url: str,
+    token: str,
+    timeout: float | None = None,
+    max_retries: int = 0,
+    *,
+    dry_run: bool = False,
+):
     """Fetch policy YAML from *url* and apply it."""
     attempts = max(1, max_retries + 1)
 
@@ -175,7 +189,7 @@ def refresh_remote(
         tmp_path = tmp.name
 
     try:
-        refresh(tmp_path, token)
+        return refresh(tmp_path, token, dry_run=dry_run)
     finally:
         os.unlink(tmp_path)
 

--- a/pyisolate/policy/compiler.py
+++ b/pyisolate/policy/compiler.py
@@ -44,7 +44,10 @@ class SandboxPolicy:
 
 @dataclass
 class CompiledPolicy:
+    schema_version: str
+    semantics_version: int
     sandboxes: Dict[str, SandboxPolicy]
+    deny_log: List[str]
 
 
 def _simple_parse(text: str) -> Dict[str, Any]:
@@ -130,6 +133,88 @@ def _compile_tcp(rules: List[dict], sb_name: str) -> List[TCPRule]:
     return compiled
 
 
+def _norm_rule_list(value: object, *, field_name: str, sb_name: str) -> list:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise PolicyCompilerError(f"'{field_name}' in '{sb_name}' must be a list")
+    return value
+
+
+def _merge_unique(parent: list, child: list) -> list:
+    merged = list(parent)
+    for item in child:
+        if item not in merged:
+            merged.append(item)
+    return merged
+
+
+def _resolve_sandbox(
+    name: str, raw_boxes: dict[str, dict[str, Any]], defaults: dict[str, Any]
+) -> dict[str, Any]:
+    resolved: dict[str, dict[str, Any]] = {}
+    resolving: set[str] = set()
+
+    def _resolve(current: str) -> dict[str, Any]:
+        if current in resolved:
+            return resolved[current]
+        if current in resolving:
+            raise PolicyCompilerError(f"cyclic inheritance detected at '{current}'")
+        if current not in raw_boxes:
+            raise PolicyCompilerError(f"unknown parent sandbox '{current}'")
+        resolving.add(current)
+        cfg = raw_boxes[current]
+        parent_name = cfg.get("extends")
+        parent_cfg: dict[str, Any] = {}
+        if parent_name is not None:
+            if not isinstance(parent_name, str):
+                raise PolicyCompilerError(f"'extends' in '{current}' must be a string")
+            parent_cfg = _resolve(parent_name)
+        base = {
+            "fs": _merge_unique(
+                _norm_rule_list(defaults.get("fs", []), field_name="fs", sb_name=current),
+                _norm_rule_list(parent_cfg.get("fs", []), field_name="fs", sb_name=current),
+            ),
+            "net": _merge_unique(
+                _norm_rule_list(
+                    defaults.get("net", defaults.get("tcp", [])),
+                    field_name="net",
+                    sb_name=current,
+                ),
+                _norm_rule_list(
+                    parent_cfg.get("net", parent_cfg.get("tcp", [])),
+                    field_name="net",
+                    sb_name=current,
+                ),
+            ),
+            "imports": _merge_unique(
+                _norm_rule_list(
+                    defaults.get("imports", []), field_name="imports", sb_name=current
+                ),
+                _norm_rule_list(
+                    parent_cfg.get("imports", []), field_name="imports", sb_name=current
+                ),
+            ),
+        }
+        child_fs = _norm_rule_list(cfg.get("fs", []), field_name="fs", sb_name=current)
+        child_net = _norm_rule_list(
+            cfg.get("net", cfg.get("tcp", [])), field_name="net", sb_name=current
+        )
+        child_imports = _norm_rule_list(
+            cfg.get("imports", []), field_name="imports", sb_name=current
+        )
+        out = {
+            "fs": _merge_unique(base["fs"], child_fs),
+            "net": _merge_unique(base["net"], child_net),
+            "imports": _merge_unique(base["imports"], child_imports),
+        }
+        resolving.remove(current)
+        resolved[current] = out
+        return out
+
+    return _resolve(name)
+
+
 def compile_policy(path: str | Path) -> CompiledPolicy:
     """Parse and validate a policy YAML file."""
 
@@ -147,6 +232,16 @@ def compile_policy(path: str | Path) -> CompiledPolicy:
     if not isinstance(data, dict):
         raise PolicyCompilerError("policy document must be a mapping")
 
+    schema_version = str(data.get("version", "0.1"))
+    if schema_version not in {"0.1", "1", "1.0"}:
+        raise PolicyCompilerError(f"unsupported policy version: {schema_version}")
+
+    defaults = data.get("defaults", {})
+    if defaults is None:
+        defaults = {}
+    if not isinstance(defaults, dict):
+        raise PolicyCompilerError("'defaults' must be a mapping")
+
     sandboxes = data.get("sandboxes")
     if sandboxes is None:
         sb_cfg = {k: v for k, v in data.items() if k != "version"}
@@ -155,21 +250,17 @@ def compile_policy(path: str | Path) -> CompiledPolicy:
         raise PolicyCompilerError("missing or invalid 'sandboxes' section")
 
     compiled_boxes: Dict[str, SandboxPolicy] = {}
+    deny_log: list[str] = []
     for name, cfg in sandboxes.items():
         if not isinstance(cfg, dict):
             raise PolicyCompilerError(f"sandbox '{name}' must be a mapping")
-        fs_raw = cfg.get("fs", [])
-        if not isinstance(fs_raw, list):
-            raise PolicyCompilerError(f"'fs' in '{name}' must be a list")
+        resolved_cfg = _resolve_sandbox(name, sandboxes, defaults)
+        fs_raw = resolved_cfg.get("fs", [])
         fs_compiled = _compile_fs(fs_raw, name)
-        tcp_raw = cfg.get("net", cfg.get("tcp", []))
-        if not isinstance(tcp_raw, list):
-            raise PolicyCompilerError(f"'net' in '{name}' must be a list")
+        tcp_raw = resolved_cfg.get("net", [])
         tcp_compiled = _compile_tcp(tcp_raw, name)
 
-        imports_raw = cfg.get("imports", [])
-        if not isinstance(imports_raw, list):
-            raise PolicyCompilerError(f"'imports' in '{name}' must be a list")
+        imports_raw = resolved_cfg.get("imports", [])
         imports: list[str] = []
         for module in imports_raw:
             if not isinstance(module, str):
@@ -181,8 +272,19 @@ def compile_policy(path: str | Path) -> CompiledPolicy:
         compiled_boxes[name] = SandboxPolicy(
             fs=fs_compiled, tcp=tcp_compiled, imports=imports
         )
+        deny_log.extend(
+            [f"sandbox={name} fs={r.path}" for r in fs_compiled if r.action == "deny"]
+        )
+        deny_log.extend(
+            [f"sandbox={name} net={r.addr}" for r in tcp_compiled if r.action == "deny"]
+        )
 
-    return CompiledPolicy(sandboxes=compiled_boxes)
+    return CompiledPolicy(
+        schema_version="1.0" if schema_version == "1" else schema_version,
+        semantics_version=1,
+        sandboxes=compiled_boxes,
+        deny_log=sorted(set(deny_log)),
+    )
 
 
 __all__ = ["CompiledPolicy", "compile_policy", "PolicyCompilerError"]

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -246,6 +246,85 @@ def test_refresh_passes_compiled_policy(monkeypatch, tmp_path):
     assert sb["tcp"][0]["addr"] == "1.1.1.1:443"
     assert sb["imports"] == ["math"]
     assert sb["fs"][0]["path"] == "/tmp/**"
+    assert captured["data"]["schema_version"] == "0.1"
+    assert captured["data"]["semantics_version"] == 1
+
+
+def test_refresh_dry_run_compiles_without_reload(monkeypatch, tmp_path):
+    policy = load_policy()
+    import pyisolate as iso
+
+    called = False
+
+    def fake_reload(*_args, **_kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("pyisolate.supervisor.reload_policy", fake_reload)
+    iso.set_policy_token("tok")
+    path = tmp_path / "p.yml"
+    path.write_text(
+        "version: 1\n"
+        "sandboxes:\n"
+        "  sb:\n"
+        "    fs:\n"
+        '      - allow: "/tmp"\n'
+    )
+
+    compiled = policy.refresh(str(path), token="tok", dry_run=True)
+    assert compiled.schema_version == "1.0"
+    assert called is False
+
+
+def test_compile_policy_supports_inheritance_and_defaults(tmp_path):
+    import pyisolate.policy as policy
+
+    doc = (
+        "version: 1.0\n"
+        "defaults:\n"
+        "  imports:\n"
+        "    - math\n"
+        "sandboxes:\n"
+        "  base:\n"
+        "    fs:\n"
+        '      - allow: "/srv/base"\n'
+        "    net:\n"
+        '      - deny: "10.0.0.0/8"\n'
+        "  child:\n"
+        "    extends: base\n"
+        "    imports:\n"
+        "      - json\n"
+        "    fs:\n"
+        '      - allow: "/srv/child"\n'
+    )
+    f = tmp_path / "inherit.yml"
+    f.write_text(doc)
+
+    compiled = policy.compile_policy(str(f))
+    child = compiled.sandboxes["child"]
+    assert [r.path for r in child.fs] == ["/srv/base", "/srv/child"]
+    assert [r.addr for r in child.tcp] == ["10.0.0.0/8"]
+    assert child.imports == ["math", "json"]
+    assert compiled.deny_log == ["sandbox=base net=10.0.0.0/8", "sandbox=child net=10.0.0.0/8"]
+
+
+def test_refresh_logs_explicit_deny_rules(tmp_path, caplog, monkeypatch):
+    policy = load_policy()
+    import pyisolate as iso
+
+    monkeypatch.setattr(
+        "pyisolate.bpf.manager.BPFManager.hot_reload", lambda *a, **k: None
+    )
+    iso.set_policy_token("tok")
+    path = tmp_path / "deny.yml"
+    path.write_text(
+        "version: 0.1\n"
+        "net:\n"
+        '  - deny: "10.0.0.0/8"\n'
+    )
+    with caplog.at_level("WARNING"):
+        policy.refresh(str(path), token="tok")
+    assert "policy deny rule active" in caplog.text
 
 
 def test_reload_policy_missing_path(tmp_path):


### PR DESCRIPTION
### Motivation
- Policy must be a central, versioned, auditable artifact that can be diffed, tested, and rolled back safely in production.
- Policies need stable semantics across releases and explicit signals (deny logs) to make rollouts and audits safer.
- Inheritance and top-level `defaults` make policy templates composable and reduce duplication.
- Operators must be able to validate/compile policies without mutating live BPF maps (`dry_run`).

### Description
- Extended the compiled policy representation with `schema_version`, `semantics_version`, and a deterministic `deny_log` in `pyisolate/policy/compiler.py` by returning a richer `CompiledPolicy` dataclass and extracting explicit deny rules.
- Added sandbox inheritance via `extends` and top-level `defaults` merging with cycle detection and deterministic merge semantics for `fs`, `net/tcp`, and `imports` in `pyisolate/policy/compiler.py` (`_resolve_sandbox`, `_merge_unique`, `_norm_rule_list`).
- Strengthened schema validation to accept `0.1`, `1`, and `1.0` and validate `defaults` shape before compilation in `pyisolate/policy/__init__.py`.
- Added `dry_run` mode to `pyisolate.policy.refresh()` and `refresh_remote()` so callers can parse/validate/compile without updating live BPF maps and return the compiled policy; `refresh()` now logs explicit deny rules via `logger.warning` when present.
- Updated `POLICY.md` to document the v1.0 schema, inheritance semantics, `dry_run` usage, and the new compiled metadata fields; added and updated tests in `tests/test_policy.py` to cover metadata, dry-run, inheritance/default merging, and deny logging.

### Testing
- Ran `pytest -q tests/test_policy.py` and all policy tests passed (`24 passed`).
- Ran targeted integration tests `pytest -q tests/test_sandbox.py::test_policy_refresh_parses_yaml tests/test_policy.py::test_compile_policy_supports_inheritance_and_defaults` and they passed (`2 passed`).
- New/updated unit tests in `tests/test_policy.py` cover `dry_run` behavior, inheritance/default merging, deny logging, and compiled metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7628148c08328886534c24fc24de0)