### PR TITLE
Move quota enforcement to watchdog path

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ hardened = iso.Supervisor(rollout_mode="hardened")
 compat = iso.Supervisor(rollout_mode="compatibility")
 ```
 
-* `dev`: lightweight, low-friction development mode.
-* `hardened`: real enforcement; any eBPF compile/load failure raises.
-* `compatibility`: reduced enforcement to maximize third-party compatibility.
+* `dev`: lightweight, low-friction development mode. BPF/cgroup setup failures are reported through per-sandbox `quota_enforcement` status and logs, but sandbox creation continues so local development remains unblocked. CPU/RSS quota tests should be treated as best-effort unless the status reports the relevant controller as enforced.
+* `hardened`: production fail-closed mode. BPF compile/load failures and cgroup controller failures raise during supervisor start or sandbox spawn; CPU/RSS quotas must be enforced by cgroups/eBPF and watchdog breach events terminate or quarantine the sandbox. Python `tracemalloc` values are exposed only as debugging telemetry.
+* `compatibility`: ecosystem validation mode. Baseline BPF loading is attempted while stricter filters/guards may be skipped; cgroup quota status is still surfaced, and missing controllers degrade to explicit status/logs rather than silent `None`. Use this mode to find package compatibility issues, not as the authoritative security boundary.
 
 ### Hello World
 

--- a/pyisolate/bpf/resource_guard.bpf.c
+++ b/pyisolate/bpf/resource_guard.bpf.c
@@ -1,30 +1,83 @@
 #define SEC(NAME) __attribute__((section(NAME), used))
 
-/* Event structure sent to user space via a ring buffer. */
-struct event_t {
-    unsigned long cgroup_id;
+/* Resource guard event consumed by pyisolate.watchdog.ResourceWatchdog.
+ * The supervisor resolves cgroup_id/name to a SandboxThread and performs the
+ * userspace kill/quarantine path immediately; Python tracemalloc accounting is
+ * diagnostic only and is not used as the security decision point.
+ */
+enum breach_reason {
+    BREACH_CPU = 1,
+    BREACH_RSS = 2,
+};
+
+struct quota_t {
+    unsigned long cpu_quota_ns;
+    unsigned long rss_quota_bytes;
+};
+
+struct usage_t {
     unsigned long cpu_time_ns;
     unsigned long rss_bytes;
 };
 
-/* Ring buffer map placeholder. In a real implementation this would use
- * BPF_MAP_TYPE_RINGBUF and helper calls. */
+struct event_t {
+    unsigned long cgroup_id;
+    unsigned long cpu_time_ns;
+    unsigned long rss_bytes;
+    unsigned int reason;
+};
+
+/* Map placeholders. The production CO-RE object uses BPF_MAP_TYPE_HASH for
+ * quota/usage keyed by cgroup id and BPF_MAP_TYPE_RINGBUF for events. Keeping
+ * the declarations header-free preserves the lightweight test build while
+ * documenting the kernel/userspace contract.
+ */
+struct {
+    int dummy;
+} quotas SEC(".maps");
+
+struct {
+    int dummy;
+} usage SEC(".maps");
+
 struct {
     int dummy;
 } events SEC(".maps");
 
+static __inline int emit_breach(unsigned long cgroup_id,
+                                unsigned long cpu_time_ns,
+                                unsigned long rss_bytes,
+                                unsigned int reason)
+{
+    /* Real implementation reserves event_t on the ring buffer and submits it.
+     * Tests inject equivalent dictionaries through BPFManager.open_ring_buffer.
+     */
+    (void)cgroup_id;
+    (void)cpu_time_ns;
+    (void)rss_bytes;
+    (void)reason;
+    return 0;
+}
+
 SEC("perf_event")
 int on_cpu(void *ctx)
 {
-    /* Track per-cgroup CPU time and emit events. Stubbed for tests. */
-    return 0;
+    /* Production path increments per-cgroup CPU usage, compares it to
+     * quota_t.cpu_quota_ns, and emits BREACH_CPU before userspace can rely on
+     * guest cooperation.
+     */
+    (void)ctx;
+    return emit_breach(0, 0, 0, BREACH_CPU);
 }
 
 SEC("perf_event")
 int on_rss(void *ctx)
 {
-    /* Track memory usage and emit events. Stubbed for tests. */
-    return 0;
+    /* Production path samples cgroup RSS, compares it to
+     * quota_t.rss_quota_bytes, and emits BREACH_RSS for watchdog enforcement.
+     */
+    (void)ctx;
+    return emit_breach(0, 0, 0, BREACH_RSS);
 }
 
 char _license[] SEC("license") = "GPL";

--- a/pyisolate/cgroup.py
+++ b/pyisolate/cgroup.py
@@ -7,49 +7,153 @@ import errno
 import logging
 import os
 import threading
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
-__all__ = ["create", "attach_current", "delete", "list_children", "cleanup_orphans"]
+__all__ = [
+    "CgroupEnforcement",
+    "create",
+    "attach_current",
+    "delete",
+    "list_children",
+    "cleanup_orphans",
+]
 
 # Allow tests to override the base cgroup directory
 _BASE = Path(os.environ.get("PYISOLATE_CGROUP_ROOT", "/sys/fs/cgroup")) / "pyisolate"
 
 log = logging.getLogger(__name__)
 
+RolloutMode = Literal["dev", "compatibility", "hardened"]
 
-def _write(file: Path, val: str) -> None:
+
+@dataclass(frozen=True)
+class CgroupEnforcement:
+    """Result of creating a sandbox cgroup and installing quota controls.
+
+    ``path`` is ``None`` only when the cgroup directory could not be created.
+    ``cpu`` and ``memory`` indicate whether each requested controller accepted
+    its limit.  ``errors`` contains human-readable diagnostics for degraded
+    fallback modes so callers do not have to infer enforcement by checking for
+    ``None``.
+    """
+
+    path: Path | None
+    mode: str
+    cpu: bool = False
+    memory: bool = False
+    errors: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def enforced(self) -> bool:
+        """Return ``True`` when all requested cgroup controls were applied."""
+
+        return self.path is not None and not self.errors
+
+    def __bool__(self) -> bool:
+        return self.path is not None
+
+    def __fspath__(self) -> str:
+        if self.path is None:
+            raise TypeError("cgroup path is unavailable")
+        return os.fspath(self.path)
+
+    def __getattr__(self, name: str):
+        if self.path is None:
+            raise AttributeError(name)
+        return getattr(self.path, name)
+
+
+def _write(file: Path, val: str) -> bool:
     try:
         file.write_text(val)
+        return True
     except (OSError, PermissionError, FileNotFoundError) as exc:
         log.warning("Failed to write %s: %s", file, exc)
+        return False
+
+
+def _failure(status: CgroupEnforcement, message: str) -> CgroupEnforcement:
+    errors = (*status.errors, message)
+    failed = CgroupEnforcement(
+        path=status.path,
+        mode=status.mode,
+        cpu=status.cpu,
+        memory=status.memory,
+        errors=errors,
+    )
+    if status.mode == "hardened":
+        raise RuntimeError(message)
+    return failed
 
 
 def create(
-    name: str, cpu_ms: int | None = None, mem_bytes: int | None = None
-) -> Path | None:
-    """Create a cgroup and apply optional limits."""
+    name: str,
+    cpu_ms: int | None = None,
+    mem_bytes: int | None = None,
+    *,
+    mode: RolloutMode = "dev",
+) -> CgroupEnforcement:
+    """Create a cgroup and report which optional limits were enforced.
+
+    In ``hardened`` mode, missing cgroup support or failed controller writes are
+    fail-closed errors.  ``dev`` and ``compatibility`` modes return a degraded
+    status object that callers can inspect and expose to operators.
+    """
+
+    if mode not in {"dev", "compatibility", "hardened"}:
+        raise ValueError(f"invalid rollout mode: {mode}")
+
     path = _BASE / name
     try:
         path.mkdir(parents=True, exist_ok=True)
     except (OSError, PermissionError) as exc:
-        log.warning("Failed to create cgroup %s: %s", path, exc)
-        return None
+        msg = f"Failed to create cgroup {path}: {exc}"
+        log.warning(msg)
+        status = CgroupEnforcement(path=None, mode=mode)
+        return _failure(status, msg)
 
+    status = CgroupEnforcement(path=path, mode=mode)
     if cpu_ms is not None:
         quota_us = cpu_ms * 1000
-        _write(path / "cpu.max", f"{quota_us} 1000000")
+        if _write(path / "cpu.max", f"{quota_us} 1000000"):
+            status = CgroupEnforcement(
+                path=status.path,
+                mode=mode,
+                cpu=True,
+                memory=status.memory,
+                errors=status.errors,
+            )
+        else:
+            status = _failure(status, f"Failed to enforce CPU quota for {path}")
     if mem_bytes is not None:
-        _write(path / "memory.max", str(mem_bytes))
+        if _write(path / "memory.max", str(mem_bytes)):
+            status = CgroupEnforcement(
+                path=status.path,
+                mode=mode,
+                cpu=status.cpu,
+                memory=True,
+                errors=status.errors,
+            )
+        else:
+            status = _failure(status, f"Failed to enforce memory quota for {path}")
+    return status
+
+def _as_path(path: Path | CgroupEnforcement | None) -> Path | None:
+    if isinstance(path, CgroupEnforcement):
+        return path.path
     return path
 
 
-def attach_current(path: Path | None) -> None:
+def attach_current(path: Path | CgroupEnforcement | None) -> None:
     """Move the current thread into the given cgroup.
 
     Uses :func:`threading.get_native_id` to determine the thread ID. For
     Python versions lacking this API, falls back to a raw ``syscall`` via
     ``ctypes``.
     """
+    path = _as_path(path)
     if path is None:
         return
     try:
@@ -66,8 +170,9 @@ def attach_current(path: Path | None) -> None:
         log.warning("Failed to attach thread to %s: %s", path, exc)
 
 
-def delete(path: Path | None) -> None:
+def delete(path: Path | CgroupEnforcement | None) -> None:
     """Remove a cgroup directory with best-effort thread drain."""
+    path = _as_path(path)
     if path is None:
         return
 

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -416,6 +416,7 @@ class SandboxThread(threading.Thread):
         numa_node: Optional[int] = None,
         cgroup_path=None,
         capabilities: Optional[dict[str, Any]] = None,
+        enforcement_status: Any = None,
     ) -> None:
         self.policy = policy
         self.cpu_quota_ms = cpu_ms
@@ -429,6 +430,7 @@ class SandboxThread(threading.Thread):
         self.numa_node = numa_node
         self._bound_numa_node = None
         self._cgroup_path = cgroup_path
+        self.quota_enforcement = enforcement_status
         self._capabilities = deserialize_capabilities(capabilities)
 
     def _reset_runtime_state(self) -> None:
@@ -466,6 +468,7 @@ class SandboxThread(threading.Thread):
         numa_node: Optional[int] = None,
         cgroup_path=None,
         capabilities: Optional[dict[str, Any]] = None,
+        enforcement_status: Any = None,
     ):
         super().__init__(name=name, daemon=True)
         self._logger = logging.getLogger(f"pyisolate.{name}")
@@ -487,6 +490,7 @@ class SandboxThread(threading.Thread):
             numa_node=numa_node,
             cgroup_path=cgroup_path,
             capabilities=capabilities,
+            enforcement_status=enforcement_status,
         )
         self._reset_runtime_state()
         # Dedup set spans sandbox lifetimes for this thread; message IDs are monotonic
@@ -650,6 +654,22 @@ class SandboxThread(threading.Thread):
         if not self.cancel(timeout=timeout):
             self.kill(timeout=timeout)
 
+    def enforce_quota_breach(self, exc: Exception, reason: str, timeout: float = 0.05) -> bool:
+        """Record a kernel/watchdog quota breach and stop guest execution.
+
+        The watchdog calls this path from outside the sandbox thread, so it does
+        not depend on guest bytecode returning to Python-level quota checks.
+        If asynchronous termination cannot stop the thread promptly, the sandbox
+        is marked quarantined for supervisor cleanup.
+        """
+
+        self.termination_reason = reason
+        stopped = self.kill(timeout=timeout)
+        if not stopped:
+            self.quarantine(reason)
+        self._outbox.put(exc)
+        return stopped
+
     def reap(self) -> bool:
         """Drain pending messages after termination."""
         if self.is_alive():
@@ -684,6 +704,7 @@ class SandboxThread(threading.Thread):
         numa_node: Optional[int] = None,
         cgroup_path=None,
         capabilities: Optional[dict[str, Any]] = None,
+        enforcement_status: Any = None,
     ) -> None:
         """Reuse this thread for a new sandbox."""
         old_path = getattr(self, "_cgroup_path", None)
@@ -701,6 +722,7 @@ class SandboxThread(threading.Thread):
             numa_node=numa_node,
             cgroup_path=cgroup_path,
             capabilities=capabilities,
+            enforcement_status=enforcement_status,
         )
         self._reset_runtime_state()
         # Request the sandbox thread to (re)attach itself to the new cgroup.
@@ -842,16 +864,9 @@ class SandboxThread(threading.Thread):
                         self._start_time = None
                         cur, peak = tracemalloc.get_traced_memory()
                         self._mem_peak = max(self._mem_peak, peak - self._mem_base)
-                        if (
-                            self.cpu_quota_ms is not None
-                            and self._cpu_time > self.cpu_quota_ms
-                        ):
-                            raise errors.CPUExceeded()
-                        if (
-                            self.mem_quota_bytes is not None
-                            and self._mem_peak > self.mem_quota_bytes
-                        ):
-                            raise errors.MemoryExceeded()
+                        # CPU and RSS quotas are enforced by cgroups/eBPF and
+                        # ResourceWatchdog.  tracemalloc remains debugging
+                        # telemetry for Stats only; it is not a security limit.
                     except Exception as exc:  # real impl would sanitize
                         if isinstance(exc, _KillRequest):
                             break

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -72,6 +72,7 @@ class Sandbox:
         self._thread.reset(
             self._thread.name,
             cgroup_path=self._thread._cgroup_path,
+            enforcement_status=self._thread.quota_enforcement,
             **reset_config,
         )
 
@@ -117,6 +118,15 @@ class Sandbox:
     def termination_reason(self) -> str | None:
         return self._thread.termination_reason
 
+    @property
+    def quota_enforcement(self):
+        """Return cgroup quota enforcement status for this sandbox."""
+        return self._thread.quota_enforcement
+
+    @property
+    def quarantine_reason(self) -> str | None:
+        return self._thread._quarantine_reason
+
 
 class Supervisor:
     """Main supervisor owning all sandboxes."""
@@ -133,7 +143,15 @@ class Supervisor:
         bpf_mod = importlib.import_module("pyisolate.bpf.manager")
         self._bpf = bpf_mod.BPFManager()
         self._rollout_mode = rollout_mode
-        self._bpf.load(mode=rollout_mode)
+        try:
+            self._bpf.load(mode=rollout_mode)
+        except TypeError as exc:
+            # Test and compatibility shims may still expose the legacy
+            # load(strict=False) signature.  Real BPFManager validates rollout
+            # modes itself.
+            if "mode" not in str(exc):
+                raise
+            self._bpf.load(strict=(rollout_mode == "hardened"))
         self._recover_state()
         self._warm_pool: list[SandboxThread] = []
         for i in range(warm_pool):
@@ -243,7 +261,10 @@ class Supervisor:
             temp_dir = None
             thread = None
             try:
-                cg_path = cgroup.create(name, cpu_ms, mem_bytes)
+                cg_status = cgroup.create(
+                    name, cpu_ms, mem_bytes, mode=self._rollout_mode
+                )
+                cg_path = cg_status.path
                 temp_dir = recovery.allocate_temp_dir(name)
                 reset_config = {
                     "policy": policy,
@@ -264,6 +285,7 @@ class Supervisor:
                     thread.reset(
                         name,
                         cgroup_path=cg_path,
+                        enforcement_status=cg_status,
                         **reset_config,
                     )
                     thread._on_violation = self._alerts.notify
@@ -275,6 +297,7 @@ class Supervisor:
                         on_violation=self._alerts.notify,
                         tracer=self._tracer,
                         cgroup_path=cg_path,
+                        enforcement_status=cg_status,
                     )
                     thread.start()
                 thread._temp_dir = temp_dir
@@ -284,6 +307,12 @@ class Supervisor:
                     {
                         "name": name,
                         "cgroup_path": str(cg_path) if cg_path is not None else None,
+                        "quota_enforcement": {
+                            "mode": cg_status.mode,
+                            "cpu": cg_status.cpu,
+                            "memory": cg_status.memory,
+                            "errors": list(cg_status.errors),
+                        },
                         "temp_dir": str(temp_dir),
                     },
                 )

--- a/pyisolate/watchdog.py
+++ b/pyisolate/watchdog.py
@@ -64,8 +64,13 @@ class ResourceWatchdog(threading.Thread):
                 continue
             if sb.cpu_quota_ms is not None and cpu_ms >= sb.cpu_quota_ms:
                 try:
-                    sb._outbox.put(errors.CPUExceeded())
-                    sb.stop()
+                    stopped = sb.enforce_quota_breach(
+                        errors.CPUExceeded(), "cpu_exceeded"
+                    )
+                    if not stopped:
+                        self._supervisor.quarantine(
+                            sb.name, "cpu_exceeded: unresponsive after watchdog breach"
+                        )
                 except Exception:
                     logger.exception(
                         "watchdog failed to stop sandbox %r after CPU quota breach", name
@@ -73,8 +78,13 @@ class ResourceWatchdog(threading.Thread):
                 continue
             if sb.mem_quota_bytes is not None and rss >= sb.mem_quota_bytes:
                 try:
-                    sb._outbox.put(errors.MemoryExceeded())
-                    sb.stop()
+                    stopped = sb.enforce_quota_breach(
+                        errors.MemoryExceeded(), "memory_exceeded"
+                    )
+                    if not stopped:
+                        self._supervisor.quarantine(
+                            sb.name, "memory_exceeded: unresponsive after watchdog breach"
+                        )
                 except Exception:
                     logger.exception(
                         "watchdog failed to stop sandbox %r after memory quota breach", name

--- a/tests/test_cgroup.py
+++ b/tests/test_cgroup.py
@@ -6,6 +6,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import pytest
+
 import pyisolate.cgroup as cgroup
 
 
@@ -24,8 +26,22 @@ def test_create_logs_warning_on_error(monkeypatch, tmp_path, caplog):
 
     monkeypatch.setattr(Path, "mkdir", failing_mkdir)
     with caplog.at_level(logging.WARNING, logger=cgroup.__name__):
-        assert cgroup.create("cg") is None
+        status = cgroup.create("cg")
+    assert status.path is None
+    assert not status.enforced
+    assert status.errors
     assert "Failed to create cgroup" in caplog.text
+
+
+def test_create_fails_closed_in_hardened_mode(monkeypatch, tmp_path):
+    monkeypatch.setattr(cgroup, "_BASE", tmp_path)
+
+    def failing_mkdir(self, parents=True, exist_ok=True):
+        raise PermissionError("boom")
+
+    monkeypatch.setattr(Path, "mkdir", failing_mkdir)
+    with pytest.raises(RuntimeError):
+        cgroup.create("cg", mode="hardened")
 
 
 def test_attach_logs_warning_on_error(tmp_path, monkeypatch, caplog):
@@ -92,3 +108,15 @@ def test_list_children_and_cleanup_orphans(tmp_path, monkeypatch):
     assert {p.name for p in removed} == {"orphan"}
     assert keep is not None and keep.exists()
     assert orphan is not None and not orphan.exists()
+
+
+def test_create_reports_controller_enforcement(tmp_path, monkeypatch):
+    monkeypatch.setattr(cgroup, "_BASE", tmp_path / "pyisolate")
+
+    status = cgroup.create("limited", cpu_ms=5, mem_bytes=4096)
+
+    assert status.path == tmp_path / "pyisolate" / "limited"
+    assert status.cpu is True
+    assert status.memory is True
+    assert status.enforced is True
+    assert status.errors == ()

--- a/tests/test_matrix_hardening.py
+++ b/tests/test_matrix_hardening.py
@@ -33,7 +33,7 @@ def test_adversarial_syntax_error_does_not_poison_sandbox():
 
 
 @pytest.mark.runaway_cpu
-def test_runaway_cpu_loop_is_stopped_by_quota(monkeypatch):
+def test_cpu_quota_without_watchdog_is_telemetry(monkeypatch):
     import pyisolate.runtime.thread as thread_mod
 
     def fake_thread_time():
@@ -45,20 +45,20 @@ def test_runaway_cpu_loop_is_stopped_by_quota(monkeypatch):
 
     sb = iso.spawn(_name("cpu"), cpu_ms=2)
     try:
-        sb.exec("pass")
-        with pytest.raises(iso.CPUExceeded):
-            sb.recv(timeout=1)
+        sb.exec("post('ok')")
+        assert sb.recv(timeout=1) == "ok"
+        assert sb.stats.cpu_ms > 2
     finally:
         sb.close()
 
 
 @pytest.mark.memory_exhaustion
-def test_memory_exhaustion_is_stopped_by_quota():
+def test_memory_quota_without_watchdog_is_telemetry():
     sb = iso.spawn(_name("mem"), mem_bytes=64 * 1024)
     try:
-        sb.exec("x = 'A' * (2 * 1024 * 1024)")
-        with pytest.raises(iso.MemoryExceeded):
-            sb.recv(timeout=1)
+        sb.exec("x = 'A' * (2 * 1024 * 1024)\npost('ok')")
+        assert sb.recv(timeout=1) == "ok"
+        assert sb.stats.mem_bytes > 64 * 1024
     finally:
         sb.close()
 

--- a/tests/test_thread_quota.py
+++ b/tests/test_thread_quota.py
@@ -6,7 +6,7 @@ from pyisolate import errors
 from pyisolate.runtime import thread
 
 
-def test_cpu_quota_enforced_without_watchdog(monkeypatch):
+def test_cpu_quota_is_debug_telemetry_without_watchdog(monkeypatch):
     def fake_thread_time():
         fake_thread_time.current += 0.002
         return fake_thread_time.current
@@ -17,20 +17,22 @@ def test_cpu_quota_enforced_without_watchdog(monkeypatch):
     sb = thread.SandboxThread("cpu", cpu_ms=1)
     sb.start()
     try:
-        sb.exec("pass")
-        with pytest.raises(errors.CPUExceeded):
-            sb.recv(timeout=1)
+        sb.exec("post('ok')")
+        assert sb.recv(timeout=1) == "ok"
+        assert sb.stats.cpu_ms > sb.cpu_quota_ms
+        assert sb.termination_reason is None
     finally:
         sb.stop()
 
 
-def test_memory_quota_enforced_without_watchdog():
+def test_memory_quota_is_debug_telemetry_without_watchdog():
     sb = thread.SandboxThread("mem", mem_bytes=1024)
     sb.start()
     try:
-        sb.exec("x = ' ' * (2 * 1024 * 1024)")
-        with pytest.raises(errors.MemoryExceeded):
-            sb.recv(timeout=1)
+        sb.exec("x = ' ' * (2 * 1024 * 1024)\npost('ok')")
+        assert sb.recv(timeout=1) == "ok"
+        assert sb.stats.mem_bytes > sb.mem_quota_bytes
+        assert sb.termination_reason is None
     finally:
         sb.stop()
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -122,3 +122,53 @@ def test_watchdog_survives_ring_buffer_iterator_exceptions(caplog):
         wd.stop()
 
     assert "watchdog ring-buffer iterator failed; resetting" in caplog.text
+
+
+def test_watchdog_kills_non_returning_cpu_loop_without_guest_cooperation(monkeypatch):
+    def fake_rb(self):
+        def gen():
+            time.sleep(0.05)
+            while True:
+                yield {"name": "spin-kill", "cpu_ms": 50, "rss_bytes": 0}
+                time.sleep(0.01)
+
+        return gen()
+
+    monkeypatch.setattr(BPFManager, "open_ring_buffer", fake_rb)
+    monkeypatch.setattr(BPFManager, "_run", lambda *a, **k: True)
+    iso.shutdown()
+
+    sb = iso.supervisor._get_supervisor().spawn("spin-kill", cpu_ms=10)
+    try:
+        sb.exec("while True:\n    pass")
+        with pytest.raises(iso.CPUExceeded):
+            sb.recv(timeout=1)
+        assert sb.termination_reason == "cpu_exceeded"
+        assert (not sb._thread.is_alive()) or sb.quarantine_reason is not None
+    finally:
+        sb.close()
+
+
+def test_watchdog_kills_large_rss_allocation_without_guest_cooperation(monkeypatch):
+    def fake_rb(self):
+        def gen():
+            time.sleep(0.05)
+            while True:
+                yield {"name": "rss-kill", "cpu_ms": 0, "rss_bytes": 64 * 1024 * 1024}
+                time.sleep(0.01)
+
+        return gen()
+
+    monkeypatch.setattr(BPFManager, "open_ring_buffer", fake_rb)
+    monkeypatch.setattr(BPFManager, "_run", lambda *a, **k: True)
+    iso.shutdown()
+
+    sb = iso.supervisor._get_supervisor().spawn("rss-kill", mem_bytes=1024 * 1024)
+    try:
+        sb.exec("blob = bytearray(16 * 1024 * 1024)\nwhile True:\n    pass")
+        with pytest.raises(iso.MemoryExceeded):
+            sb.recv(timeout=1)
+        assert sb.termination_reason == "memory_exceeded"
+        assert (not sb._thread.is_alive()) or sb.quarantine_reason is not None
+    finally:
+        sb.close()


### PR DESCRIPTION
### Motivation
- Surface cgroup enforcement status instead of silently returning `None` so callers and operators can observe whether CPU/RSS controllers were actually applied. 
- Move CPU/RSS enforcement out of post‑hoc Python checks into the kernel/watchdog path so quota breaches terminate or quarantine misbehaving sandboxes promptly even without guest cooperation. 
- Treat `tracemalloc` metrics as debugging telemetry rather than the authoritative security limit and document fallback behavior for rollout modes.

### Description
- Replace `pyisolate.cgroup.create` return value with a `CgroupEnforcement` dataclass that reports `path`, `mode`, `cpu`, `memory`, and `errors`, and add hardened-mode fail‑closed semantics for controller failures.  (see `pyisolate/cgroup.py`).
- Wire the supervisor to call `cgroup.create(..., mode=self._rollout_mode)`, persist per‑sandbox `quota_enforcement` metadata, and expose it via `Sandbox.quota_enforcement`. (see `pyisolate/supervisor.py`).
- Add `SandboxThread.enforce_quota_breach()` which records the watchdog-initiated termination reason, attempts non‑cooperative shutdown via `kill()`, quarantines unresponsive sandboxes, and posts the quota exception to the sandbox outbox. (see `pyisolate/runtime/thread.py`).
- Update `ResourceWatchdog` to call the new `enforce_quota_breach()` path for CPU and RSS events and to ask the supervisor to quarantine sandboxes that do not stop promptly. (see `pyisolate/watchdog.py`).
- Change the lightweight BPF stub to document the kernel/userspace contract for quota/usage maps and breach reasons so tests can inject equivalent events. (see `pyisolate/bpf/resource_guard.bpf.c`).
- Remove the active CPU/RSS raises from the sandbox run loop so `tracemalloc` remains telemetry-only; preserve other Python-level quotas (open files, network ops, etc.). (see `pyisolate/runtime/thread.py`).
- Update `attach_current`/`delete` helpers to accept `CgroupEnforcement` wrappers and add tests and assertions around controller enforcement and hardened-mode behavior. (see `pyisolate/cgroup.py`, `tests/*`).

### Testing
- Ran targeted unit tests with `pytest -q tests/test_cgroup.py tests/test_watchdog.py tests/test_thread_quota.py tests/test_matrix_hardening.py tests/test_sandbox.py tests/test_thread_extra.py`, which completed successfully (`52 passed`).
- Verified Python compilation with `python -m py_compile pyisolate/cgroup.py pyisolate/watchdog.py pyisolate/runtime/thread.py pyisolate/supervisor.py tests/...` which succeeded for the modified modules.
- Note: a full `pytest -q` run previously surfaced unrelated failures caused by a suite-wide BPF stub and recovery-order interactions; the quota/watchdog/cgroup changes above were validated by the targeted test set and the failures are orthogonal to the enforcement refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04715e2bdc832893c0db3160ac4ff7)