### PR TITLE
Fix SDK sandbox import grants

### DIFF
--- a/pyisolate/sdk.py
+++ b/pyisolate/sdk.py
@@ -16,26 +16,24 @@ def sandbox(
     Parameters
     ----------
     policy:
-        Name of the policy to apply to the sandbox.
+        Name of the policy (or Policy/dict) to apply to the sandbox.
     timeout:
         Seconds to wait for the sandboxed call to complete before raising
         :class:`pyisolate.errors.TimeoutError`.
-    backend:
-        Isolation backend: ``"subinterpreter"`` for an execution cell, or
-        explicit boundary modes ``"process"`` / ``"microvm"`` when available.
     """
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        target = f"{func.__module__}.{func.__name__}"
+
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             resolved_policy = resolve_policy(policy)
-            sb = spawn(func.__name__, policy=resolved_policy)
+            sb = spawn(
+                func.__name__,
+                policy=resolved_policy,
+                allowed_imports=[func.__module__],
+            )
             try:
-                return sb.call(
-                    f"{func.__module__}.{func.__name__}",
-                    *args,
-                    timeout=timeout,
-                    **kwargs,
-                )
+                return sb.call(target, *args, timeout=timeout, **kwargs)
             finally:
                 sb.close()
 
@@ -60,15 +58,16 @@ class Pipeline:
             dotted = f"{stage.__module__}.{stage.__name__}"
         else:
             dotted = stage
-        self._stages.append((dotted, policy, backend))
+        self._stages.append((dotted, policy))
         return self
 
     def run(self, data: Any) -> Any:
         """Run data through all stages sequentially."""
         value = data
-        for dotted, policy, backend in self._stages:
-            name = dotted.rsplit(".", 1)[-1]
+        for dotted, policy in self._stages:
+            module, _, name = dotted.rpartition(".")
             resolved_policy = resolve_policy(policy)
-            with spawn(name, policy=resolved_policy) as sb:
+            allowed = [module] if module else None
+            with spawn(name, policy=resolved_policy, allowed_imports=allowed) as sb:
                 value = sb.call(dotted, value)
         return value


### PR DESCRIPTION
### Motivation
- `Pipeline.add_stage` was still appending a removed `backend` value which caused incorrect tuple shape and a runtime `NameError` on first use of the pipeline stage API. 
- Sandboxed decorator calls and stage sandboxes were not granting the callee/stage module to the sandbox, which fails under the project’s default fail-closed import policy and causes imports from helper modules to be blocked.

### Description
- Updated `sandbox()` to precompute the decorated function `target` and call `spawn` with `allowed_imports=[func.__module__]` so the decorated function’s module is permitted inside the sandbox. 
- Fixed `Pipeline.add_stage()` to append the annotated 2-tuple `(dotted, policy)` instead of the stale 3-tuple containing `backend`. 
- Updated `Pipeline.run()` to extract the module from the dotted path with `rpartition` and pass it as `allowed_imports` to `spawn`, making stage sandboxes additive with any policy imports. 
- Minor docstring clarification to reflect the `policy` parameter supports `Policy`/`dict` values.

### Testing
- Ran `python -m pytest tests/test_sdk.py -q`, which passed (`2 passed`).
- Ran `python -m pytest tests/test_thread_imports.py tests/test_sandbox.py -q`, which produced one failing test: `tests/test_sandbox.py::test_call_returns_result` failed with a `PolicyError` due to `math` being blocked by the repository’s fail-closed default import behavior while spawning a sandbox with no explicit `allowed_imports` (test run result: `1 failed, 17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3420458ed48328833ac2cf542f67e2)