### PR TITLE
Narrow optional import exception handling in `pyisolate.__init__`

### DIFF
--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -20,7 +20,17 @@ from .capabilities import (  # noqa: F401
 
 try:
     from .checkpoint import checkpoint, restore
-except Exception:  # pragma: no cover - optional dependency
+except (ModuleNotFoundError, ImportError) as exc:  # pragma: no cover - optional dependency
+    # Trap only dependency-related import failures; let unrelated import-time
+    # bugs in optional modules propagate so they remain visible to developers.
+    if (
+        isinstance(exc, ModuleNotFoundError)
+        and exc.name
+        and exc.name.split(".", 1)[0] != "cryptography"
+    ):
+        raise
+    if isinstance(exc, ImportError) and "cryptography" not in str(exc):
+        raise
 
     def checkpoint(*args, **kwargs):  # type: ignore[no-redef]
         raise ModuleNotFoundError("cryptography is required for checkpoint support")
@@ -48,7 +58,17 @@ from .logging import setup_structured_logging  # noqa: F401
 
 try:
     from .migration import migrate
-except Exception:  # pragma: no cover - optional dependency
+except (ModuleNotFoundError, ImportError) as exc:  # pragma: no cover - optional dependency
+    # Trap only dependency-related import failures; let unrelated import-time
+    # bugs in optional modules propagate so they remain visible to developers.
+    if (
+        isinstance(exc, ModuleNotFoundError)
+        and exc.name
+        and exc.name.split(".", 1)[0] != "cryptography"
+    ):
+        raise
+    if isinstance(exc, ImportError) and "cryptography" not in str(exc):
+        raise
 
     def migrate(*args, **kwargs):  # type: ignore[no-redef]
         raise ModuleNotFoundError("cryptography is required for migration support")


### PR DESCRIPTION
### Motivation
- Avoid silently swallowing unrelated import-time errors in optional modules so developer-visible bugs surface during import. 
- Continue to treat the checkpoint/migration features as optional when the `cryptography` dependency is absent. 
- Preserve the existing public API and error semantics for users when optional crypto support is unavailable.

### Description
- Replace broad `except Exception` around `from .checkpoint import checkpoint, restore` and `from .migration import migrate` with `except (ModuleNotFoundError, ImportError)` and inspect the exception before deciding to swallow it. 
- Re-raise `ModuleNotFoundError`/`ImportError` instances that do not indicate the `cryptography` dependency is missing so unexpected import-time failures propagate. 
- Preserve the fallback callables `checkpoint`, `restore`, and `migrate` that raise `ModuleNotFoundError("cryptography is required ...")` to keep the same API shape and messages. 
- Add brief inline comments explaining that only dependency-related import failures are intentionally trapped.

### Testing
- Ran `python -m compileall pyisolate/__init__.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76f748b448328b97be3ef666be1cf)