### PR TITLE
Add packaging provenance reporting and `pyisolate-doctor` CLI for reproducibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ python -m pip install -e .[dev]  # install package for development and tooling
 # python -m pip install -e .[dev,pqcrypto]
 pytest -q          # run the test‑suite
 python examples/echo.py
+pyisolate-doctor  # capture provenance + kernel/hardening feature report
 ```
+
+
+### Packaging and reproducibility
+
+PyIsolate includes a `pyisolate-doctor` command for installation diagnostics and
+release provenance tracking (Python build hash, no-GIL status, kernel features,
+and deterministic-wheel policy flags). See [docs/packaging-reproducibility.md](docs/packaging-reproducibility.md).
 
 ### Structured logging
 

--- a/docs/packaging-reproducibility.md
+++ b/docs/packaging-reproducibility.md
@@ -1,0 +1,80 @@
+# Packaging and reproducibility
+
+PyIsolate now ships a machine-readable installation diagnostic via:
+
+```bash
+pyisolate-doctor
+```
+
+This command prints JSON that captures Python build provenance, no-GIL status,
+kernel feature detection, and hardening fallbacks. Store this artifact in CI and
+attach it to release tickets when triaging install issues.
+
+## 1) Exact Python build provenance
+
+`pyisolate-doctor` includes:
+
+- `executable`: resolved Python executable path.
+- `executable_sha256`: hash of the interpreter binary.
+- `version`, `cache_tag`, `soabi`, `abiflags`.
+- `CONFIG_ARGS`, `CFLAGS`, `LDFLAGS` from `sysconfig`.
+
+This is enough to identify *which* interpreter build produced a wheel and whether
+it was rebuilt by a downstream packager.
+
+## 2) no-GIL build reproducibility
+
+`hardening.no_gil_runtime.available` is derived from `Py_GIL_DISABLED`.
+When false, PyIsolate reports a clear reason and callers can fail closed.
+
+Recommended release check:
+
+```bash
+pyisolate-doctor | python -c 'import json,sys; print(json.load(sys.stdin)["hardening"]["no_gil_runtime"])'
+```
+
+## 3) Kernel feature detection
+
+`kernel.features` currently probes:
+
+- BPF LSM availability from `/sys/kernel/security/lsm`
+- bpffs mount status (`/sys/fs/bpf`)
+- cgroup v2 controller support
+- io_uring support envelope
+- Landlock presence for future fallback paths
+
+All probes include `available` and `reason` fields to avoid ambiguous failures.
+
+## 4) Feature flags for unavailable hardening paths
+
+The report exposes explicit fallback state under `hardening` and `kernel.features`.
+If a feature is unavailable, the reason text is intended to be directly shown in
+installer output and support dashboards.
+
+## 5) Deterministic wheels and unsupported platforms
+
+Deterministic wheel policy is currently defined for:
+
+- Linux `x86_64`
+- Linux `aarch64`
+
+Other targets are reported as unsupported for deterministic guarantees via
+`hardening.deterministic_wheels`.
+
+## 6) Signed releases
+
+Use the new release extra to install signing and upload tooling:
+
+```bash
+python -m pip install -e .[release]
+```
+
+Suggested release flow:
+
+1. Build: `python -m build`
+2. Sign: `python -m sigstore sign dist/*`
+3. Verify locally: `python -m sigstore verify identity ... dist/*`
+4. Upload: `python -m twine upload dist/*`
+
+Persist `pyisolate-doctor` output next to signatures to tie artifacts back to an
+exact interpreter + kernel environment.

--- a/pyisolate/doctor.py
+++ b/pyisolate/doctor.py
@@ -1,0 +1,20 @@
+"""CLI utilities for installation diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+
+from .provenance import installation_report_json
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="pyisolate-doctor",
+        description="Print PyIsolate build provenance and kernel feature flags.",
+    )
+    parser.parse_args(argv)
+    print(installation_report_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyisolate/provenance.py
+++ b/pyisolate/provenance.py
@@ -1,0 +1,124 @@
+"""Build provenance and platform feature detection helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Any
+
+
+def _safe_read_text(path: str) -> str | None:
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def _safe_sha256(path: str) -> str | None:
+    try:
+        digest = hashlib.sha256()
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None
+
+
+def python_build_provenance() -> dict[str, Any]:
+    """Return metadata that identifies the exact interpreter build."""
+
+    executable = Path(sys.executable).resolve()
+    return {
+        "executable": str(executable),
+        "executable_sha256": _safe_sha256(str(executable)),
+        "version": sys.version,
+        "cache_tag": sys.implementation.cache_tag,
+        "abiflags": getattr(sys, "abiflags", ""),
+        "platform": sysconfig.get_platform(),
+        "soabi": sysconfig.get_config_var("SOABI"),
+        "configure_args": sysconfig.get_config_var("CONFIG_ARGS"),
+        "py_gil_disabled": bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
+        "cflags": sysconfig.get_config_var("CFLAGS"),
+        "ldflags": sysconfig.get_config_var("LDFLAGS"),
+    }
+
+
+def kernel_feature_flags() -> dict[str, dict[str, Any]]:
+    """Probe host kernel capabilities and report degradations clearly."""
+
+    lsm = (_safe_read_text("/sys/kernel/security/lsm") or "").split(",")
+    return {
+        "ebpf_lsm": {
+            "available": "bpf" in lsm,
+            "reason": "Kernel LSM list does not include bpf" if "bpf" not in lsm else "ok",
+        },
+        "bpffs": {
+            "available": os.path.ismount("/sys/fs/bpf"),
+            "reason": "/sys/fs/bpf is not mounted" if not os.path.ismount("/sys/fs/bpf") else "ok",
+        },
+        "cgroup_v2": {
+            "available": Path("/sys/fs/cgroup/cgroup.controllers").exists(),
+            "reason": "cgroup v2 controllers file missing"
+            if not Path("/sys/fs/cgroup/cgroup.controllers").exists()
+            else "ok",
+        },
+        "io_uring": {
+            "available": hasattr(os, "SYS_io_uring_setup") or platform.system() == "Linux",
+            "reason": "non-Linux kernels are unsupported for io_uring"
+            if platform.system() != "Linux"
+            else "ok",
+        },
+        "landlock": {
+            "available": Path("/sys/kernel/security/landlock").exists(),
+            "reason": "Landlock securityfs entry not detected"
+            if not Path("/sys/kernel/security/landlock").exists()
+            else "ok",
+        },
+    }
+
+
+def hardening_feature_flags() -> dict[str, dict[str, Any]]:
+    """Return installation-time hardening state with explicit fallback status."""
+
+    provenance = python_build_provenance()
+    return {
+        "no_gil_runtime": {
+            "available": bool(provenance["py_gil_disabled"]),
+            "reason": "Python was not built with --disable-gil"
+            if not provenance["py_gil_disabled"]
+            else "ok",
+        },
+        "deterministic_wheels": {
+            "available": platform.system() == "Linux"
+            and platform.machine() in {"x86_64", "aarch64"},
+            "reason": "Deterministic wheel policy only defined for Linux x86_64/aarch64"
+            if not (platform.system() == "Linux" and platform.machine() in {"x86_64", "aarch64"})
+            else "ok",
+        },
+    }
+
+
+def installation_report() -> dict[str, Any]:
+    """Compose a machine-readable report for release/debug tooling."""
+
+    return {
+        "python": python_build_provenance(),
+        "kernel": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "version": platform.version(),
+            "machine": platform.machine(),
+            "features": kernel_feature_flags(),
+        },
+        "hardening": hardening_feature_flags(),
+    }
+
+
+def installation_report_json() -> str:
+    return json.dumps(installation_report(), indent=2, sort_keys=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,16 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["pyisolate"]
 
+[project.scripts]
+pyisolate-doctor = "pyisolate.doctor:main"
+
 [project.optional-dependencies]
 pqcrypto = ["pqcrypto"]
+release = [
+    "build",
+    "twine",
+    "sigstore",
+]
 dev = [
     "pytest",
     "pre-commit",

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import json
+
+from pyisolate.doctor import main
+from pyisolate.provenance import installation_report
+
+
+def test_installation_report_schema():
+    report = installation_report()
+    assert "python" in report
+    assert "kernel" in report
+    assert "hardening" in report
+    assert isinstance(report["python"]["executable_sha256"], (str, type(None)))
+
+
+def test_doctor_cli_output(capsys):
+    main([])
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert "kernel" in payload
+    assert "features" in payload["kernel"]


### PR DESCRIPTION
### Motivation

- Provide machine-readable installation diagnostics to make Python build provenance and platform capabilities explicit for production users. 
- Detect and surface hardening fallbacks (no-GIL, deterministic-wheel policy, kernel features) so installers and CI can fail closed or guide remediation. 
- Smooth fragile install/release paths by adding a simple CLI and documenting signed-release and reproducible-wheel workflows. 

### Description

- Add `pyisolate.provenance` which gathers interpreter build metadata, computes an executable SHA256, and probes kernel features and hardening flags via `python_build_provenance()`, `kernel_feature_flags()`, and `hardening_feature_flags()`. 
- Add `pyisolate.doctor` CLI exposing `main()` and register it as the `pyisolate-doctor` entrypoint in `pyproject.toml` so users can emit deterministic JSON via `pyisolate-doctor` or `python -m pyisolate.doctor`. 
- Add documentation `docs/packaging-reproducibility.md` and a README snippet linking to the diagnostic, and add a `release` optional dependency group (`build`, `twine`, `sigstore`) for signed-release tooling. 
- Add tests `tests/test_provenance.py` to validate the report shape and CLI JSON output. 

### Testing

- Ran the new unit tests with `pytest -q tests/test_provenance.py tests/test_sdk.py`, which completed successfully (`4 passed`). 
- Verified the CLI output with `python -m pyisolate.doctor | head -n 20` to confirm JSON is emitted and contains kernel feature flags. 
- An initial test run exposed an `argparse` interaction which was fixed by making `main()` accept an `argv` parameter; subsequent test runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e762cf1f588328b67a2ae6246eca1c)