### PR TITLE
Include BPF C sources in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["pyisolate", "pyisolate.*"]
 
+[tool.setuptools.package-data]
+"pyisolate.bpf" = ["*.bpf.c"]
+
 [project.scripts]
 pyisolate = "pyisolate.cli:main"
 pyisolate-doctor = "pyisolate.doctor:main"


### PR DESCRIPTION
### Motivation
- Ensure the eBPF C source files under `pyisolate/bpf` are packaged into built distributions so the runtime `BPFManager` can access `*.bpf.c` sources when the package is installed.

### Description
- Add a `[tool.setuptools.package-data]` section to `pyproject.toml` and configure `"pyisolate.bpf" = ["*.bpf.c"]` so `pyisolate/bpf/*.bpf.c` are included in wheels and sdists.

### Testing
- Built with `PYENV_VERSION=3.11.15 python -m pip wheel . --no-deps --no-build-isolation -w dist` and `setuptools.build_meta.build_sdist('dist')` and inspected the produced wheel and sdist to confirm `pyisolate/bpf/dummy.bpf.c`, `pyisolate/bpf/syscall_filter.bpf.c`, and `pyisolate/bpf/resource_guard.bpf.c` are present (succeeded); attempts to run `python -m build`, `python -m pip install build`, and `uv build` encountered environment/package index connectivity or missing-module issues unrelated to the change (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a341d98a6b88328877d45b57290ab52)