### PR TITLE
Clarify prototype hardening posture

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,4 +1,6 @@
-# API.md — Public Python Interface (v 0.1)
+# API.md — Public Python Interface (prototype v0.1)
+
+**Current state:** PyIsolate is a prototype. Kernel eBPF enforcement and CPython 3.13 no-GIL/free-threaded support are experimental roadmap items. Development and compatibility modes must not be described as hardened isolation because they can run without full kernel enforcement.
 
 ```python
 import pyisolate as psi
@@ -14,8 +16,8 @@ The canonical contract lives in [docs/execution-model.md](docs/execution-model.m
 
 | Call | Description |
 |------|-------------|
-| `psi.spawn(name:str, policy:str|dict=None, allowed_imports:list[str]|None=None) → Sandbox` | Create sandbox thread, attach eBPF, return handle with module whitelist. |
-| `psi.Supervisor(warm_pool:int=0, rollout_mode:str="dev")` | Build an isolated supervisor with explicit rollout posture (`dev`, `hardened`, `compatibility`). |
+| `psi.spawn(name:str, policy:str|dict=None, allowed_imports:list[str]|None=None) → Sandbox` | Create sandbox thread and return a handle with module whitelist. Policy attachment is prototype behavior unless hardened diagnostics pass. |
+| `psi.Supervisor(warm_pool:int=0, rollout_mode:str="dev")` | Build a prototype supervisor with explicit rollout posture (`dev`, experimental fail-closed `hardened`, or non-enforcing `compatibility`). |
 | `sandbox.close(timeout=0.2)` | Graceful stop → SIGTERM; force‑kill after timeout. |
 | `with psi.spawn(name, policy)` | Context manager form; sandbox closes on exit. |
 | `psi.list_active() → Dict[str, Sandbox]` | Introspection. |
@@ -23,7 +25,7 @@ The canonical contract lives in [docs/execution-model.md](docs/execution-model.m
 ## 2  Executing code
 
 ```python
-sb = psi.spawn("guest42", policy="defaults", numa_node=0)
+sb = psi.spawn("guest42", allowed_imports=["math"], numa_node=0)
 sb.exec("from math import sqrt; post(sqrt(2))")
 result = sb.recv(timeout=0.1)      # 1.4142135623
 ```
@@ -40,6 +42,8 @@ result = sb.recv(timeout=0.1)      # 1.4142135623
 
 ## 3  Policy helpers
 
+Policy helpers are useful for shaping prototype behavior and tests. They are not a promise of kernel enforcement in `dev` or `compatibility` mode. Use `pyisolate-doctor --mode hardened` before advertising a deployment as fail-closed.
+
 ```python
 from pyisolate.policy import Policy
 
@@ -53,7 +57,7 @@ cust.fs  # ["/srv/data/*.parquet"]
 cust.tcp # ["127.0.0.1:9200"]
 
 
-sb = psi.spawn("etl", policy=cust)
+sb = psi.spawn("etl", policy=cust)  # prototype policy object; not a hardened boundary unless doctor passes
 
 # Configure token and hot-reload policies
 psi.set_policy_token("secret")
@@ -61,6 +65,8 @@ policy.refresh("/tmp/policy.yml", token="secret")
 ```
 
 ## 4  High-level helpers
+
+The policy names below are routing/configuration labels in the prototype release; they must not silently imply kernel-enforced isolation.
 
 ```python
 @psi.sandbox(policy="ml-inference", timeout="30s")
@@ -90,7 +96,7 @@ Event types: `MEM_KILL`, `CPU_THROTTLE`, `POLICY_HOTLOAD`, `BROKER_ERROR`.
 | `psi.checkpoint(sb, key:bytes) -> bytes` | Serialize and encrypt sandbox state. |
 | `psi.restore(blob:bytes, key:bytes) -> Sandbox` | Spawn sandbox from encrypted state. |
 | `psi.migrate(sb, host:str, key:bytes) -> Sandbox` | Send checkpoint to `host` and restore there. |
-| `policy.refresh_remote(url:str, token:str, timeout: float | None = None, max_retries: int = 0)` | Fetch YAML policy over HTTP with an optional timeout and retry budget, then apply it. |
+| `policy.refresh_remote(url:str, token:str, timeout: float | None = None, max_retries: int = 0)` | Fetch YAML policy over HTTP with an optional timeout and retry budget, then apply it to prototype policy maps. Hardened deployments must fail closed if the BPF map update fails. |
 
 
 ## 6  Exceptions hierarchy

--- a/README.md
+++ b/README.md
@@ -1,25 +1,31 @@
 # PyIsolate
 <img width="256" alt="a sandbox of sandboxes!" src="https://github.com/user-attachments/assets/e5851893-ee13-4466-981e-55d6d08c01db" />
 
-**A Light‑weight, eBPF‑hardened sub‑interpreter sandbox for a no-GIL CPython**
+**Current state: prototype.** PyIsolate is a light-weight sub-interpreter sandbox prototype. Kernel eBPF enforcement and CPython no-GIL/free-threaded support are experimental roadmap work, not release guarantees.
 
-## Features
+## Current release status
 
-* **True parallelism** — built on CPython 3.13 with the `--disable-gil` build.
-* **Kernel‑enforced security** — eBPF‑LSM & cgroup hooks gate filesystem, network, and high‑risk syscalls.
-* **Deterministic quotas** — per‑interpreter arenas cap RAM; perf‑event BPF guards CPU & bandwidth.
-* **Kernel‑level accounting** — `resource_guard.bpf.c` tracks CPU time and RSS per sandbox via a ring buffer.
+PyIsolate `0.0.x` is a prototype for API, policy, broker, observability, and test-matrix development. Do **not** treat this release as a hardened security boundary. The in-repo BPF loader compiles proof-of-concept programs and the default development mode can continue when kernel/BPF tooling is missing. Hardened mode is intentionally fail-closed behind `pyisolate-doctor --mode hardened`.
+
+## Features and roadmap
+
+* **Sub-interpreter sandbox API** — available for prototype development and conformance testing.
+* **Import allow-listing and user-space quotas** — available as prototype guardrails; not a complete adversarial security boundary.
+* **No-GIL/free-threaded CPython support** — experimental roadmap target for CPython 3.13+ `--disable-gil` builds.
+* **Kernel enforcement** — experimental roadmap target; eBPF-LSM, cgroup, and verifier-backed policy enforcement are not guaranteed by the current release.
+* **Deterministic quotas** — roadmap: per-interpreter arenas plus perf-event BPF guards for CPU and bandwidth.
+* **Kernel-level accounting** — experimental: `resource_guard.bpf.c` is a proof-of-concept ring-buffer source.
 * **io_uring async I/O** — broker uses Linux io_uring for non-blocking operations.
 * **Token‑gated policy reload** — update YAML policies in micro‑seconds with authentication.
 * **Authenticated broker** — X25519 (optionally Kyber‑768) + ChaCha20‑Poly1305 secure control channel with replay counters.
 * **Hot‑reload policy** — update YAML policies in micro‑seconds without restarting guests.
-* **eBPF‑verified contracts** — runtime assertions compiled into BPF for extra safety.
-* **Observability** — Prometheus metrics & eBPF perf‑events for every sandbox.
+* **eBPF‑verified contracts** — roadmap: runtime assertions compiled into BPF for extra safety.
+* **Observability** — Prometheus metrics are available; eBPF perf-event coverage is experimental.
 * **Capability imports** — restrict module access per sandbox via `allowed_imports`.
 * **Restricted subset** — optional interpreter with move-only ownership semantics.
 * **Stack canaries & CFI** — sub‑interpreter compiled with `-fstack-protector-strong` and `-fsanitize=cfi`.
 * **NUMA‑aware scheduling** — bind sandboxes to the CPUs of a chosen node on multi‑socket hosts.
-* **Remote policy enforcement** — fetch and apply YAML over HTTP.
+* **Remote policy refresh** — fetch and apply YAML over HTTP to prototype policy maps.
 * **Encrypted checkpointing** — save sandbox state with ChaCha20‑Poly1305.
 * **Migration** — transfer checkpoints to a peer host.
 
@@ -35,7 +41,8 @@ python -m pip install -e .[dev]  # install package for development and tooling
 # python -m pip install -e .[dev,pqcrypto]
 pytest -q          # run the test‑suite
 python examples/echo.py
-pyisolate-doctor  # capture provenance + kernel/hardening feature report
+pyisolate-doctor                 # capture provenance + feature report
+pyisolate-doctor --mode hardened # fail closed on unsupported no-GIL/kernel/BPF config
 ```
 
 ### CI test matrix
@@ -60,7 +67,7 @@ pytest -q tests/test_matrix_hardening.py
 
 PyIsolate includes a `pyisolate-doctor` command for installation diagnostics and
 release provenance tracking (Python build hash, no-GIL status, kernel features,
-and deterministic-wheel policy flags). See [docs/packaging-reproducibility.md](docs/packaging-reproducibility.md).
+BPF toolchain availability, and deterministic-wheel policy flags). In `--mode hardened`, unsupported Python, kernel, or BPF configurations are reported as hard failures with a non-zero exit code. See [docs/packaging-reproducibility.md](docs/packaging-reproducibility.md).
 
 ### Structured logging
 
@@ -82,16 +89,16 @@ import pyisolate as iso
 # default: fast local iteration
 dev = iso.Supervisor(rollout_mode="dev")
 
-# strict production posture (fail closed if BPF toolchain/load fails)
+# experimental fail-closed gate; requires pyisolate-doctor --mode hardened to pass
 hardened = iso.Supervisor(rollout_mode="hardened")
 
-# looser ecosystem validation (baseline BPF only, skips stricter filters)
+# compatibility testing only; it deliberately skips stricter filters and is not enforcement
 compat = iso.Supervisor(rollout_mode="compatibility")
 ```
 
-* `dev`: lightweight, low-friction development mode.
-* `hardened`: real enforcement; any eBPF compile/load failure raises.
-* `compatibility`: reduced enforcement to maximize third-party compatibility.
+* `dev`: lightweight, low-friction development mode; may run without kernel enforcement.
+* `hardened`: experimental fail-closed mode; `pyisolate-doctor --mode hardened` must pass and any eBPF compile/load failure raises.
+* `compatibility`: compatibility testing only; reduced checks must not be presented as enforced isolation.
 
 ### Hello World
 
@@ -103,14 +110,15 @@ from math import sqrt
 post(sqrt(2))
 """
 
-with iso.spawn("demo", policy="stdlib.readonly") as sandbox:
+with iso.spawn("demo", allowed_imports=["math"]) as sandbox:
     sandbox.exec(code)
     print("Result:", sandbox.recv())   # 1.4142135623730951
 ```
 
 
 Higher‑level helpers can automatically sandbox functions and build simple
-pipelines:
+pipelines. Policy names in these examples are labels for prototype routing until
+the hardened gate passes; do not rely on them for kernel enforcement:
 
 ```python
 @iso.sandbox(policy="ml-inference", timeout="30s")
@@ -137,9 +145,9 @@ For CPython 3.13 `--disable-gil` deployments, review the extension and package c
 
 ### Host conformance suite
 
-Run the host conformance suite to measure whether the current machine satisfies
-PyIsolate guarantees (Python build, kernel capabilities, BPF readiness, cgroup
-behavior, policy enforcement, and timeout/kill behavior):
+Run the host conformance suite to measure how close the current machine is to
+PyIsolate roadmap guarantees (Python build, kernel capabilities, BPF readiness,
+cgroup behavior, policy enforcement, and timeout/kill behavior):
 
 ```bash
 python -m pyisolate.conformance
@@ -179,7 +187,7 @@ Use `pyisolate.policy.refresh("policy/<name>.yml", token="secret")` to hot‑loa
 
 ```
  ┌──────── Supervisor (root) ───────────┐
- │  • eBPF loader & maps                │
+ │  • experimental eBPF loader & maps   │
  │  • Broker (AEAD, counters)           │
  │  • Policy hot‑reloader               │
  │  • Metrics exporter (Prometheus)     │
@@ -191,7 +199,7 @@ Use `pyisolate.policy.refresh("policy/<name>.yml", token="secret")` to hot‑loa
  │   ↑         ↑              ↑         │
  │   │channel  │              │         │
  └───┴─────────┴──────────────┴─────────┘
-       eBPF cgroups & LSM hooks per thread
+       roadmap: eBPF cgroups & LSM hooks per thread
 ```
 
 ---
@@ -207,11 +215,12 @@ See [docs/execution-model.md](docs/execution-model.md). We keep this model small
 ## Security model
 
 * **Execution cell** – each guest runs in its own sub‑interpreter, hosted by one sandbox thread.
-* **Security boundary (authoritative)** – enforcement lives at the kernel/process layer (cgroups + eBPF/LSM), not at the Python sub‑interpreter boundary.
-* **Kernel boundary** – every sandbox thread enters its own cgroup; CO‑RE eBPF programs enforce FS/net/syscall policy.
+* **Current security boundary** – this prototype must not be used as the sole adversarial security boundary. Python sub-interpreters are not a hard isolation boundary.
+* **Roadmap security boundary** – hardened releases are expected to enforce at the kernel/process layer (cgroups + eBPF/LSM), not at the Python sub-interpreter boundary.
+* **Kernel boundary** – experimental BPF/cgroup work exists in-tree, but current releases may fail closed or stay in development mode rather than guaranteeing FS/net/syscall policy enforcement.
 * **Broker** – sole path to privileged syscalls, sealed with AEAD and strict replay protection.
 * **Fallback hardening** – for stronger blast‑radius isolation (or kernels with reduced features), run one sandbox per process and place that process inside a container or microVM.
-* **Verified eBPF modules** – bytecode is disassembled with `llvm-objdump -d` and must succeed `bpftool prog load` so the kernel verifier approves it before any sandbox runs.
+* **Verified eBPF modules** – roadmap/hardened-mode requirement: bytecode is disassembled with `llvm-objdump -d` and must succeed `bpftool prog load` so the kernel verifier approves it before any sandbox runs.
 
 See **SECURITY.md** for a full threat‑model walkthrough.
 
@@ -236,6 +245,8 @@ A `Dockerfile` and experimental operator are included. See [docs/kubernetes.md](
 
 ## Roadmap
 
+* [ ] Harden kernel-backed FS/net/syscall policy enforcement
+* [ ] Support and test CPython 3.13+ no-GIL/free-threaded deployments
 * [ ] Land Landlock fallback for unprivileged kernels
 * [x] Add Kyber‑768 / Dilithium PQ hybrids
 * [ ] WASM build target for browser sandboxes

--- a/pyisolate/doctor.py
+++ b/pyisolate/doctor.py
@@ -3,8 +3,97 @@
 from __future__ import annotations
 
 import argparse
+import json
+from typing import Any
 
-from .provenance import installation_report_json
+from .provenance import installation_report
+
+HARDENED_REQUIRED_KERNEL_FEATURES = ("ebpf_lsm", "bpffs", "cgroup_v2")
+HARDENED_REQUIRED_BPF_TOOLS = ("clang", "bpftool", "llvm_objdump")
+
+
+def _failure(message: str, *, check: str, reason: str) -> dict[str, str]:
+    return {"check": check, "message": message, "reason": reason}
+
+
+def hardened_failures(report: dict[str, Any]) -> list[dict[str, str]]:
+    """Return hard failures that make hardened mode unsupported on this host."""
+
+    failures: list[dict[str, str]] = []
+    python = report.get("python", {})
+    if not python.get("py_gil_disabled"):
+        failures.append(
+            _failure(
+                "hardened mode requires a CPython build configured with --disable-gil",
+                check="python.no_gil_runtime",
+                reason="Py_GIL_DISABLED is not set for the active interpreter",
+            )
+        )
+
+    kernel = report.get("kernel", {})
+    if kernel.get("system") != "Linux":
+        failures.append(
+            _failure(
+                "hardened mode requires a Linux kernel",
+                check="kernel.system",
+                reason=f"detected {kernel.get('system') or 'unknown'}",
+            )
+        )
+
+    kernel_features = kernel.get("features", {})
+    for name in HARDENED_REQUIRED_KERNEL_FEATURES:
+        feature = kernel_features.get(name, {})
+        if not feature.get("available"):
+            failures.append(
+                _failure(
+                    f"hardened mode requires kernel feature {name}",
+                    check=f"kernel.features.{name}",
+                    reason=str(feature.get("reason") or "not reported"),
+                )
+            )
+
+    bpf_tools = report.get("bpf", {}).get("toolchain", {})
+    for name in HARDENED_REQUIRED_BPF_TOOLS:
+        tool = bpf_tools.get(name, {})
+        if not tool.get("available"):
+            failures.append(
+                _failure(
+                    f"hardened mode requires BPF tool {tool.get('command') or name}",
+                    check=f"bpf.toolchain.{name}",
+                    reason=str(tool.get("reason") or "not reported"),
+                )
+            )
+
+    return failures
+
+
+def doctor_report(*, mode: str = "dev") -> dict[str, Any]:
+    """Return installation diagnostics plus mode-specific gate results."""
+
+    report = installation_report()
+    failures = hardened_failures(report) if mode == "hardened" else []
+    report["doctor"] = {
+        "mode": mode,
+        "status": "fail" if failures else "pass",
+        "failures": failures,
+    }
+    return report
+
+
+def doctor_report_json(*, mode: str = "dev") -> str:
+    return json.dumps(doctor_report(mode=mode), indent=2, sort_keys=True)
+
+
+def assert_hardened_supported(report: dict[str, Any] | None = None) -> None:
+    """Raise RuntimeError if this host cannot run PyIsolate hardened mode."""
+
+    active_report = installation_report() if report is None else report
+    failures = hardened_failures(active_report)
+    if failures:
+        details = "; ".join(
+            f"{failure['check']}: {failure['reason']}" for failure in failures
+        )
+        raise RuntimeError(f"PyIsolate hardened mode is unsupported: {details}")
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -12,8 +101,17 @@ def main(argv: list[str] | None = None) -> None:
         prog="pyisolate-doctor",
         description="Print PyIsolate build provenance and kernel feature flags.",
     )
-    parser.parse_args(argv)
-    print(installation_report_json())
+    parser.add_argument(
+        "--mode",
+        choices=("dev", "hardened"),
+        default="dev",
+        help="Validate requirements for the selected rollout mode.",
+    )
+    args = parser.parse_args(argv)
+    report = doctor_report(mode=args.mode)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.mode == "hardened" and report["doctor"]["failures"]:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/pyisolate/provenance.py
+++ b/pyisolate/provenance.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import platform
+import shutil
 import sys
 import sysconfig
 from pathlib import Path
@@ -56,31 +57,64 @@ def kernel_feature_flags() -> dict[str, dict[str, Any]]:
     return {
         "ebpf_lsm": {
             "available": "bpf" in lsm,
-            "reason": "Kernel LSM list does not include bpf" if "bpf" not in lsm else "ok",
+            "reason": (
+                "Kernel LSM list does not include bpf" if "bpf" not in lsm else "ok"
+            ),
         },
         "bpffs": {
             "available": os.path.ismount("/sys/fs/bpf"),
-            "reason": "/sys/fs/bpf is not mounted" if not os.path.ismount("/sys/fs/bpf") else "ok",
+            "reason": (
+                "/sys/fs/bpf is not mounted"
+                if not os.path.ismount("/sys/fs/bpf")
+                else "ok"
+            ),
         },
         "cgroup_v2": {
             "available": Path("/sys/fs/cgroup/cgroup.controllers").exists(),
-            "reason": "cgroup v2 controllers file missing"
-            if not Path("/sys/fs/cgroup/cgroup.controllers").exists()
-            else "ok",
+            "reason": (
+                "cgroup v2 controllers file missing"
+                if not Path("/sys/fs/cgroup/cgroup.controllers").exists()
+                else "ok"
+            ),
         },
         "io_uring": {
-            "available": hasattr(os, "SYS_io_uring_setup") or platform.system() == "Linux",
-            "reason": "non-Linux kernels are unsupported for io_uring"
-            if platform.system() != "Linux"
-            else "ok",
+            "available": hasattr(os, "SYS_io_uring_setup")
+            or platform.system() == "Linux",
+            "reason": (
+                "non-Linux kernels are unsupported for io_uring"
+                if platform.system() != "Linux"
+                else "ok"
+            ),
         },
         "landlock": {
             "available": Path("/sys/kernel/security/landlock").exists(),
-            "reason": "Landlock securityfs entry not detected"
-            if not Path("/sys/kernel/security/landlock").exists()
-            else "ok",
+            "reason": (
+                "Landlock securityfs entry not detected"
+                if not Path("/sys/kernel/security/landlock").exists()
+                else "ok"
+            ),
         },
     }
+
+
+def bpf_toolchain_flags() -> dict[str, dict[str, Any]]:
+    """Report whether the userspace BPF build/load tools are available."""
+
+    commands = {
+        "clang": "clang",
+        "bpftool": "bpftool",
+        "llvm_objdump": "llvm-objdump",
+    }
+    flags: dict[str, dict[str, Any]] = {}
+    for name, command in commands.items():
+        path = shutil.which(command)
+        flags[name] = {
+            "available": path is not None,
+            "command": command,
+            "path": path,
+            "reason": "ok" if path is not None else f"{command} not found on PATH",
+        }
+    return flags
 
 
 def hardening_feature_flags() -> dict[str, dict[str, Any]]:
@@ -90,16 +124,23 @@ def hardening_feature_flags() -> dict[str, dict[str, Any]]:
     return {
         "no_gil_runtime": {
             "available": bool(provenance["py_gil_disabled"]),
-            "reason": "Python was not built with --disable-gil"
-            if not provenance["py_gil_disabled"]
-            else "ok",
+            "reason": (
+                "Python was not built with --disable-gil"
+                if not provenance["py_gil_disabled"]
+                else "ok"
+            ),
         },
         "deterministic_wheels": {
             "available": platform.system() == "Linux"
             and platform.machine() in {"x86_64", "aarch64"},
-            "reason": "Deterministic wheel policy only defined for Linux x86_64/aarch64"
-            if not (platform.system() == "Linux" and platform.machine() in {"x86_64", "aarch64"})
-            else "ok",
+            "reason": (
+                "Deterministic wheel policy only defined for Linux x86_64/aarch64"
+                if not (
+                    platform.system() == "Linux"
+                    and platform.machine() in {"x86_64", "aarch64"}
+                )
+                else "ok"
+            ),
         },
     }
 
@@ -116,6 +157,7 @@ def installation_report() -> dict[str, Any]:
             "machine": platform.machine(),
             "features": kernel_feature_flags(),
         },
+        "bpf": {"toolchain": bpf_toolchain_flags()},
         "hardening": hardening_feature_flags(),
     }
 

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -8,6 +8,7 @@ requires eBPF enforcement which is not implemented here.
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import os
 import re
@@ -133,7 +134,11 @@ class Supervisor:
         bpf_mod = importlib.import_module("pyisolate.bpf.manager")
         self._bpf = bpf_mod.BPFManager()
         self._rollout_mode = rollout_mode
-        self._bpf.load(mode=rollout_mode)
+        if rollout_mode == "hardened":
+            from .doctor import assert_hardened_supported
+
+            assert_hardened_supported()
+        self._load_bpf(rollout_mode)
         self._recover_state()
         self._warm_pool: list[SandboxThread] = []
         for i in range(warm_pool):
@@ -146,6 +151,16 @@ class Supervisor:
         self._tenant_usage: dict[str, int] = {}
         self._quota_ledger = os.environ.get("PYISOLATE_QUOTA_LEDGER")
         self._replay_quota_ledger()
+
+    def _load_bpf(self, rollout_mode: str) -> None:
+        """Load BPF manager while tolerating legacy test doubles."""
+
+        load = self._bpf.load
+        parameters = inspect.signature(load).parameters
+        if "mode" in parameters:
+            load(mode=rollout_mode)
+        else:
+            load()
 
     def _replay_quota_ledger(self) -> None:
         if not self._quota_ledger:
@@ -321,7 +336,9 @@ class Supervisor:
         with self._lock:
             return [t for t in self._sandboxes.values() if t.is_alive()]
 
-    def _authorize_control(self, token: str | RootCapability, op: str) -> ControlRequest:
+    def _authorize_control(
+        self, token: str | RootCapability, op: str
+    ) -> ControlRequest:
         """Validate an authenticated control-plane operation request."""
 
         if token is ROOT:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pyisolate"
 version = "0.0.1"
-description = "Minimal skeleton for PyIsolate sandbox"
+description = "Prototype PyIsolate sandbox; kernel enforcement and no-GIL support are experimental roadmap items"
 authors = [{ name = "PyIsolate" }]
 requires-python = ">=3.11"
 dependencies = ["pyyaml", "cryptography"]
@@ -11,7 +11,7 @@ requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["pyisolate"]
+include = ["pyisolate", "pyisolate.*"]
 
 [project.scripts]
 pyisolate-doctor = "pyisolate.doctor:main"
@@ -47,7 +47,7 @@ markers = [
     "import_escape: module import escape attempts",
     "policy_bypass: file/network policy bypass attempts",
     "race: high-concurrency race scenarios",
-    "no_gil: free-threaded/no-GIL focused scenarios",
+    "no_gil: experimental free-threaded/no-GIL roadmap scenarios",
     "soak: long-running spawn/kill stability coverage",
     "crash_injection: injected crash/fault-recovery scenarios",
     "cross_kernel: kernel-version compatibility scenarios",

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -24,3 +24,92 @@ def test_doctor_cli_output(capsys):
     payload = json.loads(captured.out)
     assert "kernel" in payload
     assert "features" in payload["kernel"]
+
+
+def test_doctor_hardened_mode_fails_closed(monkeypatch, capsys):
+    def fake_report():
+        return {
+            "python": {"py_gil_disabled": False},
+            "kernel": {
+                "system": "Linux",
+                "features": {
+                    "ebpf_lsm": {"available": False, "reason": "missing bpf lsm"},
+                    "bpffs": {"available": True, "reason": "ok"},
+                    "cgroup_v2": {"available": True, "reason": "ok"},
+                },
+            },
+            "bpf": {
+                "toolchain": {
+                    "clang": {"available": True, "command": "clang", "reason": "ok"},
+                    "bpftool": {
+                        "available": False,
+                        "command": "bpftool",
+                        "reason": "bpftool not found on PATH",
+                    },
+                    "llvm_objdump": {
+                        "available": True,
+                        "command": "llvm-objdump",
+                        "reason": "ok",
+                    },
+                }
+            },
+            "hardening": {},
+        }
+
+    monkeypatch.setattr("pyisolate.doctor.installation_report", fake_report)
+
+    try:
+        main(["--mode", "hardened"])
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("hardened doctor should fail closed")
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["doctor"]["status"] == "fail"
+    checks = {failure["check"] for failure in payload["doctor"]["failures"]}
+    assert "python.no_gil_runtime" in checks
+    assert "kernel.features.ebpf_lsm" in checks
+    assert "bpf.toolchain.bpftool" in checks
+
+
+def test_doctor_hardened_mode_passes_supported_report(monkeypatch, capsys):
+    def fake_report():
+        return {
+            "python": {"py_gil_disabled": True},
+            "kernel": {
+                "system": "Linux",
+                "features": {
+                    "ebpf_lsm": {"available": True, "reason": "ok"},
+                    "bpffs": {"available": True, "reason": "ok"},
+                    "cgroup_v2": {"available": True, "reason": "ok"},
+                },
+            },
+            "bpf": {
+                "toolchain": {
+                    "clang": {"available": True, "command": "clang", "reason": "ok"},
+                    "bpftool": {
+                        "available": True,
+                        "command": "bpftool",
+                        "reason": "ok",
+                    },
+                    "llvm_objdump": {
+                        "available": True,
+                        "command": "llvm-objdump",
+                        "reason": "ok",
+                    },
+                }
+            },
+            "hardening": {},
+        }
+
+    monkeypatch.setattr("pyisolate.doctor.installation_report", fake_report)
+
+    main(["--mode", "hardened"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["doctor"] == {
+        "mode": "hardened",
+        "status": "pass",
+        "failures": [],
+    }


### PR DESCRIPTION
### Motivation

- The project should not advertise the current release as a hardened runtime when kernel eBPF enforcement and CPython no‑GIL support are still roadmap items.  
- Hardened, fail‑closed behavior must be gated by explicit host diagnostics so users do not silently run without the required kernel/tooling.  
- Examples and public API docs should avoid implying kernel enforcement for `dev`/`compatibility` modes.

### Description

- Mark the release as a prototype in `README.md`, adjust feature wording to label kernel enforcement and no‑GIL support as experimental/roadmap, and update examples to avoid implying enforcement.  
- Update `API.md` and `pyproject.toml` to reflect prototype status and label the `no_gil` pytest marker as experimental.  
- Add a hardened gate in `pyisolate-doctor` (`pyisolate/doctor.py`) that reports missing no‑GIL builds, kernel features, and BPF toolchain availability and returns non‑zero in `--mode hardened`.  
- Report BPF toolchain availability in `installation_report()` (`pyisolate/provenance.py`) and wire `Supervisor(rollout_mode="hardened")` to call `assert_hardened_supported()` before attempting to load BPF while preserving compatibility with test stubs via a `_load_bpf` shim in `pyisolate/supervisor.py`.

### Testing

- Compiled affected modules with `python -m py_compile pyisolate/doctor.py pyisolate/provenance.py pyisolate/supervisor.py tests/test_provenance.py` and the command succeeded.  
- Ran targeted test sets `pytest -q tests/test_provenance.py tests/test_supervisor.py` and `pytest -q tests/test_bpf_manager.py`, and these targeted suites passed.  
- Exercised the doctor CLI with `python -m pyisolate.doctor --mode hardened` which exited non‑zero on this host as expected because the host does not satisfy hardened requirements.  
- The full test-suite (`pytest -q`) currently exhibits failures unrelated to this documentation/doctor gate change (cross-test BPF manager stubbing and watchdog/thread lifecycle interactions); targeted tests validating this PR pass while the global suite requires addressing test isolation for BPF/watchdog mocks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04715fda748328ad607e50050f0d1b)