### PR TITLE
Split trusted control plane from untrusted workload plane

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,11 +1,51 @@
 # Broker Protocol
 
+PyIsolate treats the **trusted control plane** and the **untrusted workload plane**
+as separate systems.
+
+- **Trusted control plane**: supervisor, broker, metrics, and policy engine.
+- **Untrusted workload plane**: guest code running in sandbox threads.
+
+Crossings are intentionally minimal and explicit.
+
+## Plane crossings
+
+Only structured messages are allowed across the queue boundary.
+`pyisolate.runtime.protocol` defines the request vocabulary:
+
+- `ExecRequest(source)`
+- `CallRequest(target, args, kwargs)`
+- `AttachCgroupRequest(old_path)`
+- `StopRequest()`
+- `ControlRequest(op, capability, payload)`
+
+This replaces ambient tuple/string payloads with typed requests.
+
+## Capability handles
+
+Control operations must carry an explicit `CapabilityHandle(kind, subject)`.
+The supervisor maps:
+
+- canonical `ROOT` capability -> `CapabilityHandle(kind="root", subject=<op>)`
+- valid policy token -> `CapabilityHandle(kind="policy-token", subject=<op>)`
+
+No other callers can execute privileged control actions.
+
+## Authenticated control operations
+
+`Supervisor.reload_policy()` now authorizes as a control request before it can
+trigger BPF hot-reload (`op="policy.reload"`).
+
+Unauthenticated operations are rejected with `PolicyAuthError`.
+
+## Cryptographic channel
+
 The supervisor and each sandbox communicate over an authenticated channel.
 Keys are negotiated using X25519 and, if available, a Kyber‑768
 key‑encapsulation mechanism. The resulting secret feeds HKDF and all
 frames are protected with ChaCha20-Poly1305.
 
-## Handshake
+### Handshake
 
 1. Each side generates an X25519 key pair.
 2. Public keys are exchanged out of band.
@@ -17,8 +57,7 @@ frames are protected with ChaCha20-Poly1305.
 6. Keys can be rotated by repeating steps 1‑5; counters reset to zero after a
    successful rotation.
 
-
-## Framing
+### Framing
 
 Frames are formatted as:
 
@@ -30,9 +69,9 @@ The nonce is a monotonically increasing counter per direction. The same counter
 serves as the ChaCha20-Poly1305 nonce. Frames received with a counter that does
 not match the expected value are rejected to prevent replay.
 
-## Security notes
+### Security notes
 
-* Nonces are counters starting at zero to guarantee uniqueness.
-* HKDF provides key separation between channels.
-* Empty associated data is used by default but can be extended in future
+- Nonces are counters starting at zero to guarantee uniqueness.
+- HKDF provides key separation between channels.
+- Empty associated data is used by default but can be extended in future
   revisions.

--- a/pyisolate/runtime/protocol.py
+++ b/pyisolate/runtime/protocol.py
@@ -1,0 +1,56 @@
+"""Explicit request protocol between trusted and untrusted planes.
+
+The trusted control-plane (supervisor, broker, metrics, policy engine) communicates
+with untrusted sandbox threads via structured message types only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CapabilityHandle:
+    """Opaque handle bound to a control-plane capability."""
+
+    kind: str
+    subject: str
+
+
+@dataclass(frozen=True)
+class ExecRequest:
+    """Execute source code in the workload plane."""
+
+    source: str
+
+
+@dataclass(frozen=True)
+class CallRequest:
+    """Call a dotted function path in the workload plane."""
+
+    target: str
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AttachCgroupRequest:
+    """Control-plane request to (re)attach to a cgroup path."""
+
+    old_path: Path | None
+
+
+@dataclass(frozen=True)
+class StopRequest:
+    """Sentinel request indicating sandbox thread termination."""
+
+
+@dataclass(frozen=True)
+class ControlRequest:
+    """Authenticated control operation crossing plane boundaries."""
+
+    op: str
+    capability: CapabilityHandle
+    payload: dict[str, Any]

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -23,6 +23,12 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
 
 from .. import errors
+from .protocol import (
+    AttachCgroupRequest,
+    CallRequest,
+    ExecRequest,
+    StopRequest,
+)
 from ..numa import bind_current_thread
 from ..observability.trace import Tracer
 
@@ -157,9 +163,6 @@ def _sigxcpu_handler(signum, frame):
     raise errors.CPUExceeded()
 
 
-_STOP = object()
-
-
 @dataclass
 class Stats:
     cpu_ms: float
@@ -169,13 +172,6 @@ class Stats:
     errors: int
     operations: int
     cost: float
-
-
-@dataclass
-class _CgroupAttach:
-    """Control message to (re)attach the sandbox thread to a cgroup."""
-
-    old_path: Path | None
 
 
 class SandboxThread(threading.Thread):
@@ -262,13 +258,13 @@ class SandboxThread(threading.Thread):
         if self._trace_enabled:
             self._syscall_log.append(src)
         self._logger.debug("exec", extra={"code": src})
-        self._inbox.put(src)
+        self._inbox.put(ExecRequest(source=src))
 
     def call(self, func: str, *args, timeout: float | None = None, **kwargs) -> Any:
         if self._trace_enabled:
             self._syscall_log.append(f"call {func}")
         self._logger.debug("call", extra={"func": func})
-        self._inbox.put(("call", func, args, kwargs))
+        self._inbox.put(CallRequest(target=func, args=args, kwargs=kwargs))
         try:
             result = self.recv(timeout)
         except Exception as exc:  # sandbox raised
@@ -288,7 +284,7 @@ class SandboxThread(threading.Thread):
 
     def stop(self, timeout: float = 0.2) -> None:
         self._stop_event.set()
-        self._inbox.put(_STOP)
+        self._inbox.put(StopRequest())
         self.join(timeout)
 
     def reset(
@@ -322,7 +318,7 @@ class SandboxThread(threading.Thread):
         self._cgroup_path = cgroup_path
         # Request the sandbox thread to (re)attach itself to the new cgroup.
         # The attachment must happen from the sandbox thread's context.
-        self._inbox.put(_CgroupAttach(old_path))
+        self._inbox.put(AttachCgroupRequest(old_path=old_path))
 
     @property
     def stats(self):
@@ -370,9 +366,9 @@ class SandboxThread(threading.Thread):
 
             while True:
                 payload = self._inbox.get()
-                if payload is _STOP:
+                if isinstance(payload, StopRequest):
                     break
-                if isinstance(payload, _CgroupAttach):
+                if isinstance(payload, AttachCgroupRequest):
                     try:
                         from .. import cgroup
 
@@ -416,27 +412,25 @@ class SandboxThread(threading.Thread):
                     try:
                         start_cpu = time.thread_time()
                         self._start_time = time.monotonic()
-                        if isinstance(payload, tuple):
-                            kind, func, args, kwargs = payload
-                            if kind == "call":
-                                importer = builtins_dict["__import__"]
-                                try:
-                                    module_name, func_name = func.rsplit(".", 1)
-                                except ValueError as exc:
-                                    raise errors.SandboxError(
-                                        "call target {!r} must include a module path (e.g. 'module.func')".format(
-                                            func
-                                        )
-                                    ) from exc
-                                mod = importer(module_name, fromlist=["_"])
-                                res = object.__getattribute__(mod, func_name)(
-                                    *args, **kwargs
-                                )
-                                self._outbox.put(res)
-                            else:
-                                raise errors.SandboxError("unknown operation")
+                        if isinstance(payload, CallRequest):
+                            importer = builtins_dict["__import__"]
+                            try:
+                                module_name, func_name = payload.target.rsplit(".", 1)
+                            except ValueError as exc:
+                                raise errors.SandboxError(
+                                    "call target {!r} must include a module path (e.g. 'module.func')".format(
+                                        payload.target
+                                    )
+                                ) from exc
+                            mod = importer(module_name, fromlist=["_"])
+                            res = object.__getattribute__(mod, func_name)(
+                                *payload.args, **payload.kwargs
+                            )
+                            self._outbox.put(res)
+                        elif isinstance(payload, ExecRequest):
+                            exec(payload.source, local_vars, local_vars)
                         else:
-                            exec(payload, local_vars, local_vars)
+                            raise errors.SandboxError("unknown request type")
                         end_cpu = time.thread_time()
                         self._cpu_time += (end_cpu - start_cpu) * 1000
                         self._start_time = None

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -19,6 +19,7 @@ from .capabilities import ROOT, RootCapability
 from .errors import PolicyAuthError
 from .observability.alerts import AlertManager
 from .observability.trace import Tracer
+from .runtime.protocol import CapabilityHandle, ControlRequest
 from .runtime.thread import SandboxThread
 from .watchdog import ResourceWatchdog
 
@@ -190,23 +191,32 @@ class Supervisor:
         with self._lock:
             return [t for t in self._sandboxes.values() if t.is_alive()]
 
+    def _authorize_control(self, token: str | RootCapability, op: str) -> ControlRequest:
+        """Validate an authenticated control-plane operation request."""
+
+        if token is ROOT:
+            handle = CapabilityHandle(kind="root", subject=op)
+        else:
+            if self._policy_token is None or token != self._policy_token:
+                logger.warning("control operation rejected: %s", op)
+                raise PolicyAuthError("invalid policy token")
+            handle = CapabilityHandle(kind="policy-token", subject=op)
+
+        return ControlRequest(op=op, capability=handle, payload={})
+
     def set_policy_token(self, token: str) -> None:
         """Configure the secret used to authenticate policy updates."""
         self._policy_token = token
 
     def reload_policy(self, policy_path: str, token: str | RootCapability) -> None:
-        """Hot-reload policy via the BPF manager if *token* matches."""
+        """Hot-reload policy via an authenticated control-plane request."""
 
-        if token is ROOT:
-            pass
-        else:
-            if self._policy_token is not None and token != self._policy_token:
-                logger.warning("policy reload rejected: invalid token")
-                raise PolicyAuthError("invalid policy token")
+        request = self._authorize_control(token, op="policy.reload")
 
         if not Path(policy_path).is_file():
             raise FileNotFoundError(policy_path)
 
+        logger.debug("control operation accepted: %s", request.op)
         try:
             self._bpf.hot_reload(policy_path)
         except RuntimeError as exc:

--- a/tests/test_protocol_plane.py
+++ b/tests/test_protocol_plane.py
@@ -1,0 +1,44 @@
+from pyisolate.capabilities import ROOT
+from pyisolate.runtime.protocol import CallRequest, ExecRequest
+from pyisolate.runtime.thread import SandboxThread
+from pyisolate.supervisor import Supervisor
+
+
+def test_sandbox_thread_uses_structured_requests(monkeypatch):
+    thread = SandboxThread(name="proto")
+    captured = []
+    original_put = thread._inbox.put
+
+    def capture(msg):
+        captured.append(msg)
+        return original_put(msg)
+
+    monkeypatch.setattr(thread._inbox, "put", capture)
+
+    thread.start()
+    try:
+        thread.exec("x=1")
+        assert isinstance(captured[0], ExecRequest)
+
+        assert thread.call("builtins.len", [1, 2, 3]) == 3
+        assert isinstance(captured[1], CallRequest)
+    finally:
+        thread.stop()
+
+
+def test_reload_policy_requires_authenticated_control(tmp_path, monkeypatch):
+    sup = Supervisor()
+    try:
+        called = {}
+
+        def fake_hot_reload(path):
+            called["path"] = path
+
+        monkeypatch.setattr(sup._bpf, "hot_reload", fake_hot_reload)
+        policy = tmp_path / "policy.json"
+        policy.write_text("{}")
+
+        sup.reload_policy(str(policy), ROOT)
+        assert called["path"] == str(policy)
+    finally:
+        sup.shutdown(ROOT)


### PR DESCRIPTION
### Motivation
- Make crossings between the trusted control-plane (supervisor, broker, metrics, policy engine) and the untrusted workload-plane (guest sandboxes) explicit and minimal to reduce ambient privilege and implicit channels. 
- Model authenticated control operations explicitly so only authorized capabilities/tokens can trigger privileged actions such as BPF policy reload.

### Description
- Add a new `pyisolate.runtime.protocol` module introducing typed request and capability types: `ExecRequest`, `CallRequest`, `AttachCgroupRequest`, `StopRequest`, `ControlRequest`, and `CapabilityHandle`.
- Refactor `SandboxThread` to send and consume only structured request objects (`ExecRequest`/`CallRequest`/`AttachCgroupRequest`/`StopRequest`) instead of raw strings/tuples/sentinels and to raise on unknown request types.
- Add `_authorize_control(...)` to `Supervisor` which maps `ROOT` and valid policy tokens to `CapabilityHandle` and use it in `reload_policy()` to model `op="policy.reload"` as an authenticated control operation.
- Update `docs/protocol.md` to document the plane separation, request vocabulary, capability handles, and authenticated control operations, and add `tests/test_protocol_plane.py` to cover the new protocol and auth flow.

### Testing
- Ran `pytest -q tests/test_protocol_plane.py tests/test_capabilities.py tests/test_supervisor.py::test_reload_policy_delegates` and the suite completed successfully with all tests passing (`6 passed`).
- Added a focused unit test `tests/test_protocol_plane.py` which asserts structured request emission from `SandboxThread` and that `Supervisor.reload_policy()` accepts an authenticated `ROOT` capability (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76293ef70832889c7064c17a5a293)