### PR TITLE
Add crash-only supervisor recovery and replay-safe control semantics

### DIFF
--- a/pyisolate/cgroup.py
+++ b/pyisolate/cgroup.py
@@ -8,7 +8,7 @@ import os
 import threading
 from pathlib import Path
 
-__all__ = ["create", "attach_current", "delete"]
+__all__ = ["create", "attach_current", "delete", "list_children", "cleanup_orphans"]
 
 # Allow tests to override the base cgroup directory
 _BASE = Path(os.environ.get("PYISOLATE_CGROUP_ROOT", "/sys/fs/cgroup")) / "pyisolate"
@@ -75,3 +75,18 @@ def delete(path: Path | None) -> None:
         path.rmdir()
     except (OSError, PermissionError, FileNotFoundError) as exc:
         log.warning("Failed to delete cgroup %s: %s", path, exc)
+
+
+def list_children() -> list[Path]:
+    """Return cgroup children managed by PyIsolate."""
+    try:
+        return [p for p in _BASE.iterdir() if p.is_dir()]
+    except (OSError, PermissionError, FileNotFoundError):
+        return []
+
+
+def cleanup_orphans(active_names: set[str]) -> None:
+    """Delete cgroups that are not currently active."""
+    for path in list_children():
+        if path.name not in active_names:
+            delete(path)

--- a/pyisolate/checkpoint.py
+++ b/pyisolate/checkpoint.py
@@ -8,10 +8,14 @@ from __future__ import annotations
 
 import json
 import os
+import struct
 
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
 from .supervisor import Sandbox, spawn
+
+_MAGIC = b"PYISOCP1"
+_LEN_STRUCT = struct.Struct("!I")
 
 
 def checkpoint(sandbox: Sandbox, key: bytes) -> bytes:
@@ -29,7 +33,8 @@ def checkpoint(sandbox: Sandbox, key: bytes) -> bytes:
             raise ValueError("sandbox state is not JSON serializable") from exc
         aead = ChaCha20Poly1305(key)
         nonce = os.urandom(12)
-        blob = nonce + aead.encrypt(nonce, data, b"")
+        encrypted = nonce + aead.encrypt(nonce, data, b"")
+        blob = _MAGIC + _LEN_STRUCT.pack(len(encrypted)) + encrypted
         return blob
     finally:
         sandbox.close()
@@ -39,7 +44,17 @@ def restore(blob: bytes, key: bytes) -> Sandbox:
     """Decrypt *blob* with *key* and spawn a new sandbox."""
     if len(key) != 32:
         raise ValueError("key must be 32 bytes")
-    nonce, ct = blob[:12], blob[12:]
+    if len(blob) < len(_MAGIC) + _LEN_STRUCT.size:
+        raise ValueError("invalid checkpoint envelope")
+    if blob[: len(_MAGIC)] != _MAGIC:
+        raise ValueError("invalid checkpoint envelope")
+    expected_len = _LEN_STRUCT.unpack_from(blob, len(_MAGIC))[0]
+    encrypted = blob[len(_MAGIC) + _LEN_STRUCT.size :]
+    if expected_len != len(encrypted):
+        raise ValueError("invalid checkpoint envelope")
+    if len(encrypted) < 12:
+        raise ValueError("invalid checkpoint data")
+    nonce, ct = encrypted[:12], encrypted[12:]
     aead = ChaCha20Poly1305(key)
     data = aead.decrypt(nonce, ct, b"")
     try:

--- a/pyisolate/recovery.py
+++ b/pyisolate/recovery.py
@@ -1,0 +1,99 @@
+"""Crash-only recovery helpers for supervisor state."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from . import cgroup
+
+log = logging.getLogger(__name__)
+
+STATE_DIR = Path(tempfile.gettempdir()) / "pyisolate-state"
+REGISTRY_FILE = STATE_DIR / "supervisor_registry.json"
+TEMP_ROOT = STATE_DIR / "sandboxes"
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def load_registry() -> dict[str, Any]:
+    """Load persisted supervisor state, returning an empty registry on failure."""
+    try:
+        raw = REGISTRY_FILE.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return {"sandboxes": {}}
+    if not isinstance(data, dict):
+        return {"sandboxes": {}}
+    sandboxes = data.get("sandboxes")
+    if not isinstance(sandboxes, dict):
+        return {"sandboxes": {}}
+    return {"sandboxes": sandboxes}
+
+
+def save_registry(registry: dict[str, Any]) -> None:
+    _atomic_write_json(REGISTRY_FILE, registry)
+
+
+def update_sandbox(name: str, data: dict[str, Any]) -> None:
+    registry = load_registry()
+    sandboxes = registry.setdefault("sandboxes", {})
+    sandboxes[name] = data
+    save_registry(registry)
+
+
+def drop_sandbox(name: str) -> None:
+    registry = load_registry()
+    sandboxes = registry.get("sandboxes", {})
+    if name in sandboxes:
+        del sandboxes[name]
+        save_registry(registry)
+
+
+def allocate_temp_dir(name: str) -> Path:
+    """Create a deterministic per-sandbox temp directory."""
+    path = TEMP_ROOT / name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def delete_temp_dir(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        shutil.rmtree(path, ignore_errors=True)
+    except Exception as exc:
+        log.warning("Failed to delete temp dir %s: %s", path, exc)
+
+
+def recover(active_names: set[str]) -> None:
+    """Recover state after supervisor restart and cleanup orphans."""
+    registry = load_registry()
+    sandboxes = registry.get("sandboxes", {})
+    stale_names = {name for name in sandboxes if name not in active_names}
+
+    for name in stale_names:
+        entry = sandboxes.get(name, {})
+        temp_dir = entry.get("temp_dir")
+        if isinstance(temp_dir, str):
+            delete_temp_dir(Path(temp_dir))
+
+    cgroup.cleanup_orphans(active_names)
+    if TEMP_ROOT.exists():
+        for path in TEMP_ROOT.iterdir():
+            if path.is_dir() and path.name not in active_names:
+                delete_temp_dir(path)
+
+    if stale_names:
+        for name in stale_names:
+            sandboxes.pop(name, None)
+        save_registry(registry)

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -175,6 +175,7 @@ class Stats:
 class _CgroupAttach:
     """Control message to (re)attach the sandbox thread to a cgroup."""
 
+    msg_id: int
     old_path: Path | None
 
 
@@ -206,6 +207,7 @@ class SandboxThread(threading.Thread):
         tracer: Optional["Tracer"] = None,
         numa_node: Optional[int] = None,
         cgroup_path=None,
+        temp_dir: Path | None = None,
     ):
         super().__init__(name=name, daemon=True)
         self._logger = logging.getLogger(f"pyisolate.{name}")
@@ -231,6 +233,9 @@ class SandboxThread(threading.Thread):
         self._cgroup_path = cgroup_path
         self._trace_enabled = False
         self._syscall_log: list[str] = []
+        self._temp_dir = temp_dir
+        self._control_seq = 0
+        self._seen_control_ids: set[int] = set()
 
     def snapshot(self) -> dict:
         """Return serializable configuration state."""
@@ -300,6 +305,7 @@ class SandboxThread(threading.Thread):
         allowed_imports: Optional[list[str]] = None,
         numa_node: Optional[int] = None,
         cgroup_path=None,
+        temp_dir: Path | None = None,
     ) -> None:
         """Reuse this thread for a new sandbox."""
         old_path = getattr(self, "_cgroup_path", None)
@@ -320,9 +326,12 @@ class SandboxThread(threading.Thread):
         self._syscall_log = []
         self._start_time = None
         self._cgroup_path = cgroup_path
+        self._temp_dir = temp_dir
+        self._seen_control_ids.clear()
+        self._control_seq += 1
         # Request the sandbox thread to (re)attach itself to the new cgroup.
         # The attachment must happen from the sandbox thread's context.
-        self._inbox.put(_CgroupAttach(old_path))
+        self._inbox.put(_CgroupAttach(self._control_seq, old_path))
 
     @property
     def stats(self):
@@ -373,6 +382,9 @@ class SandboxThread(threading.Thread):
                 if payload is _STOP:
                     break
                 if isinstance(payload, _CgroupAttach):
+                    if payload.msg_id in self._seen_control_ids:
+                        continue
+                    self._seen_control_ids.add(payload.msg_id)
                     try:
                         from .. import cgroup
 

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -19,6 +19,13 @@ from .capabilities import ROOT, RootCapability
 from .errors import PolicyAuthError
 from .observability.alerts import AlertManager
 from .observability.trace import Tracer
+from .recovery import (
+    allocate_temp_dir,
+    delete_temp_dir,
+    drop_sandbox,
+    recover,
+    update_sandbox,
+)
 from .runtime.thread import SandboxThread
 from .watchdog import ResourceWatchdog
 
@@ -105,6 +112,7 @@ class Supervisor:
         self._watchdog = ResourceWatchdog(self)
         self._watchdog.start()
         self._policy_token: str | None = None
+        recover(active_names=set())
 
     def register_alert_handler(self, callback) -> None:
         """Subscribe to policy violation alerts."""
@@ -142,6 +150,7 @@ class Supervisor:
                 raise RuntimeError(f"sandbox '{name}' already exists")
 
             cg_path = cgroup.create(name, cpu_ms, mem_bytes)
+            temp_dir = allocate_temp_dir(name)
             if self._warm_pool:
                 thread = self._warm_pool.pop()
                 thread.reset(
@@ -152,6 +161,7 @@ class Supervisor:
                     allowed_imports=allowed_imports,
                     numa_node=numa_node,
                     cgroup_path=cg_path,
+                    temp_dir=temp_dir,
                 )
                 thread._on_violation = self._alerts.notify
                 thread._tracer = self._tracer
@@ -166,9 +176,18 @@ class Supervisor:
                     tracer=self._tracer,
                     numa_node=numa_node,
                     cgroup_path=cg_path,
+                    temp_dir=temp_dir,
                 )
                 thread.start()
             self._sandboxes[name] = thread
+            update_sandbox(
+                name,
+                {
+                    "name": name,
+                    "cgroup_path": str(cg_path) if cg_path is not None else None,
+                    "temp_dir": str(temp_dir),
+                },
+            )
         # Remove references to any terminated sandboxes
         self._cleanup()
         # Reset any temporary overrides of the name validation pattern to avoid
@@ -241,6 +260,8 @@ class Supervisor:
             for n in dead:
                 thread = self._sandboxes[n]
                 cgroup.delete(getattr(thread, "_cgroup_path", None))
+                delete_temp_dir(getattr(thread, "_temp_dir", None))
+                drop_sandbox(n)
                 del self._sandboxes[n]
             self._warm_pool = [t for t in self._warm_pool if t.is_alive()]
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(ROOT))
 
 import json
 import os
+import struct
 import types
 
 bpf_manager = types.ModuleType("pyisolate.bpf.manager")
@@ -58,7 +59,8 @@ def _make_blob(payload, key):
     nonce = b"\x00" * 12
     data = json.dumps(payload).encode("utf-8")
     aead = ChaCha20Poly1305(key)
-    return nonce + aead.encrypt(nonce, data, b"")
+    enc = nonce + aead.encrypt(nonce, data, b"")
+    return b"PYISOCP1" + struct.pack("!I", len(enc)) + enc
 
 
 def test_checkpoint_roundtrip():
@@ -165,3 +167,11 @@ def test_checkpoint_closes_on_serialization_failure():
     with pytest.raises(ValueError, match="JSON serializable"):
         iso.checkpoint(sandbox, key)
     assert sandbox.closed
+
+
+def test_restore_rejects_partial_checkpoint_envelope():
+    key = os.urandom(32)
+    sb = iso.spawn("cp")
+    blob = iso.checkpoint(sb, key)
+    with pytest.raises(ValueError, match="checkpoint envelope"):
+        iso.restore(blob[:-1], key)

--- a/tests/test_idle_thread.py
+++ b/tests/test_idle_thread.py
@@ -14,7 +14,7 @@ import pytest
 
 import pyisolate as iso
 from pyisolate import cgroup as _cgroup
-from pyisolate.runtime.thread import SandboxThread
+from pyisolate.runtime.thread import SandboxThread, _CgroupAttach
 
 # Ensure the cgroup helper writes to the temporary directory even if already imported.
 _cgroup._BASE = Path(os.environ["PYISOLATE_CGROUP_ROOT"]) / "pyisolate"
@@ -80,5 +80,32 @@ def test_thread_metrics_reset_on_reuse():
         assert t.recv(timeout=0.5) == "b"
         assert t.get_syscall_log() == []
         assert t.stats.operations == 1
+    finally:
+        t.stop()
+
+
+def test_control_messages_are_idempotent(monkeypatch):
+    calls = {"delete": 0}
+    first = Path("/tmp/pyisolate-first")
+    second = Path("/tmp/pyisolate-second")
+
+    def fake_attach(path):
+        return None
+
+    def fake_delete(path):
+        calls["delete"] += 1
+
+    monkeypatch.setattr(_cgroup, "attach_current", fake_attach)
+    monkeypatch.setattr(_cgroup, "delete", fake_delete)
+
+    t = SandboxThread(name="idempotent", cgroup_path=first)
+    t.start()
+    try:
+        t._cgroup_path = second
+        t._inbox.put(_CgroupAttach(42, first))
+        t._inbox.put(_CgroupAttach(42, first))
+        t.exec("post('ok')")
+        assert t.recv(timeout=0.5) == "ok"
+        assert calls["delete"] == 1
     finally:
         t.stop()

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from pyisolate import recovery
+
+
+def test_recover_removes_stale_registry_and_temp_dirs(tmp_path, monkeypatch):
+    monkeypatch.setattr(recovery, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(recovery, "REGISTRY_FILE", recovery.STATE_DIR / "registry.json")
+    monkeypatch.setattr(recovery, "TEMP_ROOT", recovery.STATE_DIR / "sandboxes")
+
+    stale_temp = recovery.allocate_temp_dir("stale")
+    live_temp = recovery.allocate_temp_dir("live")
+    recovery.update_sandbox("stale", {"temp_dir": str(stale_temp)})
+    recovery.update_sandbox("live", {"temp_dir": str(live_temp)})
+
+    recovery.recover(active_names={"live"})
+
+    registry = recovery.load_registry()
+    assert "live" in registry["sandboxes"]
+    assert "stale" not in registry["sandboxes"]
+    assert live_temp.exists()
+    assert not stale_temp.exists()
+
+
+def test_recover_tolerates_corrupt_registry(tmp_path, monkeypatch):
+    monkeypatch.setattr(recovery, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(recovery, "REGISTRY_FILE", recovery.STATE_DIR / "registry.json")
+    monkeypatch.setattr(recovery, "TEMP_ROOT", recovery.STATE_DIR / "sandboxes")
+    recovery.STATE_DIR.mkdir(parents=True)
+    recovery.REGISTRY_FILE.write_text("{broken")
+
+    assert recovery.load_registry() == {"sandboxes": {}}


### PR DESCRIPTION
### Motivation

- Improve robustness against supervisor or host crashes by making sandbox lifecycle durable and recoverable. 
- Ensure leaked OS resources (cgroups, temp dirs) are cleaned up after crashes or orphaned sandboxes. 
- Reject partial/truncated checkpoints before attempting decryption to avoid unsafe restores. 
- Make control-plane messages that reattach threads to cgroups idempotent and replay-safe.

### Description

- Add a new `pyisolate.recovery` module that persists a supervisor registry with atomic JSON writes, allocates deterministic per-sandbox temp dirs, and exposes `recover`, `update_sandbox`, `drop_sandbox`, `allocate_temp_dir`, and temp-dir cleanup helpers. 
- Wire recovery into the supervisor lifecycle so `Supervisor.__init__` runs `recover`, `spawn` records durable sandbox metadata, and `_cleanup` deletes cgroups, temp dirs and registry entries for dead sandboxes. 
- Extend `pyisolate.cgroup` with `list_children` and `cleanup_orphans` so stray cgroups can be found and removed on restart. 
- Harden checkpoint encoding by adding an envelope (`PYISOCP1` + 4-byte length) and strict envelope/length validation before decrypting and JSON parsing. 
- Make sandbox control messages replay-safe by tagging `_CgroupAttach` with a monotonic `msg_id` and suppressing duplicate deliveries inside `SandboxThread` using a seen-IDs set. 
- Add and update unit tests covering recovery cleanup behavior, corrupt-registry tolerance, partial checkpoint rejection, and idempotent control-message handling.

### Testing

- Ran `pytest -q tests/test_checkpoint.py tests/test_recovery.py tests/test_idle_thread.py tests/test_supervisor.py` and all tests passed (33 passed).
- New tests include `tests/test_recovery.py` and additions to `tests/test_checkpoint.py` and `tests/test_idle_thread.py` which exercised the new behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e762ab6138832893dd65e5ff0e210f)