### PR TITLE
Add hostile workload corpus and sandbox guards

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -53,6 +53,51 @@ _ORIG_SOCKET_CONNECT = socket.socket.connect
 _ORIG_THREAD_START = threading.Thread.start
 _CAPABILITY_MARKER = "__pyisolate_capability__"
 
+# Modules that hand guest code raw process, native ABI, or unsafe
+# deserialization primitives are denied even when a broad/default importer is
+# installed. They require dedicated brokered capabilities before they can be
+# made safe for hostile workloads.
+_DENIED_IMPORT_ROOTS = {
+    "_cffi_backend",
+    "_ctypes",
+    "_testcapi",
+    "_testinternalcapi",
+    "cffi",
+    "ctypes",
+    "faulthandler",
+    "marshal",
+    "mmap",
+    "multiprocessing",
+    "pickle",
+}
+
+_DANGEROUS_OS_CALLS = (
+    "execl",
+    "execle",
+    "execlp",
+    "execlpe",
+    "execv",
+    "execve",
+    "execvp",
+    "execvpe",
+    "fork",
+    "forkpty",
+    "kill",
+    "killpg",
+    "popen",
+    "posix_spawn",
+    "posix_spawnp",
+    "spawnl",
+    "spawnle",
+    "spawnlp",
+    "spawnlpe",
+    "spawnv",
+    "spawnve",
+    "spawnvp",
+    "spawnvpe",
+    "system",
+)
+
 
 def _serialize_capability(capability: Any) -> Any:
     if isinstance(capability, FilesystemCapability):
@@ -130,25 +175,30 @@ def deserialize_capabilities(capabilities: Optional[dict[str, Any]]) -> dict[str
     }
 
 
-def _blocked_open(file, *args, **kwargs):
-    """Restrict file access based on the current thread's policy."""
-
+def _check_fs_access(file) -> None:
     if isinstance(file, os.PathLike):
         file = os.fspath(file)
 
-    if isinstance(file, (str, bytes)):
-        path = Path(file).resolve(strict=False)
+    if not isinstance(file, (str, bytes)):
+        return
 
-        fs_cap = getattr(_thread_local, "fs_capability", None)
-        allowed = getattr(_thread_local, "fs", None)
-        if fs_cap is not None:
-            if not fs_cap.allows(path):
-                raise errors.PolicyError("file access blocked")
-        elif allowed is not None:
-            if not any(path.is_relative_to(a) for a in allowed):
-                raise errors.PolicyError("file access blocked")
-        elif getattr(_thread_local, "active", False):
+    path = Path(file).resolve(strict=False)
+    fs_cap = getattr(_thread_local, "fs_capability", None)
+    allowed = getattr(_thread_local, "fs", None)
+    if fs_cap is not None:
+        if not fs_cap.allows(path):
             raise errors.PolicyError("file access blocked")
+    elif allowed is not None:
+        if not any(path.is_relative_to(a) for a in allowed):
+            raise errors.PolicyError("file access blocked")
+    elif getattr(_thread_local, "active", False):
+        raise errors.PolicyError("file access blocked")
+
+
+def _blocked_open(file, *args, **kwargs):
+    """Restrict file access based on the current thread's policy."""
+
+    _check_fs_access(file)
 
     sandbox = getattr(_thread_local, "sandbox", None)
     if sandbox is not None:
@@ -198,6 +248,17 @@ def _blocked_subprocess_run(*args, **kwargs):
     return cap.run(*args, **kwargs)
 
 
+def _blocked_process_primitive(*args, **kwargs):
+    raise errors.PolicyError("process primitive blocked")
+
+
+def _guarded_os_open(path, flags, mode=0o777, *, dir_fd=None):
+    if dir_fd is not None:
+        raise errors.PolicyError("dir_fd file access blocked")
+    _check_fs_access(path)
+    return os.open(path, flags, mode)
+
+
 def _guarded_urandom(n: int) -> bytes:
     cap = getattr(_thread_local, "random_capability", None)
     if cap is None:
@@ -231,6 +292,7 @@ def _make_sandbox_thread_class(sandbox: "SandboxThread"):
 def _wrap_module(name: str, module):
     base = name.split(".")[0]
     if base == "time":
+
         def _require_clock() -> ClockCapability:
             cap = getattr(_thread_local, "clock_capability", None)
             return cap
@@ -271,7 +333,27 @@ def _wrap_module(name: str, module):
         class GuardedSocket(socket.socket):
             connect = _guarded_connect
 
+        def _guarded_create_connection(
+            address,
+            timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
+            source_address=None,
+            *,
+            all_errors=False,
+        ):
+            sock = GuardedSocket(socket.AF_INET, socket.SOCK_STREAM)
+            if timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+                sock.settimeout(timeout)
+            if source_address is not None:
+                sock.bind(source_address)
+            try:
+                sock.connect(address)
+            except Exception:
+                sock.close()
+                raise
+            return sock
+
         mod.socket = GuardedSocket
+        mod.create_connection = _guarded_create_connection
         return mod
     if base == "subprocess":
         mod = types.ModuleType("subprocess", module.__doc__)
@@ -281,7 +363,11 @@ def _wrap_module(name: str, module):
     if base == "os":
         mod = types.ModuleType("os", module.__doc__)
         mod.__dict__.update({k: getattr(os, k) for k in dir(os)})
+        mod.open = _guarded_os_open
         mod.urandom = _guarded_urandom
+        for attr in _DANGEROUS_OS_CALLS:
+            if hasattr(mod, attr):
+                setattr(mod, attr, _blocked_process_primitive)
         return mod
     if base == "secrets":
         mod = types.ModuleType("secrets", module.__doc__)
@@ -323,7 +409,20 @@ def _wrap_module(name: str, module):
     return module
 
 
+def _import_root(name: str) -> str:
+    return name.split(".", 1)[0]
+
+
+def _check_import_allowed(name: str, allowed_set: Optional[set[str]]) -> None:
+    base = _import_root(name)
+    if base in _DENIED_IMPORT_ROOTS:
+        raise errors.PolicyError(f"import of {name!r} is denied by sandbox policy")
+    if allowed_set is not None and base not in allowed_set:
+        raise errors.PolicyError(f"import of {name!r} is not permitted")
+
+
 def _sandbox_import(name, globals=None, locals=None, fromlist=(), level=0):
+    _check_import_allowed(name, None)
     module = builtins.__import__(name, globals, locals, fromlist, level)
     return _wrap_module(name, module)
 
@@ -331,12 +430,10 @@ def _sandbox_import(name, globals=None, locals=None, fromlist=(), level=0):
 def _make_importer(allowed: Optional[Iterable[str]]):
     if allowed is None:
         return _sandbox_import
-    allowed_set = {name.split(".")[0] for name in allowed}
+    allowed_set = {_import_root(name) for name in allowed}
 
     def _import(name, globals=None, locals=None, fromlist=(), level=0):
-        base = name.split(".")[0]
-        if base not in allowed_set:
-            raise errors.PolicyError(f"import of {name!r} is not permitted")
+        _check_import_allowed(name, allowed_set)
         module = builtins.__import__(name, globals, locals, fromlist, level)
         return _wrap_module(name, module)
 
@@ -501,9 +598,11 @@ class SandboxThread(threading.Thread):
             "policy": self.policy,
             "cpu_ms": self.cpu_quota_ms,
             "mem_bytes": self.mem_quota_bytes,
-            "allowed_imports": sorted(self.allowed_imports)
-            if self.allowed_imports is not None
-            else None,
+            "allowed_imports": (
+                sorted(self.allowed_imports)
+                if self.allowed_imports is not None
+                else None
+            ),
             "numa_node": self.numa_node,
             "capabilities": serialize_capabilities(self._capabilities),
             "wall_time_ms": self.wall_time_ms,
@@ -524,9 +623,11 @@ class SandboxThread(threading.Thread):
             "network_ops_max": self.network_ops_max,
             "output_bytes_max": self.output_bytes_max,
             "child_work_max": self.child_work_max,
-            "allowed_imports": sorted(self.allowed_imports)
-            if self.allowed_imports is not None
-            else None,
+            "allowed_imports": (
+                sorted(self.allowed_imports)
+                if self.allowed_imports is not None
+                else None
+            ),
             "numa_node": self.numa_node,
             "capabilities": serialize_capabilities(self._capabilities),
         }
@@ -557,7 +658,10 @@ class SandboxThread(threading.Thread):
 
     def _post(self, item: Any) -> None:
         self._output_bytes += self._estimate_output_size(item)
-        if self.output_bytes_max is not None and self._output_bytes > self.output_bytes_max:
+        if (
+            self.output_bytes_max is not None
+            and self._output_bytes > self.output_bytes_max
+        ):
             raise errors.OutputExceeded()
         self._outbox.put(item)
 

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -8,6 +8,7 @@ requires eBPF enforcement which is not implemented here.
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import os
 import re
@@ -133,7 +134,11 @@ class Supervisor:
         bpf_mod = importlib.import_module("pyisolate.bpf.manager")
         self._bpf = bpf_mod.BPFManager()
         self._rollout_mode = rollout_mode
-        self._bpf.load(mode=rollout_mode)
+        load_signature = inspect.signature(self._bpf.load)
+        if "mode" in load_signature.parameters:
+            self._bpf.load(mode=rollout_mode)
+        else:
+            self._bpf.load()
         self._recover_state()
         self._warm_pool: list[SandboxThread] = []
         for i in range(warm_pool):
@@ -321,7 +326,9 @@ class Supervisor:
         with self._lock:
             return [t for t in self._sandboxes.values() if t.is_alive()]
 
-    def _authorize_control(self, token: str | RootCapability, op: str) -> ControlRequest:
+    def _authorize_control(
+        self, token: str | RootCapability, op: str
+    ) -> ControlRequest:
         """Validate an authenticated control-plane operation request."""
 
         if token is ROOT:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 markers = [
     "adversarial: adversarial input and exploit-style behavior",
+    "hostile: hostile workload corpus cases that must be rejected safely",
     "runaway_cpu: CPU quota and runaway loop enforcement",
     "memory_exhaustion: memory pressure and exhaustion scenarios",
     "import_escape: module import escape attempts",

--- a/tests/hostile_workloads/__init__.py
+++ b/tests/hostile_workloads/__init__.py
@@ -1,0 +1,5 @@
+"""Hostile workload corpus for PyIsolate adversarial tests."""
+
+from .corpus import HOSTILE_WORKLOADS, HostileWorkload
+
+__all__ = ["HOSTILE_WORKLOADS", "HostileWorkload"]

--- a/tests/hostile_workloads/corpus.py
+++ b/tests/hostile_workloads/corpus.py
@@ -1,0 +1,128 @@
+"""Executable hostile snippets that should be boring to PyIsolate.
+
+Each workload is intentionally small and deterministic: the goal is not to
+weaponize the test process, but to keep a regression corpus of behaviors that
+real attackers routinely try against language-level sandboxes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class HostileWorkload:
+    """A single hostile guest program and the sandbox outcome it must trigger."""
+
+    name: str
+    category: str
+    source: str
+    expected_exception: str = "PolicyError"
+    allowed_imports: tuple[str, ...] | None = None
+    spawn_kwargs: dict[str, Any] = field(default_factory=dict)
+    policy: str | None = None
+
+
+HOSTILE_WORKLOADS: tuple[HostileWorkload, ...] = (
+    HostileWorkload(
+        name="object_graph_import_escape",
+        category="escape_attempt",
+        source=(
+            "# Reconnaissance through object.__subclasses__ must not become an import escape.\n"
+            "classes = (1).__class__.__mro__[1].__subclasses__()\n"
+            "__import__('os')\n"
+            "post(len(classes))\n"
+        ),
+        allowed_imports=(),
+    ),
+    HostileWorkload(
+        name="dunder_import_abuse",
+        category="import_abuse",
+        source="__import__('os').system('echo escaped')",
+        allowed_imports=("math",),
+    ),
+    HostileWorkload(
+        name="fork_bomb_primitive",
+        category="fork_bomb",
+        source="import os\nfor _ in range(3):\n    os.fork()\npost('forked')",
+        allowed_imports=("os",),
+    ),
+    HostileWorkload(
+        name="thread_bomb_quota",
+        category="fork_bomb",
+        source=(
+            "import threading\n"
+            "for _ in range(3):\n"
+            "    threading.Thread(target=lambda: None).start()\n"
+            "post('threaded')\n"
+        ),
+        expected_exception="ChildWorkExceeded",
+        allowed_imports=("threading",),
+        spawn_kwargs={"child_work_max": 0},
+    ),
+    HostileWorkload(
+        name="anonymous_mmap_allocation",
+        category="mmap_trick",
+        source="import mmap\npost(mmap.mmap(-1, 1 << 30))",
+        allowed_imports=("mmap",),
+    ),
+    HostileWorkload(
+        name="raw_socket_connect",
+        category="socket_attempt",
+        source="import socket\ns = socket.socket()\ns.connect(('203.0.113.10', 443))",
+        allowed_imports=("socket",),
+    ),
+    HostileWorkload(
+        name="socket_create_connection_helper",
+        category="socket_attempt",
+        source="import socket\nsocket.create_connection(('203.0.113.10', 443), timeout=0.01)",
+        allowed_imports=("socket",),
+    ),
+    HostileWorkload(
+        name="symlink_escape_to_host_file",
+        category="symlink_race",
+        source="post(open({blocked_symlink!r}).read())",
+        policy="tmp_allowed_dir",
+    ),
+    HostileWorkload(
+        name="pickle_gadget_loader",
+        category="pickle_ctypes_cffi_dlopen",
+        source=(
+            "import pickle\n"
+            "payload = b'cos\\nsystem\\n(S\\'echo pickle_escape\\'\\ntR.'\n"
+            "pickle.loads(payload)\n"
+        ),
+        allowed_imports=("pickle",),
+    ),
+    HostileWorkload(
+        name="ctypes_dlopen",
+        category="pickle_ctypes_cffi_dlopen",
+        source="import ctypes\nctypes.CDLL('libc.so.6').system(b'echo ctypes_escape')",
+        allowed_imports=("ctypes",),
+    ),
+    HostileWorkload(
+        name="cffi_dlopen",
+        category="pickle_ctypes_cffi_dlopen",
+        source="import cffi\nffi = cffi.FFI()\nffi.dlopen('libc.so.6')",
+        allowed_imports=("cffi",),
+    ),
+    HostileWorkload(
+        name="native_extension_crash_probe",
+        category="native_extension_crash",
+        source="import _testcapi\n_testcapi.crash_no_current_thread()",
+        allowed_imports=("_testcapi",),
+    ),
+    HostileWorkload(
+        name="os_open_bypasses_builtin_open",
+        category="escape_attempt",
+        source="import os\nfd = os.open('/etc/hosts', os.O_RDONLY)\npost(os.read(fd, 32))",
+        allowed_imports=("os",),
+    ),
+    HostileWorkload(
+        name="subprocess_without_capability",
+        category="escape_attempt",
+        source="import subprocess\nsubprocess.run(['sh', '-c', 'echo subprocess_escape'])",
+        allowed_imports=("subprocess",),
+    ),
+)

--- a/tests/test_hostile_workloads.py
+++ b/tests/test_hostile_workloads.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pyisolate as iso
+from pyisolate import policy
+from tests.hostile_workloads import HOSTILE_WORKLOADS, HostileWorkload
+
+_EXPECTED_EXCEPTIONS = {
+    "ChildWorkExceeded": iso.ChildWorkExceeded,
+    "PolicyError": iso.PolicyError,
+}
+
+
+def _spawn_for_case(case: HostileWorkload, tmp_path: Path):
+    kwargs = dict(case.spawn_kwargs)
+    source = case.source
+    case_policy = None
+
+    if case.policy == "tmp_allowed_dir":
+        allowed_dir = tmp_path / "allowed"
+        allowed_dir.mkdir()
+        blocked_symlink = allowed_dir / "hosts-link"
+        blocked_symlink.symlink_to("/etc/hosts")
+        source = source.format(blocked_symlink=str(blocked_symlink))
+        case_policy = policy.Policy().allow_fs(str(allowed_dir))
+
+    if case.allowed_imports is not None:
+        kwargs["allowed_imports"] = list(case.allowed_imports)
+    if case_policy is not None:
+        kwargs["policy"] = case_policy
+
+    sandbox = iso.spawn(f"hostile-{case.name[:40].replace('_', '-')}", **kwargs)
+    return sandbox, source
+
+
+@pytest.mark.adversarial
+@pytest.mark.hostile
+@pytest.mark.parametrize("case", HOSTILE_WORKLOADS, ids=lambda case: case.name)
+def test_hostile_workload_corpus_is_rejected(case, tmp_path):
+    expected = _EXPECTED_EXCEPTIONS[case.expected_exception]
+    sandbox, source = _spawn_for_case(case, tmp_path)
+    try:
+        sandbox.exec(source)
+        with pytest.raises(expected):
+            sandbox.recv(timeout=1)
+    finally:
+        sandbox.close()
+
+
+@pytest.mark.adversarial
+@pytest.mark.hostile
+def test_hostile_corpus_documents_required_categories():
+    categories = {case.category for case in HOSTILE_WORKLOADS}
+    assert {
+        "escape_attempt",
+        "import_abuse",
+        "fork_bomb",
+        "mmap_trick",
+        "socket_attempt",
+        "symlink_race",
+        "pickle_ctypes_cffi_dlopen",
+        "native_extension_crash",
+    } <= categories


### PR DESCRIPTION
### Motivation
- Provide a deterministic corpus of hostile guest snippets (escape attempts, import abuse, fork/thread bombs, mmap tricks, socket connects, symlink races, pickle/ctypes/cffi/dlopen attempts, native-extension probes and subprocess attempts) so regression tests make attackery boring rather than flaky. 

### Description
- Add a parametrized corpus in `tests/hostile_workloads/corpus.py` and harness `tests/test_hostile_workloads.py` with a new pytest marker `hostile` so cases can be run via `pytest -m hostile`.
- Harden the sandbox runtime in `pyisolate/runtime/thread.py` by denying sensitive import roots (`_DENIED_IMPORT_ROOTS`), checking imports via `_check_import_allowed`, enforcing filesystem checks via `_check_fs_access` (used by `open` and a guarded `os.open`), and blocking process primitives via `_blocked_process_primitive` for dangerous `os.*` calls.
- Route `socket.create_connection` through the guarded connect path and add a `GuardedSocket` to centralize connect policy enforcement.
- Make `Supervisor` initialization tolerant of test doubles that provide a `BPFManager.load` without the `mode` parameter by inspecting the `load` signature before calling it (`pyisolate/supervisor.py`).

### Testing
- Ran the hostile corpus alone with `pytest -q -m hostile` and all hostile cases passed (`15 passed`).
- Ran a focused set of related tests (`tests/test_hostile_workloads.py`, network/capabilities/policy/thread imports/matrix hardening) and they passed (`41 passed` for that subset).
- Ran the full test suite; the suite produced `217 passed, 5 failed` and the remaining failures are due to unrelated full-suite interactions (BPF manager stubs and recovery registry cleanup) rather than the hostile-corpus changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0472dd78dc8328926d3d56bb9500b2)