### PR TITLE
Record denial telemetry for filesystem and network policy blocks

### DIFF
--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -87,6 +87,7 @@ from .model import (  # noqa: F401
     from_yaml_dict,
     to_bpf_map_entries,
 )
+
 logger = logging.getLogger(__name__)
 
 
@@ -450,7 +451,7 @@ def resolve_policy(policy: str | Policy | SandboxPolicy | CompiledPolicy | dict 
     or a supported named policy, otherwise :class:`PolicyCompilerError` is raised.
     """
 
-    if policy is None or isinstance(policy, Policy):
+    if policy is None or isinstance(policy, (Policy, RuntimePolicy)):
         return policy
     if isinstance(policy, SandboxPolicy):
         return _runtime_policy_from_sandbox(policy)

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -56,7 +56,7 @@ from .protocol import (
 from ..numa import bind_current_thread
 from ..observability.trace import Tracer
 from ..telemetry import DenialEvent
-from ..policy.model import from_sandbox_policy
+from ..policy.model import RuntimePolicy, from_sandbox_policy
 
 _thread_local = threading.local()
 
@@ -147,7 +147,11 @@ def _serialize_capability(capability: Any) -> Any:
     if isinstance(capability, WritePath):
         return {_CAPABILITY_MARKER: "write_path", "path": str(capability.path)}
     if isinstance(capability, ConnectTCP):
-        return {_CAPABILITY_MARKER: "connect_tcp", "host": capability.host, "port": capability.port}
+        return {
+            _CAPABILITY_MARKER: "connect_tcp",
+            "host": capability.host,
+            "port": capability.port,
+        }
     if isinstance(capability, Import):
         return {_CAPABILITY_MARKER: "import", "module": capability.module}
     if isinstance(capability, CpuBudget):
@@ -218,12 +222,12 @@ def deserialize_capabilities(capabilities: Optional[dict[str, Any]]) -> dict[str
     }
 
 
-
-
 def _iter_authorities(policy, capabilities: Optional[dict[str, Any]]) -> list[object]:
     authorities: list[object] = []
     if policy is not None:
         authorities.extend(getattr(policy, "capabilities", []) or [])
+        if isinstance(policy, RuntimePolicy):
+            return authorities
         for path in getattr(policy, "fs", []) or []:
             authorities.extend([ReadPath(path), WritePath(path)])
         for addr in getattr(policy, "tcp", []) or []:
@@ -234,13 +238,16 @@ def _iter_authorities(policy, capabilities: Optional[dict[str, Any]]) -> list[ob
         for module in getattr(policy, "imports", []) or []:
             authorities.append(Import(module))
     if capabilities:
-        values = capabilities.values() if isinstance(capabilities, dict) else capabilities
+        values = (
+            capabilities.values() if isinstance(capabilities, dict) else capabilities
+        )
         for capability in values:
             if isinstance(capability, (list, tuple, set, frozenset)):
                 authorities.extend(capability)
             else:
                 authorities.append(capability)
     return authorities
+
 
 def _fs_rule_matches(pattern: str, path: Path) -> bool:
     path_text = str(path)
@@ -270,14 +277,7 @@ def _blocked_open(file, *args, **kwargs):
         fs_cap = getattr(_thread_local, "fs_capability", None)
         allowed = getattr(_thread_local, "fs", None)
         runtime_policy = getattr(_thread_local, "runtime_policy", None)
-        if authority is not None:
-            if wants_write:
-                permitted = authority.allows_write(path)
-            else:
-                permitted = authority.allows_read(path)
-            if not permitted:
-                raise errors.PolicyError("file access blocked")
-        elif fs_cap is not None:
+        if fs_cap is not None:
             if not fs_cap.allows(path):
                 raise _deny(
                     "filesystem",
@@ -293,13 +293,37 @@ def _blocked_open(file, *args, **kwargs):
                     f"allow_fs:{_format_roots(allowed)}",
                     "file access blocked",
                 )
+        elif authority is not None:
+            if wants_write:
+                permitted = authority.allows_write(path)
+            else:
+                permitted = authority.allows_read(path)
+            if not permitted:
+                raise _deny(
+                    "filesystem",
+                    f"open:{path}",
+                    "authority:write_path" if wants_write else "authority:read_path",
+                    "file access blocked",
+                )
         elif runtime_policy is not None:
-            if any(_fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs):
-                raise errors.PolicyError("file access blocked")
+            if any(
+                _fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs
+            ):
+                raise _deny(
+                    "filesystem",
+                    f"open:{path}",
+                    "runtime_policy:deny_fs",
+                    "file access blocked",
+                )
             if not any(
                 _fs_rule_matches(rule.path, path) for rule in runtime_policy.allow_fs
             ):
-                raise errors.PolicyError("file access blocked")
+                raise _deny(
+                    "filesystem",
+                    f"open:{path}",
+                    "runtime_policy:allow_fs",
+                    "file access blocked",
+                )
         elif getattr(_thread_local, "active", False):
             raise _deny(
                 "filesystem",
@@ -322,6 +346,7 @@ def _blocked_open(file, *args, **kwargs):
     weakref.finalize(opened, _release)
     return opened
 
+
 def _check_network_destination(address: Iterable[str]) -> None:
     authority = getattr(_thread_local, "authority", None)
     net_cap = getattr(_thread_local, "net_capability", None)
@@ -332,10 +357,7 @@ def _check_network_destination(address: Iterable[str]) -> None:
     else:
         host, port = address
     destination = f"{host}:{port}"
-    if authority is not None:
-        if not authority.allows_tcp(str(host), int(port)):
-            raise errors.PolicyError(f"connect blocked: {destination}")
-    elif net_cap is not None:
+    if net_cap is not None:
         if not net_cap.allows(str(host), int(port)):
             raise _deny(
                 "network",
@@ -351,11 +373,31 @@ def _check_network_destination(address: Iterable[str]) -> None:
                 f"allow_tcp:{','.join(sorted(allowed))}",
                 f"connect blocked: {destination}",
             )
+    elif authority is not None:
+        if not authority.allows_tcp(str(host), int(port)):
+            raise _deny(
+                "network",
+                f"connect:{destination}",
+                "authority:connect_tcp",
+                f"connect blocked: {destination}",
+            )
     elif runtime_policy is not None:
         if any(rule.destination == destination for rule in runtime_policy.deny_tcp):
-            raise errors.PolicyError(f"connect blocked: {destination}")
-        if not any(rule.destination == destination for rule in runtime_policy.allow_tcp):
-            raise errors.PolicyError(f"connect blocked: {destination}")
+            raise _deny(
+                "network",
+                f"connect:{destination}",
+                "runtime_policy:deny_tcp",
+                f"connect blocked: {destination}",
+            )
+        if not any(
+            rule.destination == destination for rule in runtime_policy.allow_tcp
+        ):
+            raise _deny(
+                "network",
+                f"connect:{destination}",
+                "runtime_policy:allow_tcp",
+                f"connect blocked: {destination}",
+            )
     elif getattr(_thread_local, "active", False):
         raise _deny(
             "network",
@@ -707,7 +749,11 @@ class SandboxThread(threading.Thread):
         if policy is not None and getattr(policy, "imports", None):
             imports.update(policy.imports)
         if policy is not None:
-            imports.update(AuthoritySet.from_authorities(getattr(policy, "capabilities", []) or []).imports)
+            imports.update(
+                AuthoritySet.from_authorities(
+                    getattr(policy, "capabilities", []) or []
+                ).imports
+            )
         runtime_policy = from_sandbox_policy(policy) if policy is not None else None
         if runtime_policy is not None and runtime_policy.imports:
             imports.update(runtime_policy.imports)
@@ -737,9 +783,13 @@ class SandboxThread(threading.Thread):
         enforcement_status: Any = None,
     ) -> None:
         self.policy = policy
-        self._authority = AuthoritySet.from_authorities(_iter_authorities(policy, capabilities))
+        self._authority = AuthoritySet.from_authorities(
+            _iter_authorities(policy, capabilities)
+        )
         self.cpu_quota_ms = cpu_ms if cpu_ms is not None else self._authority.cpu_ms
-        self.runtime_policy = from_sandbox_policy(policy) if policy is not None else None        
+        self.runtime_policy = (
+            from_sandbox_policy(policy) if policy is not None else None
+        )
         self.mem_quota_bytes = mem_bytes
         self.wall_time_ms = wall_time_ms
         self.open_files_max = open_files_max
@@ -1036,7 +1086,9 @@ class SandboxThread(threading.Thread):
         if not self.cancel(timeout=timeout):
             self.kill(timeout=timeout)
 
-    def enforce_quota_breach(self, exc: Exception, reason: str, timeout: float = 0.05) -> bool:
+    def enforce_quota_breach(
+        self, exc: Exception, reason: str, timeout: float = 0.05
+    ) -> bool:
         """Record a kernel/watchdog quota breach and stop guest execution.
 
         The watchdog calls this path from outside the sandbox thread, so it does
@@ -1193,9 +1245,11 @@ class SandboxThread(threading.Thread):
 
                 allowed_tcp = None
                 allowed_fs = None
-                if self.policy is not None:
+                if self.policy is not None and not isinstance(
+                    self.policy, RuntimePolicy
+                ):
                     tcp_policy = getattr(self.policy, "tcp", None)
-                    if tcp_policy is not None:
+                    if tcp_policy:
                         allowed_tcp = set(tcp_policy)
                     if getattr(self.policy, "fs", None):
                         allowed_fs = [

--- a/tests/test_policy_enforcement.py
+++ b/tests/test_policy_enforcement.py
@@ -173,3 +173,162 @@ def test_policy_blocks_side_effect_import_escape_surfaces(name, source, imports)
             sb.recv(timeout=1)
     finally:
         sb.close()
+
+
+def _assert_denial_event(events, *, cell, capability, attempted_action, policy_rule):
+    assert events
+    event = events[-1]
+    assert event["cell"] == cell
+    assert event["capability"] == capability
+    assert event["attempted_action"] == attempted_action
+    assert event["policy_rule"] == policy_rule
+    assert event["broker_decision"] == "deny"
+
+
+def test_authority_filesystem_denial_records_event(tmp_path):
+    allowed_dir = tmp_path / "allowed"
+    denied_dir = tmp_path / "denied"
+    allowed_dir.mkdir()
+    denied_dir.mkdir()
+    denied_file = denied_dir / "secret.txt"
+    denied_file.write_text("nope")
+
+    sb = iso.spawn(
+        "authority-fs-denial", policy=policy.Policy().allow_read(str(allowed_dir))
+    )
+    try:
+        denied_path = denied_file.resolve(strict=False)
+        sb.exec(f"open({str(denied_path)!r}).read()")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="authority-fs-denial",
+            capability="filesystem",
+            attempted_action=f"open:{denied_path}",
+            policy_rule="authority:read_path",
+        )
+    finally:
+        sb.close()
+
+
+def test_authority_network_denial_records_event():
+    sb = iso.spawn(
+        "authority-net-denial",
+        policy=policy.Policy(
+            capabilities=[iso.ConnectTCP("127.0.0.1", 1), iso.Import("socket")]
+        ),
+    )
+    try:
+        sb.exec("import socket; s=socket.socket(); s.connect(('127.0.0.1', 2))")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="authority-net-denial",
+            capability="network",
+            attempted_action="connect:127.0.0.1:2",
+            policy_rule="authority:connect_tcp",
+        )
+    finally:
+        sb.close()
+
+
+def test_runtime_policy_filesystem_deny_rule_records_event(tmp_path):
+    allowed_dir = tmp_path / "allowed"
+    denied_dir = tmp_path / "denied"
+    allowed_dir.mkdir()
+    denied_dir.mkdir()
+    denied_file = denied_dir / "secret.txt"
+    denied_file.write_text("nope")
+    denied_path = denied_file.resolve(strict=False)
+
+    runtime_policy = policy.RuntimePolicy(
+        allow_fs=(policy.FilesystemRule("allow", str(tmp_path)),),
+        deny_fs=(policy.FilesystemRule("deny", str(denied_dir)),),
+    )
+    sb = iso.spawn("runtime-fs-deny-rule", policy=runtime_policy)
+    try:
+        sb.exec(f"open({str(denied_path)!r}).read()")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="runtime-fs-deny-rule",
+            capability="filesystem",
+            attempted_action=f"open:{denied_path}",
+            policy_rule="runtime_policy:deny_fs",
+        )
+    finally:
+        sb.close()
+
+
+def test_runtime_policy_filesystem_missing_allow_rule_records_event(tmp_path):
+    allowed_dir = tmp_path / "allowed"
+    denied_dir = tmp_path / "denied"
+    allowed_dir.mkdir()
+    denied_dir.mkdir()
+    denied_file = denied_dir / "secret.txt"
+    denied_file.write_text("nope")
+    denied_path = denied_file.resolve(strict=False)
+
+    runtime_policy = policy.RuntimePolicy(
+        allow_fs=(policy.FilesystemRule("allow", str(allowed_dir)),),
+    )
+    sb = iso.spawn("runtime-fs-missing-allow", policy=runtime_policy)
+    try:
+        sb.exec(f"open({str(denied_path)!r}).read()")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="runtime-fs-missing-allow",
+            capability="filesystem",
+            attempted_action=f"open:{denied_path}",
+            policy_rule="runtime_policy:allow_fs",
+        )
+    finally:
+        sb.close()
+
+
+def test_runtime_policy_network_deny_rule_records_event():
+    runtime_policy = policy.RuntimePolicy(
+        allow_tcp=(policy.NetworkRule("connect", "127.0.0.1:2"),),
+        deny_tcp=(policy.NetworkRule("deny", "127.0.0.1:2"),),
+        imports=("socket",),
+    )
+    sb = iso.spawn("runtime-net-deny-rule", policy=runtime_policy)
+    try:
+        sb.exec("import socket; s=socket.socket(); s.connect(('127.0.0.1', 2))")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="runtime-net-deny-rule",
+            capability="network",
+            attempted_action="connect:127.0.0.1:2",
+            policy_rule="runtime_policy:deny_tcp",
+        )
+    finally:
+        sb.close()
+
+
+def test_runtime_policy_network_missing_allow_rule_records_event():
+    runtime_policy = policy.RuntimePolicy(
+        allow_tcp=(policy.NetworkRule("connect", "127.0.0.1:1"),),
+        imports=("socket",),
+    )
+    sb = iso.spawn("runtime-net-missing-allow", policy=runtime_policy)
+    try:
+        sb.exec("import socket; s=socket.socket(); s.connect(('127.0.0.1', 2))")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="runtime-net-missing-allow",
+            capability="network",
+            attempted_action="connect:127.0.0.1:2",
+            policy_rule="runtime_policy:allow_tcp",
+        )
+    finally:
+        sb.close()


### PR DESCRIPTION
### Motivation
- Ensure denied filesystem and network operations produce structured telemetry with the sandbox cell, capability, attempted action, and the policy rule that produced the denial.

### Description
- Replace direct `errors.PolicyError(...)` raises in `_blocked_open` and `_check_network_destination` with `_deny(...)` calls for all enforcement branches including `authority is not None`, capability grants, explicit allow-list branches, explicit runtime-policy deny rules, and missing allow-rule cases, using capability names `filesystem` and `network` and attempted-action strings like `open:<path>` and `connect:<host:port>`.
- Use policy-rule summary strings such as `authority:read_path`, `authority:write_path`, `authority:connect_tcp`, `capability:filesystem roots=...`, `capability:network destinations=...`, `allow_fs:...`, `allow_tcp:...`, `runtime_policy:deny_fs`, `runtime_policy:allow_fs`, `runtime_policy:deny_tcp`, `runtime_policy:allow_tcp`, and `deny-by-default` when appropriate.
- Preserve `RuntimePolicy` as a first-class runtime branch by allowing `RuntimePolicy` objects through policy resolution and by adjusting authority extraction and per-request wiring so runtime policies are enforced without coercing them into legacy allow-list/authority state.
- Add tests that assert denial telemetry via `Sandbox.get_denial_events()` for authority-based denials, explicit runtime-policy deny rules, and missing allow-rule denials for both filesystem and network checks.

### Testing
- Ran formatting with `python -m black pyisolate/runtime/thread.py pyisolate/policy/__init__.py tests/test_policy_enforcement.py` which completed successfully.
- Executed focused test suites with `pytest -q tests/test_policy_enforcement.py tests/test_network.py tests/test_capabilities.py tests/test_alerts.py::test_denied_operation_emits_structured_telemetry tests/test_checkpoint.py::test_checkpoint_restores_capabilities` and the targeted tests passed.
- Verified the new enforcement and telemetry tests under `tests/test_policy_enforcement.py` (new cases asserting `cell`, `capability`, `attempted_action`, `policy_rule`, and `broker_decision` on `Sandbox.get_denial_events()`); these tests passed in the CI-local runs.
- Confirmed no diff/check issues with `git diff --check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3426e18f6c8328aa20a2cb99046010)