### PR TITLE
Implement kernel BPF enforcement hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ Choose a supervisor rollout profile based on where you are deploying:
 ```python
 import pyisolate as iso
 
-# default: fast local iteration
-dev = iso.Supervisor(rollout_mode="dev")
-
-# strict production posture (fail closed if BPF toolchain/load fails)
+# production default: fail closed if the BPF toolchain, verifier, load, or attach fails
 hardened = iso.Supervisor(rollout_mode="hardened")
 
-# looser ecosystem validation (baseline BPF only, skips stricter filters)
+# explicitly acknowledge weaker enforcement for local iteration
+dev = iso.Supervisor(rollout_mode="dev")
+
+# explicitly acknowledge reduced enforcement for ecosystem validation
 compat = iso.Supervisor(rollout_mode="compatibility")
 ```
 
-* `dev`: lightweight, low-friction development mode.
-* `hardened`: real enforcement; any eBPF compile/load failure raises.
-* `compatibility`: reduced enforcement to maximize third-party compatibility.
+* `hardened`: documented production default with kernel LSM/cgroup enforcement; any eBPF compile/load/attach failure raises.
+* `dev`: caller-acknowledged local development mode; tooling failures are logged and kernel enforcement can be absent.
+* `compatibility`: caller-acknowledged reduced enforcement to maximize third-party compatibility; strict filters are skipped.
 
 ### Hello World
 

--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -31,10 +31,15 @@ class BPFManager:
         self._obj = Path(__file__).with_name("dummy.bpf.o")
         self._skel = Path(__file__).with_name("dummy.skel.h")
         self.skeleton = ""
+        self._compiled_skeleton = False
         self._filter_src = Path(__file__).with_name("syscall_filter.bpf.c")
         self._filter_obj = Path(__file__).with_name("syscall_filter.bpf.o")
         self._guard_src = Path(__file__).with_name("resource_guard.bpf.c")
         self._guard_obj = Path(__file__).with_name("resource_guard.bpf.o")
+        self._bpffs_root = Path("/sys/fs/bpf/pyisolate")
+        self._dummy_pin = Path("/sys/fs/bpf/dummy")
+        self._filter_pin_dir = self._bpffs_root / "syscall_filter"
+        self._guard_pin_dir = self._bpffs_root / "resource_guard"
         self._skel_cache = self._SKEL_CACHE
 
     # internal helper
@@ -79,9 +84,12 @@ class BPFManager:
         Rollout modes:
 
         * ``dev``: low-friction mode; tolerate missing tooling and keep running.
-        * ``hardened``: strict mode; any failure raises a ``RuntimeError``.
-        * ``compatibility``: looser enforcement for ecosystem testing. Loads the
-          baseline program but skips stricter filter/guard attachments.
+          Use only for local development because BPF enforcement can be absent.
+        * ``hardened``: production default; any failure raises a ``RuntimeError``
+          and leaves the manager unloaded so callers fail closed.
+        * ``compatibility``: caller-acknowledged reduced enforcement for ecosystem
+          testing. Loads the baseline program but skips stricter filter/guard
+          attachments.
 
         The legacy ``strict`` argument is still honored. When provided it
         overrides ``mode``.
@@ -125,7 +133,9 @@ class BPFManager:
         ]
         ok = True
         compile_cmd = dummy_compile
-        if self._src not in self._skel_cache:
+        if self._src not in self._skel_cache or (
+            self._skel_cache.get(self._src) == "" and not self._compiled_skeleton
+        ):
             ok &= self._run(compile_cmd, raise_on_error=strict_mode)
             skel_cmd = [
                 "sh",
@@ -138,11 +148,13 @@ class BPFManager:
                     self._skel_cache[self._src] = self._skel.read_text()
                 except OSError:
                     self._skel_cache[self._src] = ""
-            else:
-                # Cache a placeholder so repeated loads in tool-less test
-                # environments do not repeat compile/skeleton steps.
+            elif ok:
+                # Cache a placeholder when the build path was exercised but no
+                # skeleton was emitted (for example under a mocked bpftool).
                 self._skel_cache.setdefault(self._src, "")
             self.skeleton = self._skel_cache.get(self._src, "")
+            if ok:
+                self._compiled_skeleton = True
         else:
             self.skeleton = self._skel_cache[self._src]
 
@@ -150,7 +162,7 @@ class BPFManager:
             ["llvm-objdump", "-d", str(self._obj)], raise_on_error=strict_mode
         )
         ok &= self._run(
-            ["bpftool", "prog", "load", str(self._obj), "/sys/fs/bpf/dummy"],
+            ["bpftool", "prog", "load", str(self._obj), str(self._dummy_pin)],
             raise_on_error=strict_mode,
         )
         if mode != "compatibility":
@@ -168,9 +180,14 @@ class BPFManager:
                 [
                     "bpftool",
                     "prog",
-                    "load",
+                    "loadall",
                     str(self._filter_obj),
-                    "/sys/fs/bpf/syscall_filter",
+                    str(self._filter_pin_dir),
+                    "type",
+                    "lsm",
+                    "pinmaps",
+                    str(self._bpffs_root),
+                    "autoattach",
                 ],
                 raise_on_error=strict_mode,
             )
@@ -178,15 +195,44 @@ class BPFManager:
                 [
                     "bpftool",
                     "prog",
-                    "load",
+                    "loadall",
                     str(self._guard_obj),
-                    "/sys/fs/bpf/resource_guard",
+                    str(self._guard_pin_dir),
+                    "pinmaps",
+                    str(self._bpffs_root),
+                    "autoattach",
                 ],
                 raise_on_error=strict_mode,
             )
+            ok &= self._attach_loaded_programs(raise_on_error=strict_mode)
         self.loaded = ok
         if strict_mode and not ok:
             raise RuntimeError("BPF load failed; see logs for details")
+
+    def _attach_loaded_programs(self, *, raise_on_error: bool = False) -> bool:
+        """Attach programs that cannot rely solely on pinned objects.
+
+        ``bpftool prog loadall ... autoattach`` creates BPF links for LSM and
+        tracepoint programs on modern kernels.  The explicit cgroup-skb attach is
+        retained for kernels/tools that require a concrete cgroup attach point.
+        """
+
+        ok = True
+        cgroup_root = Path("/sys/fs/cgroup")
+        egress_prog = self._guard_pin_dir / "account_cgroup_egress"
+        ok &= self._run(
+            [
+                "bpftool",
+                "cgroup",
+                "attach",
+                str(cgroup_root),
+                "egress",
+                "pinned",
+                str(egress_prog),
+            ],
+            raise_on_error=raise_on_error,
+        )
+        return ok
 
     def hot_reload(self, policy_path: str) -> None:
         """Refresh maps based on a policy JSON file."""

--- a/pyisolate/bpf/resource_guard.bpf.c
+++ b/pyisolate/bpf/resource_guard.bpf.c
@@ -1,30 +1,192 @@
 #define SEC(NAME) __attribute__((section(NAME), used))
 
-/* Event structure sent to user space via a ring buffer. */
-struct event_t {
-    unsigned long cgroup_id;
-    unsigned long cpu_time_ns;
-    unsigned long rss_bytes;
+/* Per-cgroup resource accounting and quota breach events for PyIsolate. */
+
+typedef unsigned int __u32;
+typedef unsigned long long __u64;
+
+#define BPF_MAP_TYPE_HASH 1
+#define BPF_MAP_TYPE_PERCPU_HASH 5
+#define BPF_MAP_TYPE_RINGBUF 27
+
+#define PYI_RESOURCE_CPU 1U
+#define PYI_RESOURCE_RSS 2U
+#define PYI_RESOURCE_NET 3U
+
+#define __uint(name, val) int (*name)[val]
+#define __type(name, val) val *name
+
+struct resource_account {
+    __u64 cpu_time_ns;
+    __u64 rss_bytes;
+    __u64 net_bytes;
+    __u64 last_seen_ns;
 };
 
-/* Ring buffer map placeholder. In a real implementation this would use
- * BPF_MAP_TYPE_RINGBUF and helper calls. */
-struct {
-    int dummy;
-} events SEC(".maps");
+struct resource_quota {
+    __u64 cpu_time_ns;
+    __u64 rss_bytes;
+    __u64 net_bytes;
+};
 
-SEC("perf_event")
-int on_cpu(void *ctx)
+struct resource_event {
+    __u64 cgroup_id;
+    __u64 pid_tgid;
+    __u64 observed;
+    __u64 quota;
+    __u32 resource;
+    __u32 breached;
+};
+
+struct sched_switch_args {
+    unsigned long long pad;
+    char prev_comm[16];
+    int prev_pid;
+    int prev_prio;
+    long long prev_state;
+    char next_comm[16];
+    int next_pid;
+    int next_prio;
+};
+
+struct page_fault_args {
+    unsigned long long pad;
+    unsigned long address;
+    unsigned long ip;
+    int error_code;
+};
+
+struct __sk_buff {
+    __u32 len;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 22);
+} resource_events SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+    __uint(max_entries, 16384);
+    __type(key, __u64);
+    __type(value, struct resource_account);
+} cgroup_accounting SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 16384);
+    __type(key, __u64);
+    __type(value, struct resource_quota);
+} cgroup_quotas SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 65536);
+    __type(key, __u64);
+    __type(value, __u64);
+} task_cpu_start SEC(".maps");
+
+static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *)1;
+static long (*bpf_map_update_elem)(void *map, const void *key, const void *value, __u64 flags) = (void *)2;
+static __u64 (*bpf_ktime_get_ns)(void) = (void *)5;
+static __u64 (*bpf_get_current_pid_tgid)(void) = (void *)14;
+static __u64 (*bpf_get_current_cgroup_id)(void) = (void *)80;
+static long (*bpf_ringbuf_output)(void *ringbuf, void *data, __u64 size, __u64 flags) = (void *)130;
+
+static void emit_if_breached(__u64 cg, struct resource_account *account)
 {
-    /* Track per-cgroup CPU time and emit events. Stubbed for tests. */
+    struct resource_quota *quota = bpf_map_lookup_elem(&cgroup_quotas, &cg);
+    struct resource_event event = {};
+
+    if (!quota)
+        return;
+
+    event.cgroup_id = cg;
+    event.pid_tgid = bpf_get_current_pid_tgid();
+    if (quota->cpu_time_ns && account->cpu_time_ns > quota->cpu_time_ns) {
+        event.observed = account->cpu_time_ns;
+        event.quota = quota->cpu_time_ns;
+        event.resource = PYI_RESOURCE_CPU;
+        event.breached = 1;
+        bpf_ringbuf_output(&resource_events, &event, sizeof(event), 0);
+    }
+    if (quota->rss_bytes && account->rss_bytes > quota->rss_bytes) {
+        event.observed = account->rss_bytes;
+        event.quota = quota->rss_bytes;
+        event.resource = PYI_RESOURCE_RSS;
+        event.breached = 1;
+        bpf_ringbuf_output(&resource_events, &event, sizeof(event), 0);
+    }
+    if (quota->net_bytes && account->net_bytes > quota->net_bytes) {
+        event.observed = account->net_bytes;
+        event.quota = quota->net_bytes;
+        event.resource = PYI_RESOURCE_NET;
+        event.breached = 1;
+        bpf_ringbuf_output(&resource_events, &event, sizeof(event), 0);
+    }
+}
+
+static struct resource_account *account_for_current_cgroup(__u64 *cg_out)
+{
+    __u64 cg = bpf_get_current_cgroup_id();
+    struct resource_account zero = {};
+    struct resource_account *account;
+
+    account = bpf_map_lookup_elem(&cgroup_accounting, &cg);
+    if (!account) {
+        zero.last_seen_ns = bpf_ktime_get_ns();
+        bpf_map_update_elem(&cgroup_accounting, &cg, &zero, 0);
+        account = bpf_map_lookup_elem(&cgroup_accounting, &cg);
+    }
+    *cg_out = cg;
+    return account;
+}
+
+SEC("tracepoint/sched/sched_switch")
+int account_sched_switch(struct sched_switch_args *ctx)
+{
+    __u64 cg;
+    __u64 now = bpf_ktime_get_ns();
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u64 *started = bpf_map_lookup_elem(&task_cpu_start, &pid_tgid);
+    struct resource_account *account = account_for_current_cgroup(&cg);
+
+    if (account && started && now > *started) {
+        account->cpu_time_ns += now - *started;
+        account->last_seen_ns = now;
+        emit_if_breached(cg, account);
+    }
+
+    bpf_map_update_elem(&task_cpu_start, &pid_tgid, &now, 0);
     return 0;
 }
 
-SEC("perf_event")
-int on_rss(void *ctx)
+SEC("tracepoint/exceptions/page_fault_user")
+int account_user_page_fault(struct page_fault_args *ctx)
 {
-    /* Track memory usage and emit events. Stubbed for tests. */
+    __u64 cg;
+    struct resource_account *account = account_for_current_cgroup(&cg);
+
+    if (account) {
+        account->rss_bytes += 4096;
+        account->last_seen_ns = bpf_ktime_get_ns();
+        emit_if_breached(cg, account);
+    }
     return 0;
+}
+
+SEC("cgroup_skb/egress")
+int account_cgroup_egress(struct __sk_buff *skb)
+{
+    __u64 cg;
+    struct resource_account *account = account_for_current_cgroup(&cg);
+
+    if (account) {
+        account->net_bytes += skb->len;
+        account->last_seen_ns = bpf_ktime_get_ns();
+        emit_if_breached(cg, account);
+    }
+    return 1;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/pyisolate/bpf/syscall_filter.bpf.c
+++ b/pyisolate/bpf/syscall_filter.bpf.c
@@ -1,13 +1,212 @@
 #define SEC(NAME) __attribute__((section(NAME), used))
 
-/* Minimal syscall filter program. Returns 0 to allow all syscalls.
- * Real implementation would inspect arguments and decide.
+/*
+ * Kernel policy filter for PyIsolate sandboxes.
+ *
+ * The supervisor pins and updates these maps under /sys/fs/bpf/pyisolate.
+ * Every decision is keyed by bpf_get_current_cgroup_id(), so enforcement follows
+ * the sandbox cgroup even when guest code bypasses Python wrappers and performs
+ * syscalls directly through libc or native extensions.
  */
 
-SEC("lsm/file_open")
-int filter_file_open(void *ctx)
+typedef unsigned char __u8;
+typedef unsigned int __u32;
+typedef unsigned long long __u64;
+
+#define EPERM 1
+#define AF_INET 2
+#define AF_INET6 10
+
+#define BPF_MAP_TYPE_HASH 1
+#define BPF_MAP_TYPE_LRU_HASH 9
+#define BPF_MAP_TYPE_RINGBUF 27
+
+#define PYI_DENY_FS       (1U << 0)
+#define PYI_DENY_NET      (1U << 1)
+#define PYI_DENY_PROCESS  (1U << 2)
+#define PYI_DENY_RISKY    (1U << 3)
+
+#define PYI_OP_FILE_OPEN       1U
+#define PYI_OP_FILE_TRUNCATE   2U
+#define PYI_OP_SOCKET_CONNECT  3U
+#define PYI_OP_SOCKET_CREATE   4U
+#define PYI_OP_TASK_ALLOC      5U
+#define PYI_OP_EXEC            6U
+#define PYI_OP_PTRACE          7U
+#define PYI_OP_MOUNT           8U
+#define PYI_OP_BPF             9U
+
+#define __uint(name, val) int (*name)[val]
+#define __type(name, val) val *name
+
+union bpf_attr;
+
+struct sockaddr {
+    unsigned short sa_family;
+    char sa_data[14];
+};
+
+struct pyisolate_policy {
+    __u32 deny_mask;
+    __u32 audit_only;
+};
+
+struct pyisolate_decision_key {
+    __u64 cgroup_id;
+    __u32 op;
+    __u32 aux;
+};
+
+struct pyisolate_decision {
+    __u64 cgroup_id;
+    __u64 pid_tgid;
+    __u32 op;
+    __u32 denied;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 16384);
+    __type(key, __u64);
+    __type(value, struct pyisolate_policy);
+} sandbox_policy SEC(".maps");
+
+/* Optional per-operation overrides used for hot reload tests and staged rollout. */
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, 65536);
+    __type(key, struct pyisolate_decision_key);
+    __type(value, __u32);
+} syscall_policy SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 20);
+} syscall_events SEC(".maps");
+
+static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *)1;
+static long (*bpf_ringbuf_output)(void *ringbuf, void *data, __u64 size, __u64 flags) = (void *)130;
+static __u64 (*bpf_get_current_cgroup_id)(void) = (void *)80;
+static __u64 (*bpf_get_current_pid_tgid)(void) = (void *)14;
+
+static __u32 policy_mask_for_op(__u32 op)
 {
+    if (op == PYI_OP_FILE_OPEN || op == PYI_OP_FILE_TRUNCATE)
+        return PYI_DENY_FS;
+    if (op == PYI_OP_SOCKET_CONNECT || op == PYI_OP_SOCKET_CREATE)
+        return PYI_DENY_NET;
+    if (op == PYI_OP_TASK_ALLOC || op == PYI_OP_EXEC)
+        return PYI_DENY_PROCESS;
+    return PYI_DENY_RISKY;
+}
+
+static int pyisolate_check(__u32 op, __u32 aux)
+{
+    __u64 cg = bpf_get_current_cgroup_id();
+    struct pyisolate_policy *policy;
+    struct pyisolate_decision_key key = {};
+    __u32 *override;
+    __u32 denied = 0;
+
+    key.cgroup_id = cg;
+    key.op = op;
+    key.aux = aux;
+    override = bpf_map_lookup_elem(&syscall_policy, &key);
+    if (override)
+        denied = *override;
+    else {
+        policy = bpf_map_lookup_elem(&sandbox_policy, &cg);
+        if (policy && (policy->deny_mask & policy_mask_for_op(op)))
+            denied = policy->audit_only ? 0 : 1;
+    }
+
+    if (denied) {
+        struct pyisolate_decision event = {};
+        event.cgroup_id = cg;
+        event.pid_tgid = bpf_get_current_pid_tgid();
+        event.op = op;
+        event.denied = 1;
+        bpf_ringbuf_output(&syscall_events, &event, sizeof(event), 0);
+        return -EPERM;
+    }
     return 0;
+}
+
+SEC("lsm/file_open")
+int BPF_PROG_filter_file_open(void *file, int ret)
+{
+    if (ret)
+        return ret;
+    return pyisolate_check(PYI_OP_FILE_OPEN, 0);
+}
+
+SEC("lsm/file_truncate")
+int BPF_PROG_filter_file_truncate(void *file, int ret)
+{
+    if (ret)
+        return ret;
+    return pyisolate_check(PYI_OP_FILE_TRUNCATE, 0);
+}
+
+SEC("lsm/socket_create")
+int BPF_PROG_filter_socket_create(int family, int type, int protocol, int kern, int ret)
+{
+    if (ret)
+        return ret;
+    if (family == AF_INET || family == AF_INET6)
+        return pyisolate_check(PYI_OP_SOCKET_CREATE, (__u32)family);
+    return 0;
+}
+
+SEC("lsm/socket_connect")
+int BPF_PROG_filter_socket_connect(void *sock, struct sockaddr *address, int addrlen, int ret)
+{
+    if (ret)
+        return ret;
+    if (address && (address->sa_family == AF_INET || address->sa_family == AF_INET6))
+        return pyisolate_check(PYI_OP_SOCKET_CONNECT, (__u32)address->sa_family);
+    return 0;
+}
+
+SEC("lsm/task_alloc")
+int BPF_PROG_filter_task_alloc(void *task, unsigned long clone_flags, int ret)
+{
+    if (ret)
+        return ret;
+    return pyisolate_check(PYI_OP_TASK_ALLOC, 0);
+}
+
+SEC("lsm/bprm_check_security")
+int BPF_PROG_filter_exec(void *bprm, int ret)
+{
+    if (ret)
+        return ret;
+    return pyisolate_check(PYI_OP_EXEC, 0);
+}
+
+SEC("lsm/ptrace_access_check")
+int BPF_PROG_filter_ptrace(void *child, unsigned int mode, int ret)
+{
+    if (ret)
+        return ret;
+    return pyisolate_check(PYI_OP_PTRACE, mode);
+}
+
+SEC("lsm/sb_mount")
+int BPF_PROG_filter_mount(const char *dev_name, const void *path, const char *type,
+                          unsigned long flags, void *data, int ret)
+{
+    if (ret)
+        return ret;
+    return pyisolate_check(PYI_OP_MOUNT, 0);
+}
+
+SEC("lsm/bpf")
+int BPF_PROG_filter_bpf(int cmd, union bpf_attr *attr, unsigned int size, int ret)
+{
+    if (ret)
+        return ret;
+    return pyisolate_check(PYI_OP_BPF, (__u32)cmd);
 }
 
 char _license[] SEC("license") = "GPL";

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -133,7 +133,14 @@ class Supervisor:
         bpf_mod = importlib.import_module("pyisolate.bpf.manager")
         self._bpf = bpf_mod.BPFManager()
         self._rollout_mode = rollout_mode
-        self._bpf.load(mode=rollout_mode)
+        try:
+            self._bpf.load(mode=rollout_mode)
+        except TypeError as exc:
+            if "unexpected keyword argument 'mode'" not in str(exc):
+                raise
+            # Backward-compatible path for tests or integrations that provide a
+            # legacy BPFManager.load(strict=...) shim.
+            self._bpf.load(strict=rollout_mode == "hardened")
         self._recover_state()
         self._warm_pool: list[SandboxThread] = []
         for i in range(warm_pool):

--- a/tests/test_bpf_kernel_enforcement.py
+++ b/tests/test_bpf_kernel_enforcement.py
@@ -1,0 +1,104 @@
+import os
+import shutil
+import socket
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pyisolate.bpf.manager import BPFManager
+
+ROOT = Path(__file__).resolve().parents[1]
+SYSCALL_FILTER = ROOT / "pyisolate" / "bpf" / "syscall_filter.bpf.c"
+RESOURCE_GUARD = ROOT / "pyisolate" / "bpf" / "resource_guard.bpf.c"
+
+
+def test_syscall_filter_uses_lsm_hooks_and_cgroup_policy_maps():
+    src = SYSCALL_FILTER.read_text()
+
+    assert 'SEC("lsm/file_open")' in src
+    assert 'SEC("lsm/socket_connect")' in src
+    assert 'SEC("lsm/socket_create")' in src
+    assert 'SEC("lsm/task_alloc")' in src
+    assert 'SEC("lsm/bprm_check_security")' in src
+    assert 'SEC("lsm/ptrace_access_check")' in src
+    assert 'SEC("lsm/sb_mount")' in src
+    assert 'SEC("lsm/bpf")' in src
+    assert "bpf_get_current_cgroup_id" in src
+    assert "sandbox_policy" in src
+    assert "syscall_policy" in src
+    assert "return -EPERM" in src
+
+
+def test_resource_guard_uses_ringbuf_and_per_cgroup_accounting_maps():
+    src = RESOURCE_GUARD.read_text()
+
+    assert "BPF_MAP_TYPE_RINGBUF" in src
+    assert "resource_events" in src
+    assert "cgroup_accounting" in src
+    assert "cgroup_quotas" in src
+    assert 'SEC("tracepoint/sched/sched_switch")' in src
+    assert 'SEC("tracepoint/exceptions/page_fault_user")' in src
+    assert 'SEC("cgroup_skb/egress")' in src
+    assert "emit_if_breached" in src
+
+
+def test_manager_loads_and_attaches_kernel_programs(monkeypatch):
+    calls = []
+
+    def record(self, cmd, *, raise_on_error=False):
+        calls.append(cmd)
+        return True
+
+    monkeypatch.setattr(BPFManager, "_run", record)
+    mgr = BPFManager()
+
+    mgr.load(mode="hardened")
+
+    assert any(cmd[:3] == ["bpftool", "prog", "loadall"] and "autoattach" in cmd for cmd in calls)
+    assert any(cmd[:3] == ["bpftool", "cgroup", "attach"] for cmd in calls)
+    assert mgr.loaded is True
+
+
+@pytest.mark.skipif(
+    os.environ.get("PYISOLATE_LIVE_BPF_TESTS") != "1"
+    or os.geteuid() != 0
+    or shutil.which("bpftool") is None,
+    reason="live kernel-enforcement test requires root, bpftool, and PYISOLATE_LIVE_BPF_TESTS=1",
+)
+def test_live_kernel_policy_blocks_unwrapped_file_network_and_process_actions(tmp_path):
+    """Exercise kernel policy directly; no PyIsolate Python wrappers are used."""
+
+    mgr = BPFManager()
+    mgr.load(mode="hardened")
+
+    cgroup_id = os.stat("/sys/fs/cgroup").st_ino
+    key = cgroup_id.to_bytes(8, "little")
+    value = (15).to_bytes(4, "little") + (0).to_bytes(4, "little")
+    policy_map = "/sys/fs/bpf/pyisolate/sandbox_policy"
+    subprocess.run(
+        [
+            "bpftool",
+            "map",
+            "update",
+            "pinned",
+            policy_map,
+            "key",
+            "hex",
+            *[f"{byte:02x}" for byte in key],
+            "value",
+            "hex",
+            *[f"{byte:02x}" for byte in value],
+            "any",
+        ],
+        check=True,
+    )
+
+    with pytest.raises(PermissionError):
+        (tmp_path / "blocked.txt").write_text("blocked by LSM")
+
+    with pytest.raises(OSError):
+        socket.create_connection(("127.0.0.1", 9), timeout=0.05)
+
+    with pytest.raises(PermissionError):
+        subprocess.run(["/bin/true"], check=True)

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -68,20 +68,37 @@ def test_load_runs_toolchain(monkeypatch):
     assert ["llvm-objdump", "-d", str(mgr._obj)] in calls
     assert ["llvm-objdump", "-d", str(mgr._filter_obj)] in calls
     assert ["llvm-objdump", "-d", str(mgr._guard_obj)] in calls
-    assert ["bpftool", "prog", "load", str(mgr._obj), "/sys/fs/bpf/dummy"] in calls
+    assert ["bpftool", "prog", "load", str(mgr._obj), str(mgr._dummy_pin)] in calls
     assert [
         "bpftool",
         "prog",
-        "load",
+        "loadall",
         str(mgr._filter_obj),
-        "/sys/fs/bpf/syscall_filter",
+        str(mgr._filter_pin_dir),
+        "type",
+        "lsm",
+        "pinmaps",
+        str(mgr._bpffs_root),
+        "autoattach",
     ] in calls
     assert [
         "bpftool",
         "prog",
-        "load",
+        "loadall",
         str(mgr._guard_obj),
-        "/sys/fs/bpf/resource_guard",
+        str(mgr._guard_pin_dir),
+        "pinmaps",
+        str(mgr._bpffs_root),
+        "autoattach",
+    ] in calls
+    assert [
+        "bpftool",
+        "cgroup",
+        "attach",
+        "/sys/fs/cgroup",
+        "egress",
+        "pinned",
+        str(mgr._guard_pin_dir / "account_cgroup_egress"),
     ] in calls
     assert mgr.loaded
 
@@ -220,7 +237,7 @@ def test_load_compatibility_skips_strict_programs(monkeypatch):
         "prog",
         "load",
         str(mgr._obj),
-        "/sys/fs/bpf/dummy",
+        str(mgr._dummy_pin),
     ] in calls
     assert ["llvm-objdump", "-d", str(mgr._filter_obj)] not in calls
     assert ["llvm-objdump", "-d", str(mgr._guard_obj)] not in calls

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -28,10 +28,16 @@ class _StubBPFManager:
 
 bpf_stub = types.ModuleType("pyisolate.bpf.manager")
 bpf_stub.BPFManager = _StubBPFManager  # type: ignore[attr-defined]
+_original_bpf_manager = sys.modules.get("pyisolate.bpf.manager")
 sys.modules["pyisolate.bpf.manager"] = bpf_stub
 
 import pyisolate as iso
 from pyisolate.observability.metrics import MetricsExporter
+
+if _original_bpf_manager is None:
+    sys.modules.pop("pyisolate.bpf.manager", None)
+else:
+    sys.modules["pyisolate.bpf.manager"] = _original_bpf_manager
 
 
 def test_export_contains_metrics():


### PR DESCRIPTION
### Motivation

- Enforce sandbox policies in-kernel so unwrapped syscalls (libc/native extensions) cannot bypass Python-level checks. 
- Replace test/placeholders with realistic BPF artifacts: LSM hooks for syscall decisions and ring-buffer / per-cgroup accounting for resource watchdog events. 
- Make `hardened` the documented production posture and provide compatibility for test environments that lack full BPF toolchain.

### Description

- Replaced `pyisolate/bpf/syscall_filter.bpf.c` with LSM-based programs that consult pinned maps keyed by `bpf_get_current_cgroup_id()` and emit denial events to a ring buffer when a decision returns deny. 
- Replaced `pyisolate/bpf/resource_guard.bpf.c` placeholders with a real design using `BPF_MAP_TYPE_RINGBUF` for `resource_events`, per-cgroup accounting maps (`cgroup_accounting`, `cgroup_quotas`, `task_cpu_start`), and tracepoint/cgroup hooks to update CPU/RSS/net and emit quota-breach events. 
- Updated `pyisolate/bpf/manager.py::BPFManager.load` to: compile objects, pin under `/sys/fs/bpf/pyisolate`, use `bpftool prog loadall ... autoattach` for LSM/tracepoint programs, and run an explicit `bpftool cgroup attach ... egress pinned` step for kernels/tools that require a concrete cgroup attach. 
- Documented `hardened` as the production default in `README.md` and clarified `dev`/`compatibility` as caller-acknowledged weaker modes. 
- Added an opt-in live kernel-enforcement integration test and static checks in `tests/test_bpf_kernel_enforcement.py` and adjusted unit tests to expect the new `bpftool` invocation patterns and pinning layout. 
- Added small compatibility guards: handle legacy `BPFManager.load(strict=...)` call sites in the supervisor constructor and avoid leaking test module stubs (restore `pyisolate.bpf.manager` after metrics test stub). 

### Testing

- Ran targeted BPF-related tests: `pytest -q tests/test_bpf_manager.py tests/test_bpf_manager_extra.py tests/test_bpf_kernel_enforcement.py`, which passed in the CI/test environment. 
- Performed static validation with `python -m py_compile` on modified modules which succeeded. 
- Attempted to compile the BPF C files with `clang -target bpf -O2 -c ...` but the environment clang lacks a BPF backend (`No available targets are compatible with triple "bpf"`), so native object builds were not performed here. 
- Ran full test-suite locally; targeted BPF suite passed but there remain 4 failures in unrelated supervisor/policy test ordering and token-handling tests that are not caused by the BPF program logic (noted in logs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04715b6b7483289696f185ec422881)