### PR TITLE
Implement explicit sandbox capability model

### DIFF
--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -4,7 +4,19 @@ This module exposes the high-level API described in API.md.
 """
 
 from . import bpf  # noqa: F401
-from .capabilities import ROOT, Capability, RootCapability, Token  # noqa: F401
+from .capabilities import (  # noqa: F401
+    ROOT,
+    IPCChannelCapability,
+    Capability,
+    ClockCapability,
+    FilesystemCapability,
+    NetworkCapability,
+    RandomCapability,
+    RootCapability,
+    SecretCapability,
+    SubprocessCapability,
+    Token,
+)
 
 try:
     from .checkpoint import checkpoint, restore
@@ -71,6 +83,13 @@ __all__ = [
     "RootCapability",
     "ROOT",
     "set_policy_token",
+    "FilesystemCapability",
+    "NetworkCapability",
+    "SecretCapability",
+    "SubprocessCapability",
+    "IPCChannelCapability",
+    "ClockCapability",
+    "RandomCapability",
     "PolicyEditor",
     "parse_policy",
     "check_fs",

--- a/pyisolate/capabilities.py
+++ b/pyisolate/capabilities.py
@@ -1,15 +1,27 @@
-"""Typed capability tokens for mypy-based checks."""
+"""Concrete capability objects used to grant sandbox access.
+
+The default sandbox environment is deny-by-default for side effects. Access to
+filesystem, network, secrets, subprocesses, IPC, and entropy/clock primitives
+is granted only by explicitly providing capability instances.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
+import queue
+import secrets as _secrets
+import socket
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Generic, Literal, TypeVar
 
 T = TypeVar("T")
 
 
 class Capability(Generic[T]):
-    """Protocol for capability tokens."""
+    """Marker protocol for typed capability tokens."""
 
 
 @dataclass(frozen=True)
@@ -23,6 +35,150 @@ class RootCapability(Token[Literal["root"]]):
     """Capability granting privileged supervisor operations."""
 
 
+@dataclass(frozen=True)
+class FilesystemCapability(Capability[Literal["filesystem"]]):
+    """Capability that permits file access only within *roots*."""
+
+    roots: tuple[Path, ...]
+
+    @classmethod
+    def from_paths(cls, *paths: str | os.PathLike[str]) -> "FilesystemCapability":
+        roots = tuple(Path(path).resolve(strict=False) for path in paths)
+        return cls(roots=roots)
+
+    def allows(self, path: str | os.PathLike[str]) -> bool:
+        resolved = Path(path).resolve(strict=False)
+        return any(resolved.is_relative_to(root) for root in self.roots)
+
+
+@dataclass(frozen=True)
+class NetworkCapability(Capability[Literal["network"]]):
+    """Capability that permits outgoing TCP connections to explicit targets."""
+
+    destinations: frozenset[str]
+
+    @classmethod
+    def from_destinations(cls, *destinations: str) -> "NetworkCapability":
+        return cls(destinations=frozenset(destinations))
+
+    def allows(self, host: str, port: int) -> bool:
+        return f"{host}:{port}" in self.destinations
+
+
+@dataclass(frozen=True)
+class SecretCapability(Capability[Literal["secrets"]]):
+    """Capability wrapper for named secret values."""
+
+    values: dict[str, bytes]
+
+    @classmethod
+    def from_mapping(
+        cls, mapping: dict[str, str | bytes | bytearray | memoryview]
+    ) -> "SecretCapability":
+        normalized: dict[str, bytes] = {}
+        for key, value in mapping.items():
+            if isinstance(value, str):
+                normalized[key] = value.encode("utf-8")
+            else:
+                normalized[key] = bytes(value)
+        return cls(values=normalized)
+
+    def get(self, name: str) -> bytes:
+        if name not in self.values:
+            raise KeyError(name)
+        return self.values[name]
+
+
+@dataclass(frozen=True)
+class SubprocessCapability(Capability[Literal["subprocess"]]):
+    """Capability that brokers subprocess execution via an allowlist."""
+
+    allowed_commands: frozenset[str]
+    allow_shell: bool = False
+
+    @classmethod
+    def from_commands(
+        cls, *commands: str, allow_shell: bool = False
+    ) -> "SubprocessCapability":
+        return cls(allowed_commands=frozenset(commands), allow_shell=allow_shell)
+
+    def run(
+        self,
+        args: str | list[str] | tuple[str, ...],
+        *,
+        check: bool = False,
+        capture_output: bool = True,
+        text: bool = True,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess:
+        if isinstance(args, str):
+            if not self.allow_shell:
+                raise PermissionError("shell string commands are not permitted")
+            command_name = args.split(maxsplit=1)[0]
+            if command_name not in self.allowed_commands:
+                raise PermissionError(f"subprocess blocked: {command_name}")
+        else:
+            seq = list(args)
+            if not seq:
+                raise ValueError("empty command")
+            command_name = seq[0]
+            if command_name not in self.allowed_commands:
+                raise PermissionError(f"subprocess blocked: {command_name}")
+
+        return subprocess.run(
+            args,
+            check=check,
+            capture_output=capture_output,
+            text=text,
+            timeout=timeout,
+            shell=isinstance(args, str),
+        )
+
+
+@dataclass
+class IPCChannelCapability(Capability[Literal["ipc"]]):
+    """In-memory brokered message channel capability."""
+
+    _queue: "queue.Queue[object]" = field(default_factory=queue.Queue)
+
+    def send(self, message: object) -> None:
+        self._queue.put(message)
+
+    def recv(self, timeout: float | None = None) -> object:
+        return self._queue.get(timeout=timeout)
+
+
+@dataclass(frozen=True)
+class ClockCapability(Capability[Literal["clock"]]):
+    """Capability that exposes clock primitives."""
+
+    def time(self) -> float:
+        return time.time()
+
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+
+@dataclass(frozen=True)
+class RandomCapability(Capability[Literal["random"]]):
+    """Capability that exposes secure entropy primitives."""
+
+    def bytes(self, length: int) -> bytes:
+        return _secrets.token_bytes(length)
+
+
 ROOT = RootCapability(name="root")
 
-__all__ = ["Capability", "Token", "RootCapability", "ROOT"]
+__all__ = [
+    "Capability",
+    "Token",
+    "RootCapability",
+    "ROOT",
+    "FilesystemCapability",
+    "NetworkCapability",
+    "SecretCapability",
+    "SubprocessCapability",
+    "IPCChannelCapability",
+    "ClockCapability",
+    "RandomCapability",
+]

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -12,8 +12,11 @@ import io
 import logging
 import os
 import queue
+import random
+import secrets as pysecrets
 import signal
 import socket
+import subprocess
 import threading
 import time
 import tracemalloc
@@ -23,6 +26,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
 
 from .. import errors
+from ..capabilities import ClockCapability
 from ..numa import bind_current_thread
 from ..observability.trace import Tracer
 
@@ -41,40 +45,81 @@ def _blocked_open(file, *args, **kwargs):
     if isinstance(file, (str, bytes)):
         path = Path(file).resolve(strict=False)
 
+        fs_cap = getattr(_thread_local, "fs_capability", None)
         allowed = getattr(_thread_local, "fs", None)
-
-        if allowed is not None:
+        if fs_cap is not None:
+            if not fs_cap.allows(path):
+                raise errors.PolicyError("file access blocked")
+        elif allowed is not None:
             if not any(path.is_relative_to(a) for a in allowed):
                 raise errors.PolicyError("file access blocked")
-        elif getattr(_thread_local, "active", False) and path.is_relative_to(
-            Path("/etc")
-        ):
+        elif getattr(_thread_local, "active", False):
             raise errors.PolicyError("file access blocked")
 
     return _ORIG_OPEN(file, *args, **kwargs)
 
 
 def _guarded_connect(self_socket: socket.socket, address: Iterable[str]):
+    net_cap = getattr(_thread_local, "net_capability", None)
     allowed = getattr(_thread_local, "tcp", None)
-    if allowed is not None:
-        if isinstance(address, tuple):
-            host, port, *_ = address
-        else:
-            host, port = address
+    if isinstance(address, tuple):
+        host, port, *_ = address
+    else:
+        host, port = address
+    if net_cap is not None:
+        if not net_cap.allows(str(host), int(port)):
+            raise errors.PolicyError(f"connect blocked: {host}:{port}")
+    elif allowed is not None:
         if f"{host}:{port}" not in allowed:
             raise errors.PolicyError(f"connect blocked: {host}:{port}")
+    else:
+        raise errors.PolicyError(f"connect blocked: {host}:{port}")
     return _ORIG_SOCKET_CONNECT(self_socket, address)
+
+
+def _blocked_subprocess_run(*args, **kwargs):
+    cap = getattr(_thread_local, "subprocess_capability", None)
+    if cap is None:
+        raise errors.PolicyError("subprocess access blocked")
+    return cap.run(*args, **kwargs)
+
+
+def _guarded_urandom(n: int) -> bytes:
+    cap = getattr(_thread_local, "random_capability", None)
+    if cap is None:
+        raise errors.PolicyError("randomness access blocked")
+    return cap.bytes(n)
 
 
 def _wrap_module(name: str, module):
     base = name.split(".")[0]
     if base == "time":
+        def _require_clock() -> ClockCapability:
+            cap = getattr(_thread_local, "clock_capability", None)
+            return cap
+
+        def _time() -> float:
+            cap = _require_clock()
+            if cap is None:
+                return 0.0
+            return cap.time()
+
+        def _monotonic() -> float:
+            cap = _require_clock()
+            if cap is None:
+                return 0.0
+            return cap.monotonic()
 
         def _perf_counter() -> float:
-            return 0.0
+            cap = _require_clock()
+            if cap is None:
+                return 0.0
+            return cap.monotonic()
 
         mod = types.ModuleType("time", module.__doc__)
         mod.__dict__.update({k: getattr(time, k) for k in dir(time)})
+        mod.time = _time
+        mod.monotonic = _monotonic
         mod.perf_counter = _perf_counter
         return mod
     if base == "io":
@@ -90,6 +135,26 @@ def _wrap_module(name: str, module):
             connect = _guarded_connect
 
         mod.socket = GuardedSocket
+        return mod
+    if base == "subprocess":
+        mod = types.ModuleType("subprocess", module.__doc__)
+        mod.__dict__.update({k: getattr(subprocess, k) for k in dir(subprocess)})
+        mod.run = _blocked_subprocess_run
+        return mod
+    if base == "os":
+        mod = types.ModuleType("os", module.__doc__)
+        mod.__dict__.update({k: getattr(os, k) for k in dir(os)})
+        mod.urandom = _guarded_urandom
+        return mod
+    if base == "secrets":
+        mod = types.ModuleType("secrets", module.__doc__)
+        mod.__dict__.update({k: getattr(pysecrets, k) for k in dir(pysecrets)})
+        mod.token_bytes = _guarded_urandom
+        return mod
+    if base == "random":
+        mod = types.ModuleType("random", module.__doc__)
+        mod.__dict__.update({k: getattr(random, k) for k in dir(random)})
+        mod.randbytes = _guarded_urandom
         return mod
     if base == "pathlib":
         mod = types.ModuleType("pathlib", module.__doc__)
@@ -206,6 +271,7 @@ class SandboxThread(threading.Thread):
         tracer: Optional["Tracer"] = None,
         numa_node: Optional[int] = None,
         cgroup_path=None,
+        capabilities: Optional[dict[str, Any]] = None,
     ):
         super().__init__(name=name, daemon=True)
         self._logger = logging.getLogger(f"pyisolate.{name}")
@@ -231,6 +297,7 @@ class SandboxThread(threading.Thread):
         self._cgroup_path = cgroup_path
         self._trace_enabled = False
         self._syscall_log: list[str] = []
+        self._capabilities = dict(capabilities or {})
 
     def snapshot(self) -> dict:
         """Return serializable configuration state."""
@@ -243,6 +310,7 @@ class SandboxThread(threading.Thread):
             if self.allowed_imports is not None
             else None,
             "numa_node": self.numa_node,
+            "capabilities": sorted(self._capabilities),
         }
 
     def enable_tracing(self) -> None:
@@ -300,6 +368,7 @@ class SandboxThread(threading.Thread):
         allowed_imports: Optional[list[str]] = None,
         numa_node: Optional[int] = None,
         cgroup_path=None,
+        capabilities: Optional[dict[str, Any]] = None,
     ) -> None:
         """Reuse this thread for a new sandbox."""
         old_path = getattr(self, "_cgroup_path", None)
@@ -320,6 +389,7 @@ class SandboxThread(threading.Thread):
         self._syscall_log = []
         self._start_time = None
         self._cgroup_path = cgroup_path
+        self._capabilities = dict(capabilities or {})
         # Request the sandbox thread to (re)attach itself to the new cgroup.
         # The attachment must happen from the sandbox thread's context.
         self._inbox.put(_CgroupAttach(old_path))
@@ -362,7 +432,7 @@ class SandboxThread(threading.Thread):
             self._cpu_time = 0.0
             self._start_time = None
 
-            local_vars = {"post": self._outbox.put}
+            local_vars = {"post": self._outbox.put, "caps": self._capabilities}
 
             if self.numa_node is not None:
                 bind_current_thread(self.numa_node)
@@ -404,6 +474,13 @@ class SandboxThread(threading.Thread):
                 else:
                     _thread_local.tcp = allowed_tcp
                 _thread_local.fs = allowed_fs
+                _thread_local.fs_capability = self._capabilities.get("filesystem")
+                _thread_local.net_capability = self._capabilities.get("network")
+                _thread_local.subprocess_capability = self._capabilities.get(
+                    "subprocess"
+                )
+                _thread_local.clock_capability = self._capabilities.get("clock")
+                _thread_local.random_capability = self._capabilities.get("random")
 
                 builtins_dict = _SAFE_BUILTINS.copy()
                 builtins_dict["open"] = _blocked_open

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -118,6 +118,7 @@ class Supervisor:
         mem_bytes: Optional[int] = None,
         allowed_imports: Optional[list[str]] = None,
         numa_node: Optional[int] = None,
+        capabilities: Optional[dict[str, object]] = None,
     ) -> Sandbox:
         """Create and start a sandbox thread."""
         global NAME_PATTERN
@@ -152,6 +153,7 @@ class Supervisor:
                     allowed_imports=allowed_imports,
                     numa_node=numa_node,
                     cgroup_path=cg_path,
+                    capabilities=capabilities,
                 )
                 thread._on_violation = self._alerts.notify
                 thread._tracer = self._tracer
@@ -166,6 +168,7 @@ class Supervisor:
                     tracer=self._tracer,
                     numa_node=numa_node,
                     cgroup_path=cg_path,
+                    capabilities=capabilities,
                 )
                 thread.start()
             self._sandboxes[name] = thread

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,12 +1,23 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 import pyisolate as iso
 from pyisolate.bpf.manager import BPFManager
-from pyisolate.capabilities import ROOT, RootCapability
+from pyisolate.capabilities import (
+    ROOT,
+    ClockCapability,
+    FilesystemCapability,
+    NetworkCapability,
+    RandomCapability,
+    RootCapability,
+    SecretCapability,
+    SubprocessCapability,
+)
 
 
 def test_root_cap_type() -> None:
@@ -31,3 +42,100 @@ def test_shutdown_with_cap() -> None:
     sb = sup.spawn("cap")
     sup.shutdown(ROOT)
     assert not sb._thread.is_alive()
+
+
+def test_filesystem_capability_allows_only_handed_paths(tmp_path) -> None:
+    allowed = tmp_path / "allowed"
+    denied = tmp_path / "denied"
+    allowed.mkdir()
+    denied.mkdir()
+    (allowed / "ok.txt").write_text("ok")
+    (denied / "no.txt").write_text("no")
+
+    sup = iso.Supervisor()
+    sb = sup.spawn(
+        "fs-cap",
+        capabilities={"filesystem": FilesystemCapability.from_paths(str(allowed))},
+    )
+    try:
+        sb.exec(f"post(open({str(allowed / 'ok.txt')!r}).read())")
+        assert sb.recv(timeout=1) == "ok"
+
+        sb.exec(f"post(open({str(denied / 'no.txt')!r}).read())")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sup.shutdown(ROOT)
+
+
+def test_secret_capability_is_explicitly_handed() -> None:
+    sup = iso.Supervisor()
+    sb = sup.spawn(
+        "secret-cap",
+        capabilities={"secrets": SecretCapability.from_mapping({"api_key": "abc123"})},
+    )
+    try:
+        sb.exec("post(caps['secrets'].get('api_key').decode())")
+        assert sb.recv(timeout=1) == "abc123"
+    finally:
+        sup.shutdown(ROOT)
+
+
+def test_subprocess_capability_brokered() -> None:
+    sup = iso.Supervisor()
+    sb = sup.spawn("subproc-block")
+    try:
+        sb.exec("import subprocess; subprocess.run(['echo', 'hi'])")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+    sb = sup.spawn(
+        "subproc-allow",
+        capabilities={"subprocess": SubprocessCapability.from_commands("echo")},
+    )
+    try:
+        sb.exec(
+            "import subprocess; out = subprocess.run(['echo', 'hi']); post(out.stdout.strip())"
+        )
+        assert sb.recv(timeout=1) == "hi"
+    finally:
+        sup.shutdown(ROOT)
+
+
+def test_network_and_entropy_capabilities() -> None:
+    import socket
+
+    srv = socket.socket()
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    host, port = srv.getsockname()
+
+    sup = iso.Supervisor()
+    sb = sup.spawn("net-cap-block")
+    try:
+        sb.exec(f"import socket; s=socket.socket(); s.connect(({host!r}, {port}))")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+    sb = sup.spawn(
+        "net-cap-allow",
+        capabilities={
+            "network": NetworkCapability.from_destinations(f"{host}:{port}"),
+            "random": RandomCapability(),
+            "clock": ClockCapability(),
+        },
+    )
+    try:
+        sb.exec(
+            f"import socket, os, time; s=socket.socket(); s.connect(({host!r}, {port})); post((len(os.urandom(8)), time.time() > 0))"
+        )
+        size, has_time = sb.recv(timeout=1)
+        assert size == 8
+        assert has_time is True
+    finally:
+        sup.shutdown(ROOT)
+        srv.close()


### PR DESCRIPTION
### Motivation

- Move from a placeholder typed-token capability model to concrete, enforceable capability objects so side-effectful operations are deny-by-default and sandboxes receive only what the supervisor explicitly grants. 
- Make filesystem, network, subprocess, secrets, IPC, clock and randomness access explicit and checkable at runtime to prepare for stronger isolation/enforcement layers.

### Description

- Added concrete capability classes in `pyisolate/capabilities.py`: `FilesystemCapability`, `NetworkCapability`, `SecretCapability`, `SubprocessCapability`, `IPCChannelCapability`, `ClockCapability`, and `RandomCapability`, plus kept `RootCapability`/`Token`/`Capability` markers.
- Enforced capability checks in the sandbox runtime (`pyisolate/runtime/thread.py`) by gating `open`, socket `connect`, `os.urandom`/`secrets.token_bytes`, `random.randbytes`, `subprocess.run`, and time/monotonic APIs; capabilities are looked up on thread-local state and fall back to existing policy allowlists where applicable.
- Thread and supervisor plumbing: threaded a `capabilities` argument through `Supervisor.spawn()` and `SandboxThread.reset()` / constructor so callers can hand specific capability objects to each sandbox; exposed handed-in capabilities to guest code via a `caps` local in the sandbox environment.
- Exported the new capability classes from the package root (`pyisolate/__init__.py`) and updated tests to exercise the capability model.

### Testing

- Ran: `pytest -q tests/test_capabilities.py tests/test_network.py tests/test_security_suite.py tests/test_policy_enforcement.py tests/test_thread_imports.py`.
- Result: all tests passed: `19 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e762a54ed083288a54e466b60bf285)