### PR TITLE
Avoid duplicate legacy BPF load

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -8,7 +8,6 @@ requires eBPF enforcement which is not implemented here.
 from __future__ import annotations
 
 import importlib
-import inspect
 import logging
 import os
 import re
@@ -186,15 +185,8 @@ class Supervisor:
         except TypeError as exc:
             if "unexpected keyword argument 'mode'" not in str(exc):
                 raise
-            # Backward-compatible path for tests or integrations that provide a
-            # legacy BPFManager.load(strict=...) shim.
+            # Backward-compatible path for legacy BPFManager.load(strict=...) shims.
             self._bpf.load(strict=rollout_mode == "hardened")
-            # Test and compatibility shims may still expose the legacy
-            # load(strict=False) signature.  Real BPFManager validates rollout
-            # modes itself.
-            if "mode" not in str(exc):
-                raise
-            self._bpf.load(strict=(rollout_mode == "hardened"))
         self._recover_state()
         self._warm_pool: list[SandboxThread] = []
         for i in range(warm_pool):
@@ -207,16 +199,6 @@ class Supervisor:
         self._tenant_usage: dict[str, int] = {}
         self._quota_ledger = os.environ.get("PYISOLATE_QUOTA_LEDGER")
         self._replay_quota_ledger()
-
-    def _load_bpf(self, rollout_mode: str) -> None:
-        """Load BPF manager while tolerating legacy test doubles."""
-
-        load = self._bpf.load
-        parameters = inspect.signature(load).parameters
-        if "mode" in parameters:
-            load(mode=rollout_mode)
-        else:
-            load()
 
     def _replay_quota_ledger(self) -> None:
         if not self._quota_ledger:


### PR DESCRIPTION
### Motivation
- The legacy-shim fallback path in `Supervisor.__init__` could invoke a `load(strict=...)` shim twice when `BPFManager.load` raised a `TypeError` for an unexpected `mode` keyword, causing test doubles that only implement `strict=` to run redundant loads.

### Description
- Trimmed the `except TypeError` path so the legacy `BPFManager.load(strict=...)` fallback is invoked only once after a `mode` keyword `TypeError` and removed the now-unused `_load_bpf` helper and its `inspect` import.
- Kept the change minimal to avoid shifting existing test expectations around lazy import and rollout-mode propagation to BPF.

### Testing
- Ran `pytest tests/test_supervisor.py::test_module_import_is_lazy` and `pytest tests/test_supervisor.py::test_supervisor_rollout_mode_passed_to_bpf`, and both tests passed.
- Ran the full `pytest tests/test_supervisor.py -q`, which resulted in `28 passed, 1 failed` where the single failure was `test_recycle_preserves_capabilities`; failure appears caused by missing BPF toolchain and a read-only cgroup environment (clang/bpftool/llvm-objdump not available), which is unrelated to the changed fallback logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34205024a883289c86916bfaf40267)