### PR TITLE
Add durable sandbox recovery and replay-safe cgroup control handling

### DIFF
--- a/pyisolate/cgroup.py
+++ b/pyisolate/cgroup.py
@@ -8,7 +8,7 @@ import os
 import threading
 from pathlib import Path
 
-__all__ = ["create", "attach_current", "delete"]
+__all__ = ["create", "attach_current", "delete", "list_children", "cleanup_orphans"]
 
 # Allow tests to override the base cgroup directory
 _BASE = Path(os.environ.get("PYISOLATE_CGROUP_ROOT", "/sys/fs/cgroup")) / "pyisolate"
@@ -75,3 +75,26 @@ def delete(path: Path | None) -> None:
         path.rmdir()
     except (OSError, PermissionError, FileNotFoundError) as exc:
         log.warning("Failed to delete cgroup %s: %s", path, exc)
+
+
+def list_children() -> list[Path]:
+    """List child cgroup directories under the pyisolate root."""
+    if not _BASE.exists():
+        return []
+    try:
+        return [p for p in _BASE.iterdir() if p.is_dir()]
+    except (OSError, PermissionError, FileNotFoundError) as exc:
+        log.warning("Failed to list cgroups under %s: %s", _BASE, exc)
+        return []
+
+
+def cleanup_orphans(active_names: set[str] | None = None) -> list[Path]:
+    """Delete cgroups not present in *active_names*."""
+    active = active_names or set()
+    removed: list[Path] = []
+    for child in list_children():
+        if child.name in active:
+            continue
+        delete(child)
+        removed.append(child)
+    return removed

--- a/pyisolate/checkpoint.py
+++ b/pyisolate/checkpoint.py
@@ -13,6 +13,29 @@ from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
 from .supervisor import Sandbox, spawn
 
+_MAGIC = b"PYISOCP1"
+_NONCE_LEN = 12
+_LEN_SIZE = 4
+
+
+def _encode_envelope(blob: bytes) -> bytes:
+    return _MAGIC + len(blob).to_bytes(_LEN_SIZE, "big") + blob
+
+
+def _decode_envelope(payload: bytes) -> bytes:
+    header_len = len(_MAGIC) + _LEN_SIZE
+    if len(payload) < header_len:
+        raise ValueError("invalid checkpoint envelope")
+    if payload[: len(_MAGIC)] != _MAGIC:
+        raise ValueError("invalid checkpoint envelope")
+    expected = int.from_bytes(payload[len(_MAGIC) : header_len], "big")
+    body = payload[header_len:]
+    if expected != len(body):
+        raise ValueError("invalid checkpoint envelope length")
+    if len(body) < _NONCE_LEN:
+        raise ValueError("invalid checkpoint envelope length")
+    return body
+
 
 def checkpoint(sandbox: Sandbox, key: bytes) -> bytes:
     """Serialize *sandbox* state and encrypt it with *key*.
@@ -28,9 +51,9 @@ def checkpoint(sandbox: Sandbox, key: bytes) -> bytes:
         except (TypeError, ValueError) as exc:  # json raises ValueError on NaN
             raise ValueError("sandbox state is not JSON serializable") from exc
         aead = ChaCha20Poly1305(key)
-        nonce = os.urandom(12)
+        nonce = os.urandom(_NONCE_LEN)
         blob = nonce + aead.encrypt(nonce, data, b"")
-        return blob
+        return _encode_envelope(blob)
     finally:
         sandbox.close()
 
@@ -39,7 +62,8 @@ def restore(blob: bytes, key: bytes) -> Sandbox:
     """Decrypt *blob* with *key* and spawn a new sandbox."""
     if len(key) != 32:
         raise ValueError("key must be 32 bytes")
-    nonce, ct = blob[:12], blob[12:]
+    sealed = _decode_envelope(blob)
+    nonce, ct = sealed[:_NONCE_LEN], sealed[_NONCE_LEN:]
     aead = ChaCha20Poly1305(key)
     data = aead.decrypt(nonce, ct, b"")
     try:

--- a/pyisolate/recovery.py
+++ b/pyisolate/recovery.py
@@ -1,0 +1,137 @@
+"""Durable supervisor recovery helpers.
+
+The supervisor persists lightweight sandbox metadata to allow restart-time cleanup
+of leaked resources (cgroups, temp directories) after crashes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_STATE_ROOT = Path(
+    os.environ.get("PYISOLATE_STATE_ROOT", Path(tempfile.gettempdir()) / "pyisolate")
+)
+_REGISTRY_PATH = Path(
+    os.environ.get("PYISOLATE_REGISTRY_PATH", _STATE_ROOT / "supervisor_registry.json")
+)
+_TEMP_ROOT = Path(os.environ.get("PYISOLATE_TEMP_ROOT", _STATE_ROOT / "sandboxes"))
+
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    _ensure_parent(path)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, sort_keys=True)
+        fh.flush()
+        os.fsync(fh.fileno())
+    tmp.replace(path)
+
+
+
+def _read_registry() -> dict[str, dict[str, Any]]:
+    if not _REGISTRY_PATH.exists():
+        return {}
+    try:
+        data = json.loads(_REGISTRY_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError, TypeError) as exc:
+        log.warning("failed to read recovery registry %s: %s", _REGISTRY_PATH, exc)
+        return {}
+
+    if not isinstance(data, dict):
+        log.warning("invalid recovery registry format in %s", _REGISTRY_PATH)
+        return {}
+
+    sandboxes = data.get("sandboxes", {})
+    if not isinstance(sandboxes, dict):
+        log.warning("invalid sandboxes map in recovery registry %s", _REGISTRY_PATH)
+        return {}
+
+    result: dict[str, dict[str, Any]] = {}
+    for name, meta in sandboxes.items():
+        if isinstance(name, str) and isinstance(meta, dict):
+            result[name] = dict(meta)
+    return result
+
+
+
+def _write_registry(sandboxes: dict[str, dict[str, Any]]) -> None:
+    _atomic_write_json(_REGISTRY_PATH, {"sandboxes": sandboxes})
+
+
+
+def recover() -> dict[str, dict[str, Any]]:
+    """Load persisted sandbox metadata.
+
+    Corrupt registries are tolerated and reset to an empty map.
+    """
+
+    sandboxes = _read_registry()
+    if not sandboxes and _REGISTRY_PATH.exists():
+        # Normalize a corrupt/invalid registry to empty valid JSON.
+        _write_registry({})
+    return sandboxes
+
+
+
+def update_sandbox(name: str, meta: dict[str, Any]) -> None:
+    sandboxes = _read_registry()
+    sandboxes[name] = dict(meta)
+    _write_registry(sandboxes)
+
+
+
+def drop_sandbox(name: str) -> None:
+    sandboxes = _read_registry()
+    sandboxes.pop(name, None)
+    _write_registry(sandboxes)
+
+
+
+def allocate_temp_dir(name: str) -> Path:
+    """Allocate a deterministic per-sandbox temp directory."""
+
+    path = _TEMP_ROOT / name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+
+def cleanup_temp_dir(path_or_name: str | Path) -> None:
+    """Remove a sandbox temp directory if it exists."""
+
+    if isinstance(path_or_name, Path):
+        path = path_or_name
+    else:
+        path = _TEMP_ROOT / path_or_name
+    shutil.rmtree(path, ignore_errors=True)
+
+
+
+def cleanup_temp_orphans(active_names: set[str]) -> list[Path]:
+    """Remove temp directories that do not belong to active sandboxes."""
+
+    removed: list[Path] = []
+    if not _TEMP_ROOT.exists():
+        return removed
+    for child in _TEMP_ROOT.iterdir():
+        if not child.is_dir():
+            continue
+        if child.name in active_names:
+            continue
+        cleanup_temp_dir(child)
+        removed.append(child)
+    return removed

--- a/pyisolate/runtime/protocol.py
+++ b/pyisolate/runtime/protocol.py
@@ -40,6 +40,7 @@ class AttachCgroupRequest:
     """Control-plane request to (re)attach to a cgroup path."""
 
     old_path: Path | None
+    msg_id: int = 0
 
 
 @dataclass(frozen=True)

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -303,6 +303,8 @@ class SandboxThread(threading.Thread):
         self._syscall_log: list[str] = []
         self._capabilities = dict(capabilities or {})
         self._quarantine_reason: str | None = None
+        self._next_attach_msg_id = 1
+        self._seen_attach_msg_ids: set[int] = set()
 
     def snapshot(self) -> dict:
         """Return serializable configuration state."""
@@ -441,7 +443,9 @@ class SandboxThread(threading.Thread):
         self._capabilities = dict(capabilities or {})
         # Request the sandbox thread to (re)attach itself to the new cgroup.
         # The attachment must happen from the sandbox thread's context.
-        self._inbox.put(AttachCgroupRequest(old_path=old_path))
+        msg_id = self._next_attach_msg_id
+        self._next_attach_msg_id += 1
+        self._inbox.put(AttachCgroupRequest(old_path=old_path, msg_id=msg_id))
 
     @property
     def stats(self):
@@ -492,6 +496,9 @@ class SandboxThread(threading.Thread):
                 if isinstance(payload, StopRequest):
                     break
                 if isinstance(payload, AttachCgroupRequest):
+                    if payload.msg_id in self._seen_attach_msg_ids:
+                        continue
+                    self._seen_attach_msg_ids.add(payload.msg_id)
                     try:
                         from .. import cgroup
 

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -14,7 +14,7 @@ import threading
 from pathlib import Path
 from typing import Dict, Optional
 
-from . import cgroup
+from . import cgroup, recovery
 from .capabilities import ROOT, RootCapability
 from .errors import PolicyAuthError
 from .observability.alerts import AlertManager
@@ -133,6 +133,7 @@ class Supervisor:
         self._bpf = bpf_mod.BPFManager()
         self._rollout_mode = rollout_mode
         self._bpf.load(mode=rollout_mode)
+        self._recover_state()
         self._warm_pool: list[SandboxThread] = []
         for i in range(warm_pool):
             t = SandboxThread(name=f"warm-{i}")
@@ -141,6 +142,24 @@ class Supervisor:
         self._watchdog = ResourceWatchdog(self)
         self._watchdog.start()
         self._policy_token: str | None = None
+
+    def _recover_state(self) -> None:
+        """Recover durable supervisor state and clean stale resources."""
+        stale = recovery.recover()
+        for name, meta in stale.items():
+            cg_path = meta.get("cgroup_path")
+            if isinstance(cg_path, str) and cg_path:
+                cgroup.delete(Path(cg_path))
+            else:
+                cgroup.delete(cgroup._BASE / name)
+            temp_dir = meta.get("temp_dir")
+            if isinstance(temp_dir, str) and temp_dir:
+                recovery.cleanup_temp_dir(Path(temp_dir))
+            else:
+                recovery.cleanup_temp_dir(name)
+            recovery.drop_sandbox(name)
+        cgroup.cleanup_orphans(set())
+        recovery.cleanup_temp_orphans(set())
 
     def register_alert_handler(self, callback) -> None:
         """Subscribe to policy violation alerts."""
@@ -179,6 +198,7 @@ class Supervisor:
                 raise RuntimeError(f"sandbox '{name}' already exists")
 
             cg_path = cgroup.create(name, cpu_ms, mem_bytes)
+            temp_dir = recovery.allocate_temp_dir(name)
             if self._warm_pool:
                 thread = self._warm_pool.pop()
                 thread.reset(
@@ -207,7 +227,16 @@ class Supervisor:
                     capabilities=capabilities,
                 )
                 thread.start()
+            thread._temp_dir = temp_dir
             self._sandboxes[name] = thread
+            recovery.update_sandbox(
+                name,
+                {
+                    "name": name,
+                    "cgroup_path": str(cg_path) if cg_path is not None else None,
+                    "temp_dir": str(temp_dir),
+                },
+            )
         # Remove references to any terminated sandboxes
         self._cleanup()
         # Reset any temporary overrides of the name validation pattern to avoid
@@ -297,6 +326,8 @@ class Supervisor:
         with self._lock:
             self._sandboxes.pop(name, None)
         cgroup.delete(getattr(thread, "_cgroup_path", None))
+        recovery.cleanup_temp_dir(getattr(thread, "_temp_dir", name))
+        recovery.drop_sandbox(name)
 
     def recycle(self, name: str) -> Sandbox:
         """Replace a sandbox thread with a fresh instance using prior config."""
@@ -328,6 +359,8 @@ class Supervisor:
             for n in dead:
                 thread = self._sandboxes[n]
                 cgroup.delete(getattr(thread, "_cgroup_path", None))
+                recovery.cleanup_temp_dir(getattr(thread, "_temp_dir", n))
+                recovery.drop_sandbox(n)
                 del self._sandboxes[n]
             self._warm_pool = [t for t in self._warm_pool if t.is_alive()]
 

--- a/tests/test_cgroup.py
+++ b/tests/test_cgroup.py
@@ -50,3 +50,18 @@ def test_delete_logs_warning_on_error(tmp_path, monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger=cgroup.__name__):
         cgroup.delete(path)
     assert "Failed to delete cgroup" in caplog.text
+
+
+
+def test_list_children_and_cleanup_orphans(tmp_path, monkeypatch):
+    monkeypatch.setattr(cgroup, "_BASE", tmp_path / "pyisolate")
+    keep = cgroup.create("keep")
+    orphan = cgroup.create("orphan")
+
+    children = {p.name for p in cgroup.list_children()}
+    assert {"keep", "orphan"}.issubset(children)
+
+    removed = cgroup.cleanup_orphans({"keep"})
+    assert {p.name for p in removed} == {"orphan"}
+    assert keep is not None and keep.exists()
+    assert orphan is not None and not orphan.exists()

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -58,7 +58,8 @@ def _make_blob(payload, key):
     nonce = b"\x00" * 12
     data = json.dumps(payload).encode("utf-8")
     aead = ChaCha20Poly1305(key)
-    return nonce + aead.encrypt(nonce, data, b"")
+    sealed = nonce + aead.encrypt(nonce, data, b"")
+    return b"PYISOCP1" + len(sealed).to_bytes(4, "big") + sealed
 
 
 def test_checkpoint_roundtrip():
@@ -165,3 +166,23 @@ def test_checkpoint_closes_on_serialization_failure():
     with pytest.raises(ValueError, match="JSON serializable"):
         iso.checkpoint(sandbox, key)
     assert sandbox.closed
+
+
+
+def test_restore_rejects_truncated_envelope_before_decrypt(monkeypatch):
+    key = os.urandom(32)
+
+    from cryptography.hazmat.primitives.ciphers import aead as aead_mod
+
+    def fail_decrypt(self, nonce, data, aad):
+        raise AssertionError("decrypt should not be called")
+
+    monkeypatch.setattr(aead_mod.ChaCha20Poly1305, "decrypt", fail_decrypt)
+    with pytest.raises(ValueError, match="envelope length"):
+        iso.restore(b"PYISOCP1" + (99).to_bytes(4, "big") + b"x", key)
+
+
+def test_restore_rejects_bad_envelope_magic():
+    key = os.urandom(32)
+    with pytest.raises(ValueError, match="envelope"):
+        iso.restore(b"NOTMAGIC" + (0).to_bytes(4, "big"), key)

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,106 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+from pyisolate import cgroup, recovery
+from pyisolate.bpf.manager import BPFManager
+
+
+def test_recover_tolerates_corrupt_registry(tmp_path, monkeypatch):
+    reg = tmp_path / "registry.json"
+    tmp_root = tmp_path / "tmp"
+
+    monkeypatch.setattr(recovery, "_REGISTRY_PATH", reg)
+    monkeypatch.setattr(recovery, "_TEMP_ROOT", tmp_root)
+
+    reg.write_text("{broken", encoding="utf-8")
+    assert recovery.recover() == {}
+
+    normalized = json.loads(reg.read_text(encoding="utf-8"))
+    assert normalized == {"sandboxes": {}}
+
+
+def test_supervisor_recovery_cleans_stale_resources(tmp_path, monkeypatch):
+    cgroup_root = tmp_path / "cgroup"
+    reg = tmp_path / "registry.json"
+    tmp_root = tmp_path / "tmp"
+
+    monkeypatch.setattr(cgroup, "_BASE", cgroup_root / "pyisolate")
+    monkeypatch.setattr(recovery, "_REGISTRY_PATH", reg)
+    monkeypatch.setattr(recovery, "_TEMP_ROOT", tmp_root)
+
+    def fake_load(self, *, mode="dev", strict=None):
+        return None
+
+    def fake_watchdog_start(self):
+        return None
+
+    def fake_watchdog_stop(self, timeout=0.2):
+        return None
+
+    monkeypatch.setattr(BPFManager, "load", fake_load)
+    monkeypatch.setattr("pyisolate.watchdog.ResourceWatchdog.start", fake_watchdog_start)
+    monkeypatch.setattr("pyisolate.watchdog.ResourceWatchdog.stop", fake_watchdog_stop)
+
+    stale_cg = cgroup.create("stale")
+    stale_tmp = recovery.allocate_temp_dir("stale")
+    assert stale_cg is not None and stale_cg.exists()
+    assert stale_tmp.exists()
+
+    recovery.update_sandbox(
+        "stale",
+        {
+            "name": "stale",
+            "cgroup_path": str(stale_cg),
+            "temp_dir": str(stale_tmp),
+        },
+    )
+
+    sup = iso.Supervisor()
+    try:
+        assert recovery.recover() == {}
+        assert not stale_cg.exists()
+        assert not stale_tmp.exists()
+    finally:
+        sup.shutdown()
+
+
+def test_cleanup_drops_registry_and_temp_dir_for_dead_sandbox(tmp_path, monkeypatch):
+    cgroup_root = tmp_path / "cgroup"
+    reg = tmp_path / "registry.json"
+    tmp_root = tmp_path / "tmp"
+
+    monkeypatch.setattr(cgroup, "_BASE", cgroup_root / "pyisolate")
+    monkeypatch.setattr(recovery, "_REGISTRY_PATH", reg)
+    monkeypatch.setattr(recovery, "_TEMP_ROOT", tmp_root)
+
+    def fake_load(self, *, mode="dev", strict=None):
+        return None
+
+    def fake_watchdog_start(self):
+        return None
+
+    def fake_watchdog_stop(self, timeout=0.2):
+        return None
+
+    monkeypatch.setattr(BPFManager, "load", fake_load)
+    monkeypatch.setattr("pyisolate.watchdog.ResourceWatchdog.start", fake_watchdog_start)
+    monkeypatch.setattr("pyisolate.watchdog.ResourceWatchdog.stop", fake_watchdog_stop)
+
+    sup = iso.Supervisor()
+    try:
+        sb = sup.spawn("dead")
+        temp_dir = sb._thread._temp_dir
+        assert temp_dir.exists()
+
+        sb.close()
+        sup._cleanup()
+
+        assert "dead" not in recovery.recover()
+        assert not temp_dir.exists()
+    finally:
+        sup.shutdown()

--- a/tests/test_thread_extra.py
+++ b/tests/test_thread_extra.py
@@ -11,7 +11,8 @@ sys.path.insert(0, str(ROOT))
 
 import pyisolate as iso
 from pyisolate import errors, policy
-from pyisolate.runtime.thread import _sigxcpu_handler
+from pyisolate.runtime.protocol import AttachCgroupRequest
+from pyisolate.runtime.thread import SandboxThread, _sigxcpu_handler
 
 
 def test_sigxcpu_handler_raises():
@@ -66,3 +67,33 @@ def test_other_thread_unaffected_by_sandbox():
         assert sb.recv(timeout=1) == "done"
     finally:
         sb.close()
+
+
+
+def test_attach_cgroup_control_message_is_idempotent(monkeypatch):
+    from pyisolate import cgroup
+
+    calls = {"attach": 0, "delete": 0}
+
+    def fake_attach(path):
+        calls["attach"] += 1
+
+    def fake_delete(path):
+        calls["delete"] += 1
+
+    monkeypatch.setattr(cgroup, "attach_current", fake_attach)
+    monkeypatch.setattr(cgroup, "delete", fake_delete)
+
+    t = SandboxThread(name="msg-idem")
+    t.start()
+    try:
+        t._inbox.put(AttachCgroupRequest(old_path=None, msg_id=7))
+        t._inbox.put(AttachCgroupRequest(old_path=None, msg_id=7))
+        t.exec("post('ok')")
+        assert t.recv(timeout=0.5) == "ok"
+    finally:
+        t.stop()
+
+    # One call comes from thread startup attach, one from unique control message.
+    assert calls["attach"] == 2
+    assert calls["delete"] == 0


### PR DESCRIPTION
### Motivation
- Improve robustness to supervisor/host crashes by persisting lightweight sandbox metadata so leaked OS resources (cgroups, temp dirs) can be discovered and cleaned on restart. 
- Harden checkpoint restores to reject truncated or malformed blobs before attempting decryption. 
- Make control-plane cgroup attach messages idempotent and replay-safe to tolerate duplicate deliveries when reattaching threads.

### Description
- Add a new `pyisolate.recovery` module that maintains a durable supervisor registry with atomic JSON writes and deterministic per-sandbox temp directory helpers (`recover`, `update_sandbox`, `drop_sandbox`, `allocate_temp_dir`, `cleanup_temp_dir`, `cleanup_temp_orphans`).
- Wire recovery into `Supervisor` lifecycle so `Supervisor.__init__` calls `recover()` and cleans stale cgroups/temp dirs, `spawn()` allocates temp dirs and records durable metadata via `recovery.update_sandbox`, and `_cleanup()`/`quarantine()` remove cgroups, temp dirs and registry entries for dead sandboxes.
- Extend `pyisolate.cgroup` with `list_children()` and `cleanup_orphans()` to enumerate and remove orphaned cgroups on restart.
- Harden checkpoint framing in `pyisolate.checkpoint` by adding an envelope (`PYISOCP1` + 4-byte length) and performing strict envelope and length validation before any decrypt/JSON parse to reject truncated or malformed checkpoints.
- Make attach control messages replay-safe by adding a monotonic `msg_id` to `AttachCgroupRequest`, generating message ids in `SandboxThread.reset()` and deduplicating in the sandbox run loop using a seen-IDs set.
- Add and update unit tests covering corrupt-registry tolerance, supervisor recovery cleanup, cgroup orphan cleanup, checkpoint envelope validation, and idempotent attach control-message handling (`tests/test_recovery.py`, `tests/test_cgroup.py`, updates to `tests/test_checkpoint.py` and `tests/test_thread_extra.py`).

### Testing
- Ran `pytest -q tests/test_checkpoint.py tests/test_recovery.py tests/test_cgroup.py tests/test_thread_extra.py tests/test_supervisor.py`; all tests passed locally (`44 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e765b792dc83289096445ff2641f0d)