### PR TITLE
Assert denied socket connect and ensure sandbox cleanup in test_named_policy_applies_runtime_restrictions

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -410,6 +410,12 @@ def test_named_policy_applies_runtime_restrictions(tmp_path):
             "finally:\n"
             "    s.close()\n"
         )
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
 def test_compile_policy_emits_first_class_capabilities(tmp_path):
     import pyisolate.policy as policy
     from pyisolate.capabilities import ConnectTCP, CpuBudget, Import, ReadPath, WritePath


### PR DESCRIPTION
### Motivation
- Make the `test_named_policy_applies_runtime_restrictions` test explicitly assert that a denied network operation raises `iso.PolicyError` and ensure the spawned sandbox is always cleaned up to avoid leaking resources between tests.

### Description
- After the socket `sb.exec(...)` call, add `with pytest.raises(iso.PolicyError): sb.recv(timeout=1)` to assert the denied network operation.
- Wrap the test body in a `try:` / `finally:` and call `sb.close()` in the `finally` block to guarantee sandbox cleanup before the next test definition begins.
- Ensure the `def test_compile_policy_emits_first_class_capabilities(...)` definition starts after the completed `try`/`finally` block.

### Testing
- `python -m py_compile tests/test_policy.py` succeeded.
- Running `pytest tests/test_policy.py::test_named_policy_applies_runtime_restrictions` was attempted but failed before reaching the modified assertion due to a pre-existing `IndentationError` in `pyisolate/runtime/thread.py` (line 280).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34000a06c083288516caa419f911e2)