### PR TITLE
Add isort pre-commit hook and configure isort with Black profile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
   - repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ A `Dockerfile` and experimental operator are included. See [docs/kubernetes.md](
 ## Contributing
 
 1. Fork & create a feature branch.
-2. Enable `pre‑commit` hooks (`pre‑commit install`). Black handles formatting and import ordering, alongside Flake8, Pylint, and Mypy for linting.
+2. Enable `pre‑commit` hooks (`pre‑commit install`). Black handles formatting and isort handles import ordering, alongside Flake8, Pylint, and Mypy for linting.
 3. Run `pre-commit run --all-files` and ensure CI passes.
 4. Submit a PR with docs & tests.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "pytest",
     "pre-commit",
     "black",
+    "isort",
     "flake8",
     "pylint",
     "mypy",
@@ -53,3 +54,6 @@ markers = [
     "crash_injection: injected crash/fault-recovery scenarios",
     "cross_kernel: kernel-version compatibility scenarios",
 ]
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
### Motivation
- Ensure `pre-commit run isort` resolves to a real hook and enforce import ordering consistently across the project.
- Add `isort` to development dependencies and align its formatting profile with `black` for consistent formatting rules.

### Description
- Add an `isort` hook entry to `.pre-commit-config.yaml` pointing at `https://github.com/PyCQA/isort` with `rev: 5.13.2` and `id: isort`.
- Add `"isort"` to the `dev` optional dependencies in `pyproject.toml` and append a `[tool.isort]` section with `profile = "black"`.
- Update `README.md` contributing guidance to state that `isort` handles import ordering alongside `black` for formatting.

### Testing
- Ran configuration assertions via a short Python script that verified `.pre-commit-config.yaml`, `pyproject.toml`, and `README.md` contain the expected `isort` entries and they passed.
- Ran `git diff --check` which reported no issues for the modified files and the check passed.
- Attempted to run `pre-commit run isort --all-files` but `pre-commit` is not installed in the environment and `python -m pip install pre-commit` failed due to package index access returning `403 Forbidden`, so the hook execution could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a341c8ac6108328843d0e2743d0e79d)