### PR TITLE
Make capability objects first-class

### DIFF
--- a/API.md
+++ b/API.md
@@ -44,14 +44,16 @@ result = sb.recv(timeout=0.1)      # 1.4142135623
 from pyisolate.policy import Policy
 
 cust = (Policy(mem="256MiB")
-        .allow_fs("/srv/data/*.parquet")
-        .allow_tcp("127.0.0.1:9200")
-        .allow_import("math"))
+        .grant(psi.ReadPath("/srv/input"),
+               psi.WritePath("/srv/output"),
+               psi.ConnectTCP("127.0.0.1", 9200),
+               psi.Import("math"),
+               psi.CpuBudget(50)))
 
-# Lists of accumulated permissions are available via `fs` and `tcp`:
-cust.fs  # ["/srv/data/*.parquet"]
-cust.tcp # ["127.0.0.1:9200"]
-
+# Legacy helpers remain available and are converted to the same authority model:
+cust.allow_fs("/srv/data/*.parquet")   # read + write path authority
+cust.allow_tcp("127.0.0.1:9200")
+cust.allow_import("json")
 
 sb = psi.spawn("etl", policy=cust)
 

--- a/POLICY.md
+++ b/POLICY.md
@@ -34,7 +34,43 @@ sandboxes:
 
 *Rule precedence:* inherited/default rules are evaluated before child rules. Unmatched operation → **deny**.
 
-## 3  Live reloading
+
+## 3 First-class capabilities
+
+Policy is an authority model first and a YAML format second.  The same grants can
+be expressed as Python objects or serialized in YAML:
+
+```python
+from pyisolate import ConnectTCP, CpuBudget, Import, ReadPath, WritePath
+from pyisolate.policy import Policy
+
+policy = Policy().grant(
+    ReadPath("/tmp/input"),
+    WritePath("/tmp/output"),
+    ConnectTCP("api.example.com", 443),
+    Import("math"),
+    CpuBudget(50),
+)
+```
+
+```yaml
+version: 1.0
+sandboxes:
+  job:
+    fs:
+      - read: "/tmp/input"
+      - write: "/tmp/output"
+    net:
+      - connect: "api.example.com:443"
+    imports: [math]
+    cpu_ms: 50
+```
+
+Legacy `allow` filesystem entries deserialize to both `ReadPath` and
+`WritePath`, so existing policies keep their read/write behavior while new
+policies can split input and output authority.
+
+## 4  Live reloading
 `pyisolate.policy.refresh(path, token)` calls `bpftool map update` for every
 changed row; the supervisor verifies *token* and new limits apply within µs—no
 guest restart required.
@@ -49,7 +85,7 @@ without touching live policy maps. Compiled output includes:
 - `semantics_version` (stable evaluation semantics across releases)
 - `deny_log` (explicit deny entries for auditing and rollout checks)
 
-## 4  Fallback YAML parser
+## 5  Fallback YAML parser
 If the optional **PyYAML** dependency is missing, `pyisolate.policy` falls
 back to a very small parser.  It understands only two constructs:
 
@@ -63,7 +99,7 @@ back to a very small parser.  It understands only two constructs:
 
 Anything more complex results in a `ValueError` during `refresh()`.
 
-## 5  Extending the schema
+## 6  Extending the schema
 Add custom keys by shipping a new eBPF object and registering a
 `PolicyPlugin`:
 
@@ -80,7 +116,7 @@ class IpcLimiter(PolicyPlugin):
 register_plugin(IpcLimiter)
 ```
 
-## 6  Policy templates
+## 7  Policy templates
 
 Several ready-to-use policies are included under the `policy/` directory:
 

--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -6,16 +6,23 @@ This module exposes the high-level API described in API.md.
 from . import bpf  # noqa: F401
 from .capabilities import (  # noqa: F401
     ROOT,
+    Authority,
+    AuthoritySet,
+    ConnectTCP,
+    CpuBudget,
     IPCChannelCapability,
     Capability,
     ClockCapability,
     FilesystemCapability,
     NetworkCapability,
+    Import,
     RandomCapability,
+    ReadPath,
     RootCapability,
     SecretCapability,
     SubprocessCapability,
     Token,
+    WritePath,
 )
 
 try:
@@ -111,6 +118,13 @@ __all__ = [
     "RestrictedExec",
     "OwnershipError",
     "Capability",
+    "Authority",
+    "AuthoritySet",
+    "ReadPath",
+    "WritePath",
+    "ConnectTCP",
+    "Import",
+    "CpuBudget",
     "Token",
     "RootCapability",
     "ROOT",

--- a/pyisolate/capabilities.py
+++ b/pyisolate/capabilities.py
@@ -15,7 +15,7 @@ import subprocess
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Generic, Literal, TypeVar
+from typing import Any, Generic, Iterable, Literal, TypeVar
 
 T = TypeVar("T")
 
@@ -33,6 +33,177 @@ class Token(Capability[T]):
 
 class RootCapability(Token[Literal["root"]]):
     """Capability granting privileged supervisor operations."""
+
+
+class Authority(Capability[str]):
+    """Base class for first-class sandbox authority grants."""
+
+    kind: str
+
+    def to_policy_rule(self) -> dict[str, Any]:
+        """Return a YAML-serializable representation of this authority."""
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class ReadPath(Authority):
+    """Grant read access below a filesystem path."""
+
+    path: Path | str
+    kind: str = "read_path"
+
+    @property
+    def root(self) -> Path:
+        return Path(self.path).resolve(strict=False)
+
+    def allows(self, path: str | os.PathLike[str]) -> bool:
+        return Path(path).resolve(strict=False).is_relative_to(self.root)
+
+    def to_policy_rule(self) -> dict[str, str]:
+        return {"read": str(self.path)}
+
+
+@dataclass(frozen=True)
+class WritePath(Authority):
+    """Grant write access below a filesystem path."""
+
+    path: Path | str
+    kind: str = "write_path"
+
+    @property
+    def root(self) -> Path:
+        return Path(self.path).resolve(strict=False)
+
+    def allows(self, path: str | os.PathLike[str]) -> bool:
+        return Path(path).resolve(strict=False).is_relative_to(self.root)
+
+    def to_policy_rule(self) -> dict[str, str]:
+        return {"write": str(self.path)}
+
+
+@dataclass(frozen=True)
+class ConnectTCP(Authority):
+    """Grant outgoing TCP connect authority to a host and port."""
+
+    host: str
+    port: int
+    kind: str = "connect_tcp"
+
+    @classmethod
+    def from_address(cls, address: str) -> "ConnectTCP":
+        host, sep, port_text = address.rpartition(":")
+        if not sep or not host or not port_text.isdigit():
+            raise ValueError(f"TCP address must be 'host:port': {address!r}")
+        return cls(host=host, port=int(port_text))
+
+    @property
+    def address(self) -> str:
+        return f"{self.host}:{self.port}"
+
+    def allows(self, host: str, port: int) -> bool:
+        return self.host == host and self.port == port
+
+    def to_policy_rule(self) -> dict[str, str]:
+        return {"connect": self.address}
+
+
+@dataclass(frozen=True)
+class Import(Authority):
+    """Grant authority to import a module root."""
+
+    module: str
+    kind: str = "import"
+
+    def __post_init__(self) -> None:
+        if not self.module or not isinstance(self.module, str):
+            raise ValueError("module must be a non-empty string")
+
+    @property
+    def root_module(self) -> str:
+        return self.module.split(".", 1)[0]
+
+    def to_policy_rule(self) -> str:
+        return self.module
+
+
+@dataclass(frozen=True)
+class CpuBudget(Authority):
+    """Grant a bounded CPU budget in milliseconds."""
+
+    ms: int
+    kind: str = "cpu_budget"
+
+    def __post_init__(self) -> None:
+        if self.ms <= 0:
+            raise ValueError("CPU budget must be positive")
+
+    def to_policy_rule(self) -> dict[str, int]:
+        return {"cpu_ms": self.ms}
+
+
+@dataclass(frozen=True)
+class AuthoritySet:
+    """Normalized authority model shared by Python objects and YAML policy."""
+
+    read_paths: tuple[Path, ...] = ()
+    write_paths: tuple[Path, ...] = ()
+    tcp: frozenset[str] = frozenset()
+    imports: frozenset[str] = frozenset()
+    cpu_ms: int | None = None
+
+    @classmethod
+    def from_authorities(cls, authorities: Iterable[object]) -> "AuthoritySet":
+        read_paths: list[Path] = []
+        write_paths: list[Path] = []
+        tcp: set[str] = set()
+        imports: set[str] = set()
+        cpu_ms: int | None = None
+        for authority in authorities:
+            if isinstance(authority, ReadPath):
+                read_paths.append(authority.root)
+            elif isinstance(authority, WritePath):
+                write_paths.append(authority.root)
+            elif isinstance(authority, ConnectTCP):
+                tcp.add(authority.address)
+            elif isinstance(authority, Import):
+                imports.add(authority.root_module)
+            elif isinstance(authority, CpuBudget):
+                cpu_ms = authority.ms if cpu_ms is None else min(cpu_ms, authority.ms)
+            elif isinstance(authority, FilesystemCapability):
+                read_paths.extend(authority.roots)
+                write_paths.extend(authority.roots)
+            elif isinstance(authority, NetworkCapability):
+                tcp.update(authority.destinations)
+        return cls(
+            read_paths=tuple(read_paths),
+            write_paths=tuple(write_paths),
+            tcp=frozenset(tcp),
+            imports=frozenset(imports),
+            cpu_ms=cpu_ms,
+        )
+
+    def allows_read(self, path: str | os.PathLike[str]) -> bool:
+        resolved = Path(path).resolve(strict=False)
+        return any(resolved.is_relative_to(root) for root in self.read_paths)
+
+    def allows_write(self, path: str | os.PathLike[str]) -> bool:
+        resolved = Path(path).resolve(strict=False)
+        return any(resolved.is_relative_to(root) for root in self.write_paths)
+
+    def allows_tcp(self, host: str, port: int) -> bool:
+        return f"{host}:{port}" in self.tcp
+
+    def merge(self, other: "AuthoritySet") -> "AuthoritySet":
+        cpu_ms = self.cpu_ms
+        if other.cpu_ms is not None:
+            cpu_ms = other.cpu_ms if cpu_ms is None else min(cpu_ms, other.cpu_ms)
+        return AuthoritySet(
+            read_paths=self.read_paths + other.read_paths,
+            write_paths=self.write_paths + other.write_paths,
+            tcp=frozenset(set(self.tcp) | set(other.tcp)),
+            imports=frozenset(set(self.imports) | set(other.imports)),
+            cpu_ms=cpu_ms,
+        )
 
 
 @dataclass(frozen=True)
@@ -174,6 +345,13 @@ __all__ = [
     "Token",
     "RootCapability",
     "ROOT",
+    "Authority",
+    "AuthoritySet",
+    "ReadPath",
+    "WritePath",
+    "ConnectTCP",
+    "Import",
+    "CpuBudget",
     "FilesystemCapability",
     "NetworkCapability",
     "SecretCapability",

--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -68,6 +68,7 @@ except ModuleNotFoundError:  # minimal fallback when PyYAML is unavailable
     yaml = _MiniYaml()
 
 
+from ..capabilities import ConnectTCP, CpuBudget, Import, ReadPath, WritePath
 from .compiler import PolicyCompilerError, compile_policy  # noqa: F401
 logger = logging.getLogger(__name__)
 
@@ -78,18 +79,113 @@ class Policy:
     fs: list[str] = field(default_factory=list)
     tcp: list[str] = field(default_factory=list)
     imports: list[str] = field(default_factory=list)
+    capabilities: list[object] = field(default_factory=list)
+
+    def grant(self, *capabilities: object) -> "Policy":
+        """Add first-class authority objects to this policy."""
+        self.capabilities.extend(capabilities)
+        for capability in capabilities:
+            if isinstance(capability, (ReadPath, WritePath)):
+                continue
+            if isinstance(capability, ConnectTCP):
+                if capability.address not in self.tcp:
+                    self.tcp.append(capability.address)
+            elif isinstance(capability, Import):
+                if capability.module not in self.imports:
+                    self.imports.append(capability.module)
+        return self
 
     def allow_fs(self, path: str) -> "Policy":
         self.fs.append(path)
+        self.capabilities.extend([ReadPath(path), WritePath(path)])
+        return self
+
+    def allow_read(self, path: str) -> "Policy":
+        self.capabilities.append(ReadPath(path))
+        return self
+
+    def allow_write(self, path: str) -> "Policy":
+        self.capabilities.append(WritePath(path))
         return self
 
     def allow_tcp(self, addr: str) -> "Policy":
         self.tcp.append(addr)
+        try:
+            self.capabilities.append(ConnectTCP.from_address(addr))
+        except ValueError:
+            pass
         return self
 
     def allow_import(self, module: str) -> "Policy":
         self.imports.append(module)
+        self.capabilities.append(Import(module))
         return self
+
+    def cpu_budget(self, ms: int) -> "Policy":
+        self.capabilities.append(CpuBudget(ms))
+        return self
+
+    def to_dict(self, name: str = "default") -> dict[str, object]:
+        """Serialize this authority model to the YAML policy schema."""
+        fs_rules: list[object] = []
+        net_rules: list[object] = []
+        imports: list[str] = []
+        cpu_ms: int | None = None
+        for path in self.fs:
+            fs_rules.append({"allow": path})
+        for addr in self.tcp:
+            net_rules.append({"connect": addr})
+        imports.extend(self.imports)
+        for capability in self.capabilities:
+            if isinstance(capability, ReadPath):
+                fs_rules.append(capability.to_policy_rule())
+            elif isinstance(capability, WritePath):
+                fs_rules.append(capability.to_policy_rule())
+            elif isinstance(capability, ConnectTCP):
+                rule = capability.to_policy_rule()
+                if rule not in net_rules:
+                    net_rules.append(rule)
+            elif isinstance(capability, Import):
+                if capability.module not in imports:
+                    imports.append(capability.module)
+            elif isinstance(capability, CpuBudget):
+                cpu_ms = capability.ms if cpu_ms is None else min(cpu_ms, capability.ms)
+
+        sandbox: dict[str, object] = {}
+        if fs_rules:
+            sandbox["fs"] = fs_rules
+        if net_rules:
+            sandbox["net"] = net_rules
+        if imports:
+            sandbox["imports"] = imports
+        if cpu_ms is not None:
+            sandbox["cpu_ms"] = cpu_ms
+        return {"version": "1.0", "sandboxes": {name: sandbox}}
+
+    def to_yaml(self, name: str = "default") -> str:
+        """Serialize this policy to YAML using the configured YAML backend."""
+        data = self.to_dict(name)
+        if hasattr(yaml, "safe_dump"):
+            return yaml.safe_dump(data, sort_keys=False)
+
+        lines = ["version: 1.0", "sandboxes:", f"  {name}:"]
+        sandbox = data["sandboxes"][name]  # type: ignore[index]
+        for rule in sandbox.get("fs", []):
+            key, value = next(iter(rule.items()))
+            lines.append("    fs:" if "    fs:" not in lines else "")
+            lines.append(f"      - {key}: {value!r}")
+        if sandbox.get("net"):
+            lines.append("    net:")
+            for rule in sandbox["net"]:
+                key, value = next(iter(rule.items()))
+                lines.append(f"      - {key}: {value!r}")
+        if sandbox.get("imports"):
+            lines.append("    imports:")
+            for module in sandbox["imports"]:
+                lines.append(f"      - {module}")
+        if sandbox.get("cpu_ms") is not None:
+            lines.append(f"    cpu_ms: {sandbox['cpu_ms']}")
+        return "\n".join(line for line in lines if line) + "\n"
 
 
 def _validate(data: object) -> None:
@@ -196,6 +292,11 @@ def refresh_remote(
 
 __all__ = [
     "Policy",
+    "ReadPath",
+    "WritePath",
+    "ConnectTCP",
+    "Import",
+    "CpuBudget",
     "refresh",
     "compile_policy",
     "PolicyCompilerError",

--- a/pyisolate/policy/compiler.py
+++ b/pyisolate/policy/compiler.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List
 
+from ..capabilities import ConnectTCP, CpuBudget, Import, ReadPath, WritePath
+
 try:
     import yaml  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - fallback already tested
@@ -40,6 +42,8 @@ class SandboxPolicy:
     fs: List[FSRule]
     tcp: List[TCPRule]
     imports: List[str]
+    capabilities: List[object]
+    cpu_ms: int | None = None
 
 
 @dataclass
@@ -98,13 +102,18 @@ def _compile_fs(rules: List[dict], sb_name: str) -> List[FSRule]:
         if not isinstance(rule, dict) or len(rule) != 1:
             raise PolicyCompilerError(f"invalid fs rule in '{sb_name}': {rule}")
         action, path = next(iter(rule.items()))
-        if action not in ("allow", "deny"):
+        if action not in ("allow", "deny", "read", "write"):
             raise PolicyCompilerError(f"invalid fs action '{action}' in '{sb_name}'")
-        if path in seen and seen[path] != action:
+        existing = seen.get(path)
+        if (
+            existing is not None
+            and {existing, action} != {"read", "write"}
+            and existing != action
+        ):
             raise PolicyCompilerError(
                 f"conflicting fs rules for '{path}' in '{sb_name}'"
             )
-        seen[path] = action
+        seen[path] = "allow" if {existing, action} == {"read", "write"} else action
         compiled.append(FSRule(action=action, path=path))
     return compiled
 
@@ -203,10 +212,12 @@ def _resolve_sandbox(
         child_imports = _norm_rule_list(
             cfg.get("imports", []), field_name="imports", sb_name=current
         )
+        cpu_ms = cfg.get("cpu_ms", parent_cfg.get("cpu_ms", defaults.get("cpu_ms")))
         out = {
             "fs": _merge_unique(base["fs"], child_fs),
             "net": _merge_unique(base["net"], child_net),
             "imports": _merge_unique(base["imports"], child_imports),
+            "cpu_ms": cpu_ms,
         }
         resolving.remove(current)
         resolved[current] = out
@@ -269,8 +280,37 @@ def compile_policy(path: str | Path) -> CompiledPolicy:
                 )
             imports.append(module)
 
+        cpu_ms = resolved_cfg.get("cpu_ms")
+        if cpu_ms is not None:
+            if not isinstance(cpu_ms, int) or cpu_ms <= 0:
+                raise PolicyCompilerError(
+                    f"cpu_ms in '{name}' must be a positive integer"
+                )
+
+        capabilities: list[object] = []
+        for rule in fs_compiled:
+            if rule.action == "allow":
+                capabilities.extend([ReadPath(rule.path), WritePath(rule.path)])
+            elif rule.action == "read":
+                capabilities.append(ReadPath(rule.path))
+            elif rule.action == "write":
+                capabilities.append(WritePath(rule.path))
+        for rule in tcp_compiled:
+            if rule.action == "connect":
+                try:
+                    capabilities.append(ConnectTCP.from_address(rule.addr))
+                except ValueError:
+                    pass
+        capabilities.extend(Import(module) for module in imports)
+        if cpu_ms is not None:
+            capabilities.append(CpuBudget(cpu_ms))
+
         compiled_boxes[name] = SandboxPolicy(
-            fs=fs_compiled, tcp=tcp_compiled, imports=imports
+            fs=fs_compiled,
+            tcp=tcp_compiled,
+            imports=imports,
+            capabilities=capabilities,
+            cpu_ms=cpu_ms,
         )
         deny_log.extend(
             [f"sandbox={name} fs={r.path}" for r in fs_compiled if r.action == "deny"]

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -30,12 +30,18 @@ from typing import Any, Callable, Iterable, Optional
 
 from .. import errors
 from ..capabilities import (
+    AuthoritySet,
     ClockCapability,
+    ConnectTCP,
+    CpuBudget,
+    Import,
     FilesystemCapability,
     NetworkCapability,
     RandomCapability,
+    ReadPath,
     SecretCapability,
     SubprocessCapability,
+    WritePath,
 )
 from .protocol import (
     AttachCgroupRequest,
@@ -55,6 +61,8 @@ _CAPABILITY_MARKER = "__pyisolate_capability__"
 
 
 def _serialize_capability(capability: Any) -> Any:
+    if isinstance(capability, (list, tuple, set, frozenset)):
+        return [_serialize_capability(item) for item in capability]
     if isinstance(capability, FilesystemCapability):
         return {
             _CAPABILITY_MARKER: "filesystem",
@@ -78,6 +86,16 @@ def _serialize_capability(capability: Any) -> Any:
             "allowed_commands": sorted(capability.allowed_commands),
             "allow_shell": capability.allow_shell,
         }
+    if isinstance(capability, ReadPath):
+        return {_CAPABILITY_MARKER: "read_path", "path": str(capability.path)}
+    if isinstance(capability, WritePath):
+        return {_CAPABILITY_MARKER: "write_path", "path": str(capability.path)}
+    if isinstance(capability, ConnectTCP):
+        return {_CAPABILITY_MARKER: "connect_tcp", "host": capability.host, "port": capability.port}
+    if isinstance(capability, Import):
+        return {_CAPABILITY_MARKER: "import", "module": capability.module}
+    if isinstance(capability, CpuBudget):
+        return {_CAPABILITY_MARKER: "cpu_budget", "ms": capability.ms}
     if isinstance(capability, ClockCapability):
         return {_CAPABILITY_MARKER: "clock"}
     if isinstance(capability, RandomCapability):
@@ -86,6 +104,8 @@ def _serialize_capability(capability: Any) -> Any:
 
 
 def _deserialize_capability(capability: Any) -> Any:
+    if isinstance(capability, list):
+        return [_deserialize_capability(item) for item in capability]
     if not isinstance(capability, dict):
         return capability
     kind = capability.get(_CAPABILITY_MARKER)
@@ -105,6 +125,16 @@ def _deserialize_capability(capability: Any) -> Any:
         commands = capability.get("allowed_commands", [])
         allow_shell = bool(capability.get("allow_shell", False))
         return SubprocessCapability.from_commands(*commands, allow_shell=allow_shell)
+    if kind == "read_path":
+        return ReadPath(capability["path"])
+    if kind == "write_path":
+        return WritePath(capability["path"])
+    if kind == "connect_tcp":
+        return ConnectTCP(str(capability["host"]), int(capability["port"]))
+    if kind == "import":
+        return Import(str(capability["module"]))
+    if kind == "cpu_budget":
+        return CpuBudget(int(capability["ms"]))
     if kind == "clock":
         return ClockCapability()
     if kind == "random":
@@ -124,11 +154,37 @@ def serialize_capabilities(capabilities: Optional[dict[str, Any]]) -> dict[str, 
 def deserialize_capabilities(capabilities: Optional[dict[str, Any]]) -> dict[str, Any]:
     if not capabilities:
         return {}
+    if not isinstance(capabilities, dict):
+        return {"authority": capabilities}
     return {
         name: _deserialize_capability(capability)
         for name, capability in capabilities.items()
     }
 
+
+
+
+def _iter_authorities(policy, capabilities: Optional[dict[str, Any]]) -> list[object]:
+    authorities: list[object] = []
+    if policy is not None:
+        authorities.extend(getattr(policy, "capabilities", []) or [])
+        for path in getattr(policy, "fs", []) or []:
+            authorities.extend([ReadPath(path), WritePath(path)])
+        for addr in getattr(policy, "tcp", []) or []:
+            try:
+                authorities.append(ConnectTCP.from_address(addr))
+            except ValueError:
+                pass
+        for module in getattr(policy, "imports", []) or []:
+            authorities.append(Import(module))
+    if capabilities:
+        values = capabilities.values() if isinstance(capabilities, dict) else capabilities
+        for capability in values:
+            if isinstance(capability, (list, tuple, set, frozenset)):
+                authorities.extend(capability)
+            else:
+                authorities.append(capability)
+    return authorities
 
 def _blocked_open(file, *args, **kwargs):
     """Restrict file access based on the current thread's policy."""
@@ -139,9 +195,20 @@ def _blocked_open(file, *args, **kwargs):
     if isinstance(file, (str, bytes)):
         path = Path(file).resolve(strict=False)
 
+        mode = args[0] if args else kwargs.get("mode", "r")
+        text_mode = str(mode)
+        wants_write = any(flag in text_mode for flag in ("w", "a", "x", "+"))
+        authority = getattr(_thread_local, "authority", None)
         fs_cap = getattr(_thread_local, "fs_capability", None)
         allowed = getattr(_thread_local, "fs", None)
-        if fs_cap is not None:
+        if authority is not None:
+            if wants_write:
+                permitted = authority.allows_write(path)
+            else:
+                permitted = authority.allows_read(path)
+            if not permitted:
+                raise errors.PolicyError("file access blocked")
+        elif fs_cap is not None:
             if not fs_cap.allows(path):
                 raise errors.PolicyError("file access blocked")
         elif allowed is not None:
@@ -166,13 +233,17 @@ def _blocked_open(file, *args, **kwargs):
 
 
 def _guarded_connect(self_socket: socket.socket, address: Iterable[str]):
+    authority = getattr(_thread_local, "authority", None)
     net_cap = getattr(_thread_local, "net_capability", None)
     allowed = getattr(_thread_local, "tcp", None)
     if isinstance(address, tuple):
         host, port, *_ = address
     else:
         host, port = address
-    if net_cap is not None:
+    if authority is not None:
+        if not authority.allows_tcp(str(host), int(port)):
+            raise errors.PolicyError(f"connect blocked: {host}:{port}")
+    elif net_cap is not None:
         if not net_cap.allows(str(host), int(port)):
             raise errors.PolicyError(f"connect blocked: {host}:{port}")
     elif allowed is not None:
@@ -393,6 +464,8 @@ class SandboxThread(threading.Thread):
         imports: set[str] = set()
         if policy is not None and getattr(policy, "imports", None):
             imports.update(policy.imports)
+        if policy is not None:
+            imports.update(AuthoritySet.from_authorities(getattr(policy, "capabilities", []) or []).imports)
 
         allowed_imports_provided = allowed_imports is not None
         if allowed_imports_provided:
@@ -418,7 +491,8 @@ class SandboxThread(threading.Thread):
         capabilities: Optional[dict[str, Any]] = None,
     ) -> None:
         self.policy = policy
-        self.cpu_quota_ms = cpu_ms
+        self._authority = AuthoritySet.from_authorities(_iter_authorities(policy, capabilities))
+        self.cpu_quota_ms = cpu_ms if cpu_ms is not None else self._authority.cpu_ms
         self.mem_quota_bytes = mem_bytes
         self.wall_time_ms = wall_time_ms
         self.open_files_max = open_files_max
@@ -796,6 +870,11 @@ class SandboxThread(threading.Thread):
                 else:
                     _thread_local.tcp = allowed_tcp
                 _thread_local.fs = allowed_fs
+                _thread_local.authority = (
+                    self._authority
+                    if _iter_authorities(self.policy, self._capabilities)
+                    else None
+                )
                 _thread_local.fs_capability = self._capabilities.get("filesystem")
                 _thread_local.net_capability = self._capabilities.get("network")
                 _thread_local.subprocess_capability = self._capabilities.get(

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -328,7 +328,7 @@ class Supervisor:
             handle = CapabilityHandle(kind="root", subject=op)
         else:
             if self._policy_token is None or token != self._policy_token:
-                logger.warning("control operation rejected: %s", op)
+                logger.warning("control operation rejected: %s: invalid token", op)
                 raise PolicyAuthError("invalid policy token")
             handle = CapabilityHandle(kind="policy-token", subject=op)
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -139,3 +139,52 @@ def test_network_and_entropy_capabilities() -> None:
     finally:
         sup.shutdown(ROOT)
         srv.close()
+
+
+def test_first_class_path_capabilities_split_read_and_write(tmp_path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    source = input_dir / "data.txt"
+    source.write_text("payload")
+
+    sup = iso.Supervisor()
+    sb = sup.spawn(
+        "object-path-caps",
+        policy=iso.policy.Policy().grant(
+            iso.ReadPath(input_dir),
+            iso.WritePath(output_dir),
+            iso.Import("pathlib"),
+        ),
+    )
+    try:
+        sb.exec(f"post(open({str(source)!r}).read())")
+        assert sb.recv(timeout=1) == "payload"
+
+        target = output_dir / "result.txt"
+        sb.exec(f"open({str(target)!r}, 'w').write('done'); post('ok')")
+        assert sb.recv(timeout=1) == "ok"
+        assert target.read_text() == "done"
+
+        sb.exec(f"open({str(source)!r}, 'w').write('blocked')")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sup.shutdown(ROOT)
+
+
+def test_first_class_tcp_import_and_cpu_budget() -> None:
+    p = iso.policy.Policy().grant(
+        iso.ConnectTCP("api.example.com", 443), iso.Import("math"), iso.CpuBudget(25)
+    )
+    assert p.tcp == ["api.example.com:443"]
+    assert p.imports == ["math"]
+
+    sb = iso.spawn("object-import-cpu", policy=p)
+    try:
+        assert sb._thread.cpu_quota_ms == 25
+        sb.exec("import math; post(math.sqrt(9))")
+        assert sb.recv(timeout=1) == 3.0
+    finally:
+        sb.close()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -374,3 +374,57 @@ def test_reload_policy_rejects_non_canonical_root(monkeypatch, tmp_path, caplog)
         with pytest.raises(iso.PolicyAuthError):
             iso.reload_policy(str(path), token=fake)
     assert "invalid token" in caplog.text
+
+
+def test_compile_policy_emits_first_class_capabilities(tmp_path):
+    import pyisolate.policy as policy
+    from pyisolate.capabilities import ConnectTCP, CpuBudget, Import, ReadPath, WritePath
+
+    doc = (
+        "version: 1.0\n"
+        "sandboxes:\n"
+        "  sb:\n"
+        "    fs:\n"
+        '      - read: "/tmp/input"\n'
+        '      - write: "/tmp/output"\n'
+        "    net:\n"
+        '      - connect: "api.example.com:443"\n'
+        "    imports: [math]\n"
+        "    cpu_ms: 50\n"
+    )
+    f = tmp_path / "p.yml"
+    f.write_text(doc)
+
+    compiled = policy.compile_policy(str(f))
+    caps = compiled.sandboxes["sb"].capabilities
+    assert any(isinstance(cap, ReadPath) and str(cap.path) == "/tmp/input" for cap in caps)
+    assert any(isinstance(cap, WritePath) and str(cap.path) == "/tmp/output" for cap in caps)
+    assert any(isinstance(cap, ConnectTCP) and cap.address == "api.example.com:443" for cap in caps)
+    assert any(isinstance(cap, Import) and cap.module == "math" for cap in caps)
+    assert any(isinstance(cap, CpuBudget) and cap.ms == 50 for cap in caps)
+    assert compiled.sandboxes["sb"].cpu_ms == 50
+
+
+def test_policy_objects_serialize_to_yaml_shape():
+    import pyisolate as iso
+    from pyisolate import policy
+
+    p = policy.Policy().grant(
+        iso.ReadPath("/tmp/input"),
+        iso.WritePath("/tmp/output"),
+        iso.ConnectTCP("api.example.com", 443),
+        iso.Import("math"),
+        iso.CpuBudget(50),
+    )
+
+    assert p.to_dict("job") == {
+        "version": "1.0",
+        "sandboxes": {
+            "job": {
+                "fs": [{"read": "/tmp/input"}, {"write": "/tmp/output"}],
+                "net": [{"connect": "api.example.com:443"}],
+                "imports": ["math"],
+                "cpu_ms": 50,
+            }
+        },
+    }


### PR DESCRIPTION
### Motivation
- Replace ad‑hoc YAML-only policy with a first-class authority model so callers can hand `ReadPath`, `WritePath`, `ConnectTCP`, `Import`, `CpuBudget`, etc., directly to the runtime and have YAML remain a serialization of the same model. 
- Allow finer-grained semantics (e.g. split read vs write path grants) and a normalized `AuthoritySet` to drive runtime enforcement and import/CPU wiring.

### Description
- Added a family of authority classes in `pyisolate/capabilities.py`: `Authority`, `ReadPath`, `WritePath`, `ConnectTCP`, `Import`, `CpuBudget` and `AuthoritySet`, and extended `__all__` exports so they are available from the top-level package.  (see `pyisolate/capabilities.py`).
- Extended `Policy` in `pyisolate/policy/__init__.py` with `capabilities` and a `grant()` API and implemented `to_dict()`/`to_yaml()` so object-based policies serialize to the same YAML shape as the DSL. Legacy helpers remain and are converted into the authority model (`allow_fs` → read+write).  (see `pyisolate/policy/__init__.py`).
- Updated the YAML compiler in `pyisolate/policy/compiler.py` to accept `read`/`write` filesystem rules, `cpu_ms`, and to emit a `capabilities` list in the `SandboxPolicy` containing first-class capability objects.  (see `pyisolate/policy/compiler.py`).
- Plumbed capability serialization/deserialization and enforcement into the runtime in `pyisolate/runtime/thread.py`: added (de)serialization for first-class authorities, computed an `AuthoritySet` from the union of `policy` objects and handed capabilities, and enforced read/write/connect checks using the authority model (`_blocked_open`, `_guarded_connect`, importer wiring and CPU budget resolution).  (see `pyisolate/runtime/thread.py`).
- Minor supervisor logging tweak to improve diagnostic on control-plane auth rejection. (see `pyisolate/supervisor.py`).
- Documentation updates in `POLICY.md` and `API.md` describing the object-based authority model and examples, plus new unit tests that cover object grants and serialization. (see `POLICY.md`, `API.md`, `tests/test_capabilities.py`, `tests/test_policy.py`).

### Testing
- Ran the capability & policy focused test suite: `pytest -q tests/test_capabilities.py tests/test_policy.py tests/test_policy_enforcement.py` and all tests passed (39 passed). 
- Performed static compile checks with `python -m py_compile` on the modified modules and they succeeded. 
- Note: a full local run of the entire test-suite depends on host toolchain / kernel helpers (BPF toolchain, `bpftool`, etc.); running the entire suite in this environment previously surfaced host/tooling-related failures (BPF compilation / stub manager differences) that are not related to the authority-model changes and should be validated in CI with the proper toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0472a83c5c832885d93a2b524c5f8a)