### PR TITLE
Support YAML policy hot reload

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -12,6 +12,7 @@ import subprocess
 from pathlib import Path
 from typing import Literal
 
+from ..policy.compiler import PolicyCompilerError, compile_policy
 from ..policy.model import from_compiled_policy, to_bpf_map_entries
 
 logger = logging.getLogger(__name__)
@@ -236,23 +237,66 @@ class BPFManager:
         )
         return ok
 
-    def hot_reload(self, policy_path: str) -> None:
-        """Refresh maps based on a policy JSON file."""
-        if not self.loaded:
-            raise RuntimeError("BPF not loaded")
+    def _load_runtime_policy_yaml(self, path: Path):
         try:
-            with open(policy_path, "r", encoding="utf-8") as fh:
-                data = json.load(fh)
-        except FileNotFoundError as exc:
-            raise RuntimeError(f"Policy file not found: {policy_path}") from exc
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f"Invalid JSON in policy file {policy_path}") from exc
+            return from_compiled_policy(compile_policy(path))
+        except FileNotFoundError:
+            raise
+        except Exception as exc:
+            raise RuntimeError(f"Invalid policy data in {path}: {exc}") from exc
+
+    def _load_runtime_policy_json(self, path: Path):
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
         if not isinstance(data, dict):
             raise RuntimeError("Policy data must be a JSON object")
         try:
-            runtime_policy = from_compiled_policy(data)
+            return from_compiled_policy(data)
         except (TypeError, ValueError) as exc:
+            raise RuntimeError(f"Invalid policy data in {path}: {exc}") from exc
+
+    def hot_reload(self, policy_path: str) -> None:
+        """Refresh maps based on a policy file.
+
+        ``.yml``/``.yaml`` files are treated as authoring templates and compiled
+        through the policy compiler.  ``.json`` files keep the existing canonical
+        runtime-policy path.  Unknown suffixes try YAML first so users get DSL
+        validation errors before falling back to JSON parsing.
+        """
+        if not self.loaded:
+            raise RuntimeError("BPF not loaded")
+
+        path = Path(policy_path)
+        suffix = path.suffix.lower()
+
+        try:
+            if suffix in {".yml", ".yaml"}:
+                runtime_policy = self._load_runtime_policy_yaml(path)
+            elif suffix == ".json":
+                runtime_policy = self._load_runtime_policy_json(path)
+            else:
+                try:
+                    runtime_policy = self._load_runtime_policy_yaml(path)
+                except (OSError, RuntimeError) as yaml_exc:
+                    try:
+                        runtime_policy = self._load_runtime_policy_json(path)
+                    except (RuntimeError, json.JSONDecodeError) as json_exc:
+                        raise RuntimeError(
+                            f"Invalid policy file {policy_path}: YAML error: {yaml_exc}; "
+                            f"JSON error: {json_exc}"
+                        ) from json_exc
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Policy file not found: {policy_path}") from exc
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Invalid JSON in policy file {policy_path}: {exc}"
+            ) from exc
+        except (PolicyCompilerError, TypeError, ValueError) as exc:
             raise RuntimeError(f"Invalid policy data in {policy_path}: {exc}") from exc
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unable to read policy file {policy_path}: {exc}"
+            ) from exc
 
         # Replace the active policy entirely to drop removed entries. Store the
         # canonical structure, not the source JSON shape, so the userspace and BPF

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -182,6 +182,49 @@ def test_hot_reload_handles_nested_policy(tmp_path, monkeypatch):
     ] in calls
 
 
+def test_hot_reload_accepts_yaml_template(monkeypatch):
+    monkeypatch.setattr(
+        BPFManager, "_run", lambda self, cmd, *, raise_on_error=False: True
+    )
+    mgr = BPFManager()
+    mgr.loaded = True
+
+    mgr.hot_reload(str(ROOT / "policy" / "readonly-fs.yml"))
+
+    assert mgr.policy_maps["sandboxes"]["default"]["allow_fs"] == [
+        {"action": "allow", "path": "/tmp"}
+    ]
+    assert mgr.policy_maps["sandboxes"]["default"]["allow_tcp"] == []
+
+
+def test_hot_reload_canonical_json_policy(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        BPFManager, "_run", lambda self, cmd, *, raise_on_error=False: True
+    )
+    mgr = BPFManager()
+    mgr.loaded = True
+    policy = tmp_path / "canonical.json"
+    expected = _canonical_policy(fs_path="/var/tmp/**", tcp_addr="127.0.0.1:443")
+    policy.write_text(json.dumps(expected))
+
+    mgr.hot_reload(str(policy))
+
+    assert mgr.policy_maps == expected
+
+
+def test_hot_reload_invalid_yaml_reports_runtime_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        BPFManager, "_run", lambda self, cmd, *, raise_on_error=False: True
+    )
+    mgr = BPFManager()
+    mgr.loaded = True
+    bad = tmp_path / "bad.yml"
+    bad.write_text("version: [not-a-supported-version\n")
+
+    with pytest.raises(RuntimeError, match="Invalid policy data"):
+        mgr.hot_reload(str(bad))
+
+
 def test_load_failure_logs_and_raises(monkeypatch, caplog):
     def fake_run(cmd, check, capture_output, text):
         if "bpftool" in cmd:
@@ -332,7 +375,9 @@ def test_load_lenient_missing_executable_keeps_unloaded(
     mgr.load(strict=False)
 
     assert mgr.loaded is False
-    assert any("command not found while running" in rec.getMessage() for rec in caplog.records)
+    assert any(
+        "command not found while running" in rec.getMessage() for rec in caplog.records
+    )
     assert any(missing_tool in rec.getMessage() for rec in caplog.records)
 
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -60,6 +60,25 @@ def test_reload_policy_delegates(tmp_path, monkeypatch):
     assert called["path"] == str(p)
 
 
+def test_reload_policy_preserves_auth_and_accepts_yaml(tmp_path, monkeypatch):
+    called = {}
+
+    def fake_hot_reload(self, path):
+        called["path"] = path
+
+    monkeypatch.setattr(BPFManager, "hot_reload", fake_hot_reload)
+    p = tmp_path / "p.yml"
+    p.write_text('version: 1.0\nfs:\n  - allow: "/tmp"\nnet: []\nimports: []\n')
+    iso.set_policy_token("tok")
+
+    with pytest.raises(iso.PolicyAuthError):
+        iso.reload_policy(str(p), token="bad")
+    assert called == {}
+
+    iso.reload_policy(str(p), token="tok")
+    assert called["path"] == str(p)
+
+
 def test_shutdown_joins_threads():
     sup = iso.Supervisor()
     sb = sup.spawn("sd")


### PR DESCRIPTION
### Motivation
- Allow policy hot-reload to accept authored YAML templates (DSL) in addition to the existing canonical JSON runtime-policy format.
- Provide clearer validation errors for malformed YAML/JSON and prefer DSL errors for unknown suffixes so users get helpful feedback.
- Keep the canonical runtime-policy path intact for `.json` payloads so existing behavior is preserved.

### Description
- Added import of `compile_policy`/`PolicyCompilerError` and reused `from_compiled_policy` to convert compiled YAML policies into the canonical runtime representation. (`pyisolate/bpf/manager.py`)
- Implemented `_load_runtime_policy_yaml` and `_load_runtime_policy_json` helpers and updated `BPFManager.hot_reload` to detect file suffixes (`.yml`/`.yaml`/`.json`) and to try YAML first for unknown suffixes, with combined error reporting if both parsers fail. (`pyisolate/bpf/manager.py`)
- Surface file-not-found, YAML/JSON parse errors, and compiler validation failures as clear `RuntimeError`s with descriptive messages. (`pyisolate/bpf/manager.py`)
- Added tests covering YAML template reload, canonical JSON reload, invalid YAML surfacing a `RuntimeError`, and `Supervisor.reload_policy()` auth behavior when accepting a YAML policy. (tests updated: `tests/test_bpf_manager.py`, `tests/test_supervisor.py`)

### Testing
- Ran the targeted test set: `pytest -q tests/test_bpf_manager.py tests/test_bpf_manager_extra.py tests/test_policy.py::test_reload_policy_malformed_json tests/test_supervisor.py::test_reload_policy_delegates tests/test_supervisor.py::test_reload_policy_preserves_auth_and_accepts_yaml` and all tests passed (24 passed).
- Also ran focused runs during development to reproduce and fix an initial YAML parse failure; after fixes the YAML and JSON reload tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3426e22ad8832884ca9cacce436d3f)