### PR TITLE
Fix doctor CLI argument parsing

### DIFF
--- a/pyisolate/doctor.py
+++ b/pyisolate/doctor.py
@@ -96,7 +96,6 @@ def assert_hardened_supported(report: dict[str, Any] | None = None) -> None:
         raise RuntimeError(f"PyIsolate hardened mode is unsupported: {details}")
 from .conformance import ConformanceSuite
 from .nogil import imported_native_extensions, no_gil_readiness_report
-from .provenance import installation_report_json
 
 
 def _print_json(payload: object) -> None:
@@ -142,14 +141,6 @@ def main(argv: list[str] | None = None) -> None:
         default="dev",
         help="Validate requirements for the selected rollout mode.",
     )
-    args = parser.parse_args(argv)
-    report = doctor_report(mode=args.mode)
-    print(json.dumps(report, indent=2, sort_keys=True))
-    if args.mode == "hardened" and report["doctor"]["failures"]:
-        raise SystemExit(1)
-    args = parser.parse_args(argv)
-    if args.grade:
-        print(ConformanceSuite().grade().to_json())
     subparsers = parser.add_subparsers(dest="command")
 
     gil_parser = subparsers.add_parser(
@@ -169,6 +160,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     args = parser.parse_args(argv)
+
     if args.command == "gil":
         report = no_gil_readiness_report()
         if args.json:
@@ -176,6 +168,7 @@ def main(argv: list[str] | None = None) -> None:
         else:
             _print_gil_human(report)
         return
+
     if args.command == "extensions":
         extensions = imported_native_extensions()
         if args.json:
@@ -183,7 +176,15 @@ def main(argv: list[str] | None = None) -> None:
         else:
             _print_extensions_human(extensions)
         return
-    print(installation_report_json())
+
+    if args.grade:
+        print(ConformanceSuite().grade().to_json())
+        return
+
+    report = doctor_report(mode=args.mode)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.mode == "hardened" and report["doctor"]["failures"]:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The `pyisolate.doctor.main()` function previously mixed two CLI flows and called `parse_args()` multiple times which produced duplicated outputs, unexpected fallthrough behavior, and crashes for subcommands.

### Description
- Rebuild the `pyisolate-doctor` `argparse` parser once with top-level `--grade`/`--mode` and `gil`/`extensions` subparsers before calling `parse_args()`.
- Handle the `gil` and `extensions` subcommands (and their `--json` flags) in dedicated branches that `return` after printing to avoid emitting multiple blobs.
- Move `--grade` handling to its own branch that returns, and emit the single `doctor_report` at the end while preserving hardened-mode fail-closed behavior (`SystemExit(1)`).
- Remove the now-unused `installation_report_json` import and tidy up output calls to emit exactly one report per invocation.

### Testing
- Ran `pytest -q tests/test_provenance.py`, which passed (`9 passed`).
- Ran the full test suite with `pytest -q`, which reported 14 failing tests unrelated to this change (sandbox/policy and import-related failures) and thus are not caused by the CLI parser fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34203a9f888328a970dbdbaedb3425)