### PR TITLE
Refactor policy YAML fallback serialization

### DIFF
--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -187,22 +187,24 @@ class Policy:
 
         lines = ["version: 1.0", "sandboxes:", f"  {name}:"]
         sandbox = data["sandboxes"][name]  # type: ignore[index]
-        for rule in sandbox.get("fs", []):
-            key, value = next(iter(rule.items()))
-            lines.append("    fs:" if "    fs:" not in lines else "")
-            lines.append(f"      - {key}: {value!r}")
-        if sandbox.get("net"):
-            lines.append("    net:")
-            for rule in sandbox["net"]:
+
+        def append_rule_list(section: str, rules: object) -> None:
+            if not rules:
+                return
+            lines.append(f"    {section}:")
+            for rule in rules:  # type: ignore[union-attr]
                 key, value = next(iter(rule.items()))
                 lines.append(f"      - {key}: {value!r}")
+
+        append_rule_list("fs", sandbox.get("fs", []))
+        append_rule_list("net", sandbox.get("net", []))
         if sandbox.get("imports"):
             lines.append("    imports:")
             for module in sandbox["imports"]:
                 lines.append(f"      - {module}")
         if sandbox.get("cpu_ms") is not None:
             lines.append(f"    cpu_ms: {sandbox['cpu_ms']}")
-        return "\n".join(line for line in lines if line) + "\n"
+        return "\n".join(lines) + "\n"
 
 
 def _validate(data: object) -> None:

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -468,6 +468,36 @@ def test_policy_objects_serialize_to_yaml_shape():
             }
         },
     }
+
+
+def test_policy_objects_serialize_to_yaml_without_pyyaml(monkeypatch):
+    import pyisolate as iso
+    from pyisolate import policy
+
+    p = policy.Policy().grant(
+        iso.ReadPath("/tmp/input"),
+        iso.WritePath("/tmp/output"),
+        iso.ConnectTCP("api.example.com", 443),
+        iso.Import("math"),
+        iso.CpuBudget(50),
+    )
+
+    monkeypatch.setattr(policy, "yaml", object())
+
+    assert p.to_yaml("job") == (
+        "version: 1.0\n"
+        "sandboxes:\n"
+        "  job:\n"
+        "    fs:\n"
+        "      - read: '/tmp/input'\n"
+        "      - write: '/tmp/output'\n"
+        "    net:\n"
+        "      - connect: 'api.example.com:443'\n"
+        "    imports:\n"
+        "      - math\n"
+        "    cpu_ms: 50\n"
+    )
+
 def test_canonical_yaml_policy_drives_sandbox_and_bpf_maps(tmp_path, monkeypatch):
     import pyisolate as iso
     import pyisolate.policy as policy


### PR DESCRIPTION
### Motivation
- The no-PyYAML fallback in `Policy.to_yaml` used a fragile pattern that appended empty placeholders for section headers then filtered empties, which is brittle and untested.
- Improve reliability and clarity of the fallback YAML emitter and add test coverage for the code path exercised when `yaml.safe_dump` is unavailable.

### Description
- Replaced the placeholder-and-filter approach with an `append_rule_list(section, rules)` helper that emits a section header only when `rules` are present and appends properly formatted items for both `fs` and `net` sections in the fallback path of `Policy.to_yaml` in `pyisolate/policy/__init__.py`.
- Removed the empty-string filtering step and now returns the joined `lines` directly with a trailing newline.
- Added `test_policy_objects_serialize_to_yaml_without_pyyaml` to `tests/test_policy.py` which monkeypatches `policy.yaml` to an object without `safe_dump` and asserts the exact YAML text produced by `Policy.to_yaml`.

### Testing
- Ran `python -m pytest tests/test_policy.py::test_policy_objects_serialize_to_yaml_without_pyyaml -q`, which passed.
- Ran `pytest tests/test_policy.py -q` earlier in the iteration and observed an unrelated existing test (`test_canonical_yaml_policy_drives_sandbox_and_bpf_maps`) failing with `ValueError: unsupported policy type: RuntimePolicy` during investigation; the targeted fallback test itself passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34206c16e88328b3af25e1ea2ea3be)