### PR TITLE
Resolve named policies before sandbox spawn

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -80,14 +80,32 @@ class IpcLimiter(PolicyPlugin):
 register_plugin(IpcLimiter)
 ```
 
-## 6  Policy templates
+## 6  Policy templates and public names
 
-Several ready-to-use policies are included under the `policy/` directory:
+Named policies live as YAML files in the repository-level `policy/` directory.
+Sandbox creation APIs resolve public string names with `pyisolate.policy.resolve_policy()`
+before a `SandboxThread` is constructed. Unknown names fail closed with
+`PolicyCompilerError` rather than falling back to an unconstrained sandbox.
 
-| File | Intended use |
-|------|--------------|
-| `ml.yml` | Machine learning jobs with outbound HTTPS and generous quotas |
-| `web_scraper.yml` | Basic web scraping with only HTTP/HTTPS access |
+Supported public names are:
 
-Load any template with `pyisolate.policy.refresh("policy/<name>.yml", token)` and the
-new limits take effect instantly.
+| Public name | File | Intended use |
+|-------------|------|--------------|
+| `stdlib.readonly` | `policy/stdlib.readonly.yml` | Standard-library-oriented sandbox with a small import allow-list, `/tmp` filesystem access, and no outbound network. |
+| `ml-inference` | `policy/ml-inference.yml` | Offline ML inference workloads with model/data paths and no outbound network by default. |
+| `readonly-fs` | `policy/readonly-fs.yml` | Filesystem-focused sandbox rooted at `/tmp` with no imports or outbound network by default. |
+| `ml` | `policy/ml.yml` | Legacy machine learning template loaded by filename stem. |
+| `web_scraper` | `policy/web_scraper.yml` | Legacy web scraping template loaded by filename stem. |
+
+Use a public name directly when spawning a sandbox:
+
+```python
+import pyisolate as iso
+
+with iso.spawn("worker", policy="stdlib.readonly") as sb:
+    sb.exec("import math; post(math.sqrt(16))")
+```
+
+You can still hot-reload a template with
+`pyisolate.policy.refresh("policy/<name>.yml", token)` when updating live eBPF maps;
+the resolver is for sandbox construction-time policy selection.

--- a/policy/ml-inference.yml
+++ b/policy/ml-inference.yml
@@ -1,0 +1,12 @@
+# Offline ML inference sandbox template.
+version: 1.0
+imports:
+  - math
+  - json
+  - statistics
+  - pathlib
+fs:
+  - allow: "/tmp"
+  - allow: "/srv/models"
+  - allow: "/srv/data"
+net: []

--- a/policy/readonly-fs.yml
+++ b/policy/readonly-fs.yml
@@ -1,0 +1,6 @@
+# Filesystem-focused template with no imports or outbound network by default.
+version: 1.0
+fs:
+  - allow: "/tmp"
+net: []
+imports: []

--- a/policy/stdlib.readonly.yml
+++ b/policy/stdlib.readonly.yml
@@ -1,0 +1,11 @@
+# Standard-library-only sandbox template.
+version: 1.0
+imports:
+  - math
+  - json
+  - pathlib
+  - statistics
+  - socket
+fs:
+  - allow: "/tmp"
+net: []

--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -74,7 +74,7 @@ except (ModuleNotFoundError, ImportError) as exc:  # pragma: no cover - optional
         raise ModuleNotFoundError("cryptography is required for migration support")
 
 
-from .policy import refresh_remote  # noqa: F401
+from .policy import refresh_remote, resolve_policy  # noqa: F401
 from .sdk import Pipeline, sandbox  # noqa: F401
 from .subset import OwnershipError, RestrictedExec  # noqa: F401
 from .supervisor import (
@@ -130,6 +130,7 @@ __all__ = [
     "restore",
     "migrate",
     "refresh_remote",
+    "resolve_policy",
     "setup_structured_logging",
     "bpf",
 ]

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -68,7 +68,13 @@ except ModuleNotFoundError:  # minimal fallback when PyYAML is unavailable
     yaml = _MiniYaml()
 
 
-from .compiler import PolicyCompilerError, compile_policy  # noqa: F401
+from .compiler import (
+    CompiledPolicy,
+    PolicyCompilerError,
+    SandboxPolicy,
+    compile_policy,
+)  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 
@@ -194,10 +200,171 @@ def refresh_remote(
         os.unlink(tmp_path)
 
 
+def _policy_root() -> Path:
+    """Return the repository-level directory that stores named policy YAML files."""
+
+    return Path(__file__).resolve().parents[2] / "policy"
+
+
+NAMED_POLICIES: dict[str, str] = {
+    "stdlib.readonly": "stdlib.readonly.yml",
+    "ml-inference": "ml-inference.yml",
+    "readonly-fs": "readonly-fs.yml",
+}
+
+
+def _select_sandbox_policy(compiled, selector: str | None = None):
+    sandboxes = compiled.sandboxes
+    if selector and selector in sandboxes:
+        return sandboxes[selector]
+    if "default" in sandboxes:
+        return sandboxes["default"]
+    if len(sandboxes) == 1:
+        return next(iter(sandboxes.values()))
+    available = ", ".join(sorted(sandboxes))
+    raise PolicyCompilerError(
+        "policy document contains multiple sandboxes; " f"select one of: {available}"
+    )
+
+
+def _runtime_policy_from_sandbox(sandbox_policy: SandboxPolicy) -> Policy:
+    runtime = Policy()
+    for rule in sandbox_policy.fs:
+        if rule.action == "allow":
+            runtime.allow_fs(rule.path)
+    for rule in sandbox_policy.tcp:
+        if rule.action == "connect":
+            runtime.allow_tcp(rule.addr)
+    for module in sandbox_policy.imports:
+        runtime.allow_import(module)
+    return runtime
+
+
+def _runtime_policy_from_dict(data: dict) -> Policy:
+    if "sandboxes" in data:
+        sandboxes = data.get("sandboxes")
+        if not isinstance(sandboxes, dict):
+            raise PolicyCompilerError("missing or invalid 'sandboxes' section")
+        selector = "default" if "default" in sandboxes else None
+        if selector is None and len(sandboxes) == 1:
+            selector = next(iter(sandboxes))
+        if selector is None:
+            available = ", ".join(sorted(str(k) for k in sandboxes))
+            raise PolicyCompilerError(
+                "policy mapping contains multiple sandboxes; "
+                f"select one of: {available}"
+            )
+        selected = sandboxes[selector]
+        if not isinstance(selected, dict):
+            raise PolicyCompilerError(f"sandbox '{selector}' must be a mapping")
+        merged = dict(data.get("defaults") or {})
+        merged.update(selected)
+        data = merged
+
+    runtime = Policy()
+    fs_rules = data.get("fs", []) or []
+    if not isinstance(fs_rules, list):
+        raise PolicyCompilerError("'fs' must be a list")
+    for rule in fs_rules:
+        if isinstance(rule, str):
+            runtime.allow_fs(rule)
+        elif isinstance(rule, dict) and len(rule) == 1:
+            action, path = next(iter(rule.items()))
+            if action == "allow" and isinstance(path, str):
+                runtime.allow_fs(path)
+            elif action not in {"allow", "deny"}:
+                raise PolicyCompilerError(f"invalid fs action '{action}'")
+        else:
+            raise PolicyCompilerError(f"invalid fs rule: {rule!r}")
+
+    net_rules = data.get("net", data.get("tcp", [])) or []
+    if not isinstance(net_rules, list):
+        raise PolicyCompilerError("'net' must be a list")
+    for rule in net_rules:
+        if isinstance(rule, str):
+            runtime.allow_tcp(rule)
+        elif isinstance(rule, dict) and len(rule) == 1:
+            action, addr = next(iter(rule.items()))
+            if action == "connect":
+                addresses = addr if isinstance(addr, list) else [addr]
+                for address in addresses:
+                    if not isinstance(address, str):
+                        raise PolicyCompilerError(
+                            f"net addresses must be strings: {address!r}"
+                        )
+                    runtime.allow_tcp(address)
+            elif action != "deny":
+                raise PolicyCompilerError(f"invalid net action '{action}'")
+        else:
+            raise PolicyCompilerError(f"invalid net rule: {rule!r}")
+
+    imports = data.get("imports", []) or []
+    if not isinstance(imports, list):
+        raise PolicyCompilerError("'imports' must be a list")
+    for module in imports:
+        if not isinstance(module, str):
+            raise PolicyCompilerError(f"import rules must be strings: {module!r}")
+        runtime.allow_import(module)
+    return runtime
+
+
+def _resolve_policy_path(name: str) -> Path:
+    candidate = Path(name)
+    if candidate.exists():
+        return candidate
+
+    policy_root = _policy_root()
+    mapped = NAMED_POLICIES.get(name)
+    if mapped is not None:
+        path = policy_root / mapped
+        if path.exists():
+            return path
+        raise PolicyCompilerError(
+            f"named policy '{name}' is registered but {path} does not exist"
+        )
+
+    for suffix in (".yml", ".yaml"):
+        path = policy_root / f"{name}{suffix}"
+        if path.exists():
+            return path
+
+    supported = ", ".join(sorted(NAMED_POLICIES))
+    raise PolicyCompilerError(
+        f"unknown policy '{name}'. Supported named policies: {supported}"
+    )
+
+
+def resolve_policy(policy: str | Policy | SandboxPolicy | CompiledPolicy | dict | None):
+    """Resolve public policy inputs to the runtime policy applied by a sandbox.
+
+    String inputs are fail-closed: they must name an existing file in ``policy/``
+    or a supported named policy, otherwise :class:`PolicyCompilerError` is raised.
+    """
+
+    if policy is None or isinstance(policy, Policy):
+        return policy
+    if isinstance(policy, SandboxPolicy):
+        return _runtime_policy_from_sandbox(policy)
+    if isinstance(policy, CompiledPolicy):
+        return _runtime_policy_from_sandbox(_select_sandbox_policy(policy))
+    if isinstance(policy, dict):
+        return _runtime_policy_from_dict(policy)
+    if isinstance(policy, str):
+        path = _resolve_policy_path(policy)
+        compiled = compile_policy(path)
+        selector = path.stem if path.stem in compiled.sandboxes else policy
+        return _runtime_policy_from_sandbox(_select_sandbox_policy(compiled, selector))
+    raise ValueError(f"unsupported policy type: {type(policy).__name__}")
+
+
 __all__ = [
     "Policy",
     "refresh",
     "compile_policy",
     "PolicyCompilerError",
     "refresh_remote",
+    "resolve_policy",
+    "NAMED_POLICIES",
+    "SandboxPolicy",
+    "CompiledPolicy",
 ]

--- a/pyisolate/sdk.py
+++ b/pyisolate/sdk.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from .policy import Policy, resolve_policy
 from .supervisor import spawn
 
 
 def sandbox(
-    policy: str | None = None, timeout: float | None = None
+    policy: str | Policy | dict | None = None, timeout: float | None = None
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorate a function to run inside a sandbox when called.
 
@@ -23,7 +24,8 @@ def sandbox(
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            sb = spawn(func.__name__, policy=policy)
+            resolved_policy = resolve_policy(policy)
+            sb = spawn(func.__name__, policy=resolved_policy)
             try:
                 return sb.call(
                     f"{func.__module__}.{func.__name__}",
@@ -43,10 +45,12 @@ class Pipeline:
     """Sequential sandboxed stages."""
 
     def __init__(self) -> None:
-        self._stages: list[tuple[str, str | None]] = []
+        self._stages: list[tuple[str, str | Policy | dict | None]] = []
 
     def add_stage(
-        self, stage: str | Callable[[Any], Any], policy: str | None = None
+        self,
+        stage: str | Callable[[Any], Any],
+        policy: str | Policy | dict | None = None,
     ) -> "Pipeline":
         """Register a stage by dotted path or callable."""
         if callable(stage):
@@ -61,6 +65,7 @@ class Pipeline:
         value = data
         for dotted, policy in self._stages:
             name = dotted.rsplit(".", 1)[-1]
-            with spawn(name, policy=policy) as sb:
+            resolved_policy = resolve_policy(policy)
+            with spawn(name, policy=resolved_policy) as sb:
                 value = sb.call(dotted, value)
         return value

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -20,6 +20,7 @@ from .capabilities import ROOT, RootCapability
 from .errors import PolicyAuthError, TenantQuotaExceeded
 from .observability.alerts import AlertManager
 from .observability.trace import Tracer
+from .policy import resolve_policy
 from .runtime.protocol import CapabilityHandle, ControlRequest
 from .runtime.thread import SandboxThread
 from .watchdog import ResourceWatchdog
@@ -222,6 +223,8 @@ class Supervisor:
             raise ValueError("Sandbox name contains invalid characters")
         self._cleanup()
 
+        policy = resolve_policy(policy)
+
         if policy is not None and getattr(policy, "imports", None):
             imports = set(policy.imports)
             if allowed_imports is not None:
@@ -321,14 +324,16 @@ class Supervisor:
         with self._lock:
             return [t for t in self._sandboxes.values() if t.is_alive()]
 
-    def _authorize_control(self, token: str | RootCapability, op: str) -> ControlRequest:
+    def _authorize_control(
+        self, token: str | RootCapability, op: str
+    ) -> ControlRequest:
         """Validate an authenticated control-plane operation request."""
 
         if token is ROOT:
             handle = CapabilityHandle(kind="root", subject=op)
         else:
             if self._policy_token is None or token != self._policy_token:
-                logger.warning("control operation rejected: %s", op)
+                logger.warning("control operation rejected: %s (invalid token)", op)
                 raise PolicyAuthError("invalid policy token")
             handle = CapabilityHandle(kind="policy-token", subject=op)
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -170,7 +170,9 @@ def test_validation_bad_section_type(tmp_path):
         ("version: 0.1\nsandboxes: []\n", "sandboxes"),
     ],
 )
-def test_refresh_validation_fails_before_compile_or_reload(monkeypatch, tmp_path, doc, msg):
+def test_refresh_validation_fails_before_compile_or_reload(
+    monkeypatch, tmp_path, doc, msg
+):
     policy = load_policy(no_yaml=True)
     import pyisolate as iso
 
@@ -264,11 +266,7 @@ def test_refresh_dry_run_compiles_without_reload(monkeypatch, tmp_path):
     iso.set_policy_token("tok")
     path = tmp_path / "p.yml"
     path.write_text(
-        "version: 1\n"
-        "sandboxes:\n"
-        "  sb:\n"
-        "    fs:\n"
-        '      - allow: "/tmp"\n'
+        "version: 1\n" "sandboxes:\n" "  sb:\n" "    fs:\n" '      - allow: "/tmp"\n'
     )
 
     compiled = policy.refresh(str(path), token="tok", dry_run=True)
@@ -305,7 +303,10 @@ def test_compile_policy_supports_inheritance_and_defaults(tmp_path):
     assert [r.path for r in child.fs] == ["/srv/base", "/srv/child"]
     assert [r.addr for r in child.tcp] == ["10.0.0.0/8"]
     assert child.imports == ["math", "json"]
-    assert compiled.deny_log == ["sandbox=base net=10.0.0.0/8", "sandbox=child net=10.0.0.0/8"]
+    assert compiled.deny_log == [
+        "sandbox=base net=10.0.0.0/8",
+        "sandbox=child net=10.0.0.0/8",
+    ]
 
 
 def test_refresh_logs_explicit_deny_rules(tmp_path, caplog, monkeypatch):
@@ -317,11 +318,7 @@ def test_refresh_logs_explicit_deny_rules(tmp_path, caplog, monkeypatch):
     )
     iso.set_policy_token("tok")
     path = tmp_path / "deny.yml"
-    path.write_text(
-        "version: 0.1\n"
-        "net:\n"
-        '  - deny: "10.0.0.0/8"\n'
-    )
+    path.write_text("version: 0.1\n" "net:\n" '  - deny: "10.0.0.0/8"\n')
     with caplog.at_level("WARNING"):
         policy.refresh(str(path), token="tok")
     assert "policy deny rule active" in caplog.text
@@ -374,3 +371,46 @@ def test_reload_policy_rejects_non_canonical_root(monkeypatch, tmp_path, caplog)
         with pytest.raises(iso.PolicyAuthError):
             iso.reload_policy(str(path), token=fake)
     assert "invalid token" in caplog.text
+
+
+def test_resolve_unknown_policy_fails_closed():
+    import pyisolate.policy as policy
+
+    with pytest.raises(policy.PolicyCompilerError, match="unknown policy"):
+        policy.resolve_policy("does-not-exist")
+
+
+def test_named_policy_applies_runtime_restrictions(tmp_path):
+    import pyisolate as iso
+
+    allowed = tmp_path / "allowed.txt"
+    allowed.write_text("ok")
+
+    sb = iso.spawn("named-policy", policy="stdlib.readonly")
+    try:
+        sb.exec("import math; post(math.sqrt(25))")
+        assert sb.recv(timeout=1) == 5.0
+
+        sb.exec("import random")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+
+        sb.exec(f"post(open({str(allowed)!r}).read())")
+        assert sb.recv(timeout=1) == "ok"
+
+        sb.exec("post(open('/etc/hosts').read())")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+
+        sb.exec(
+            "import socket\n"
+            "s = socket.socket()\n"
+            "try:\n"
+            "    s.connect(('127.0.0.1', 9))\n"
+            "finally:\n"
+            "    s.close()\n"
+        )
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()


### PR DESCRIPTION
### Motivation
- Ensure public policy strings map to concrete runtime restrictions instead of allowing unconstrained sandboxes when a name/path is provided.
- Provide a single resolver to accept `str`, `dict`, compiled policy objects, `SandboxPolicy`, and `Policy` inputs for consistent behavior across APIs.

### Description
- Add `resolve_policy(...)` in `pyisolate/policy/__init__.py` that: resolves file paths and registered public names under `policy/`, parses compiled or dict policy inputs, converts `SandboxPolicy`/`CompiledPolicy` to runtime `Policy`, and raises `PolicyCompilerError` for unknown named strings. (`pyisolate/policy/__init__.py`)
- Wire the resolver into sandbox construction by calling `policy = resolve_policy(policy)` early in `Supervisor.spawn` so `SandboxThread` always receives a runtime `Policy` object. (`pyisolate/supervisor.py`)
- Update SDK helpers to resolve `policy` in the `@sandbox` decorator and in `Pipeline` stages before calling `spawn`. (`pyisolate/sdk.py`)
- Add repository-level named policy templates under `policy/` and document supported public names and resolution semantics in `POLICY.md` (examples: `stdlib.readonly`, `ml-inference`, `readonly-fs`).
- Export `resolve_policy` from the package API and include `SandboxPolicy`/`CompiledPolicy` types where needed.

### Testing
- Ran targeted unit tests: `pytest -q tests/test_policy.py::test_resolve_unknown_policy_fails_closed tests/test_policy.py::test_named_policy_applies_runtime_restrictions tests/test_sdk.py` and these tests passed.
- Ran a subset: `pytest -q tests/test_policy.py tests/test_policy_enforcement.py tests/test_sdk.py` and these suites passed.
- Verified bytecode/formatting: `python -m py_compile pyisolate/policy/__init__.py pyisolate/supervisor.py pyisolate/sdk.py` and ran `black` on changed files; both succeeded.
- Full test run (`pytest -q`) was attempted but the run failed due to an unrelated test that injects a stubbed `pyisolate.bpf.manager` into `sys.modules` that does not accept the `mode=` signature used by the supervisor; this is a test-environment interaction and not caused by the resolver changes. All added tests for policy resolution passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04715d14788328856ad3238079d003)