### PR TITLE
Track tenant reservations on SandboxThread and ensure single-release of tenant quota

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -147,7 +147,11 @@ def _serialize_capability(capability: Any) -> Any:
     if isinstance(capability, WritePath):
         return {_CAPABILITY_MARKER: "write_path", "path": str(capability.path)}
     if isinstance(capability, ConnectTCP):
-        return {_CAPABILITY_MARKER: "connect_tcp", "host": capability.host, "port": capability.port}
+        return {
+            _CAPABILITY_MARKER: "connect_tcp",
+            "host": capability.host,
+            "port": capability.port,
+        }
     if isinstance(capability, Import):
         return {_CAPABILITY_MARKER: "import", "module": capability.module}
     if isinstance(capability, CpuBudget):
@@ -218,8 +222,6 @@ def deserialize_capabilities(capabilities: Optional[dict[str, Any]]) -> dict[str
     }
 
 
-
-
 def _iter_authorities(policy, capabilities: Optional[dict[str, Any]]) -> list[object]:
     authorities: list[object] = []
     if policy is not None:
@@ -234,13 +236,16 @@ def _iter_authorities(policy, capabilities: Optional[dict[str, Any]]) -> list[ob
         for module in getattr(policy, "imports", []) or []:
             authorities.append(Import(module))
     if capabilities:
-        values = capabilities.values() if isinstance(capabilities, dict) else capabilities
+        values = (
+            capabilities.values() if isinstance(capabilities, dict) else capabilities
+        )
         for capability in values:
             if isinstance(capability, (list, tuple, set, frozenset)):
                 authorities.extend(capability)
             else:
                 authorities.append(capability)
     return authorities
+
 
 def _fs_rule_matches(pattern: str, path: Path) -> bool:
     path_text = str(path)
@@ -294,7 +299,9 @@ def _blocked_open(file, *args, **kwargs):
                     "file access blocked",
                 )
         elif runtime_policy is not None:
-            if any(_fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs):
+            if any(
+                _fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs
+            ):
                 raise errors.PolicyError("file access blocked")
             if not any(
                 _fs_rule_matches(rule.path, path) for rule in runtime_policy.allow_fs
@@ -321,6 +328,7 @@ def _blocked_open(file, *args, **kwargs):
 
     weakref.finalize(opened, _release)
     return opened
+
 
 def _check_network_destination(address: Iterable[str]) -> None:
     authority = getattr(_thread_local, "authority", None)
@@ -354,7 +362,9 @@ def _check_network_destination(address: Iterable[str]) -> None:
     elif runtime_policy is not None:
         if any(rule.destination == destination for rule in runtime_policy.deny_tcp):
             raise errors.PolicyError(f"connect blocked: {destination}")
-        if not any(rule.destination == destination for rule in runtime_policy.allow_tcp):
+        if not any(
+            rule.destination == destination for rule in runtime_policy.allow_tcp
+        ):
             raise errors.PolicyError(f"connect blocked: {destination}")
     elif getattr(_thread_local, "active", False):
         raise _deny(
@@ -707,7 +717,11 @@ class SandboxThread(threading.Thread):
         if policy is not None and getattr(policy, "imports", None):
             imports.update(policy.imports)
         if policy is not None:
-            imports.update(AuthoritySet.from_authorities(getattr(policy, "capabilities", []) or []).imports)
+            imports.update(
+                AuthoritySet.from_authorities(
+                    getattr(policy, "capabilities", []) or []
+                ).imports
+            )
         runtime_policy = from_sandbox_policy(policy) if policy is not None else None
         if runtime_policy is not None and runtime_policy.imports:
             imports.update(runtime_policy.imports)
@@ -737,9 +751,14 @@ class SandboxThread(threading.Thread):
         enforcement_status: Any = None,
     ) -> None:
         self.policy = policy
-        self._authority = AuthoritySet.from_authorities(_iter_authorities(policy, capabilities))
+        capabilities = deserialize_capabilities(capabilities)
+        self._authority = AuthoritySet.from_authorities(
+            _iter_authorities(policy, capabilities)
+        )
         self.cpu_quota_ms = cpu_ms if cpu_ms is not None else self._authority.cpu_ms
-        self.runtime_policy = from_sandbox_policy(policy) if policy is not None else None        
+        self.runtime_policy = (
+            from_sandbox_policy(policy) if policy is not None else None
+        )
         self.mem_quota_bytes = mem_bytes
         self.wall_time_ms = wall_time_ms
         self.open_files_max = open_files_max
@@ -834,6 +853,9 @@ class SandboxThread(threading.Thread):
             enforcement_status=enforcement_status,
         )
         self._reset_runtime_state()
+        self._tenant: str | None = None
+        self._tenant_quota: int | None = None
+        self._tenant_quota_reserved = False
         # Dedup set spans sandbox lifetimes for this thread; message IDs are monotonic
         # and intentionally preserved across reset() to avoid stale replay collisions.
         self._next_attach_msg_id = 1
@@ -1036,7 +1058,9 @@ class SandboxThread(threading.Thread):
         if not self.cancel(timeout=timeout):
             self.kill(timeout=timeout)
 
-    def enforce_quota_breach(self, exc: Exception, reason: str, timeout: float = 0.05) -> bool:
+    def enforce_quota_breach(
+        self, exc: Exception, reason: str, timeout: float = 0.05
+    ) -> bool:
         """Record a kernel/watchdog quota breach and stop guest execution.
 
         The watchdog calls this path from outside the sandbox thread, so it does

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -225,6 +225,21 @@ class Supervisor:
         with path.open("a", encoding="utf-8") as handle:
             handle.write(f"{tenant},{delta}\n")
 
+    def _mark_tenant_reservation(
+        self, thread: SandboxThread, tenant: str | None, tenant_quota: int | None
+    ) -> None:
+        thread._tenant = tenant
+        thread._tenant_quota = tenant_quota
+        thread._tenant_quota_reserved = bool(tenant and tenant_quota is not None)
+
+    def _release_tenant_reservation(self, thread: SandboxThread) -> bool:
+        tenant = getattr(thread, "_tenant", None)
+        if tenant and getattr(thread, "_tenant_quota_reserved", False):
+            self._record_tenant_usage(tenant, -1)
+            thread._tenant_quota_reserved = False
+            return True
+        return False
+
     def _recover_state(self) -> None:
         """Recover durable supervisor state and clean stale resources."""
         stale = recovery.recover()
@@ -348,6 +363,7 @@ class Supervisor:
                     )
                     thread._backend = backend
                     thread.start()
+                self._mark_tenant_reservation(thread, tenant, tenant_quota)
                 thread._temp_dir = temp_dir
                 self._sandboxes[name] = thread
                 recovery.update_sandbox(
@@ -372,7 +388,12 @@ class Supervisor:
                 if temp_dir is not None:
                     recovery.cleanup_temp_dir(temp_dir)
                 recovery.drop_sandbox(name)
-                if usage_reserved and tenant:
+                released = (
+                    self._release_tenant_reservation(thread)
+                    if thread is not None
+                    else False
+                )
+                if usage_reserved and tenant and not released:
                     self._record_tenant_usage(tenant, -1)
                 raise
         # Remove references to any terminated sandboxes
@@ -473,6 +494,7 @@ class Supervisor:
         thread.reap()
         with self._lock:
             self._sandboxes.pop(name, None)
+            self._release_tenant_reservation(thread)
         cgroup.delete(getattr(thread, "_cgroup_path", None))
         recovery.cleanup_temp_dir(getattr(thread, "_temp_dir", name))
         recovery.drop_sandbox(name)
@@ -484,6 +506,9 @@ class Supervisor:
             if thread is None:
                 raise KeyError(f"unknown sandbox: {name}")
             snap = thread.snapshot()
+            snap["capabilities"] = getattr(thread, "_capabilities", None)
+            tenant = getattr(thread, "_tenant", None)
+            tenant_quota = getattr(thread, "_tenant_quota", None)
         if thread.is_alive():
             if not thread.cancel(timeout=0.2):
                 self.quarantine(name, "recycle requested on unresponsive sandbox")
@@ -491,6 +516,7 @@ class Supervisor:
                 thread.reap()
         with self._lock:
             self._sandboxes.pop(name, None)
+            self._release_tenant_reservation(thread)
         return self.spawn(
             name=snap["name"],
             policy=snap["policy"],
@@ -504,6 +530,8 @@ class Supervisor:
             allowed_imports=snap["allowed_imports"],
             numa_node=snap["numa_node"],
             capabilities=snap["capabilities"],
+            tenant=tenant,
+            tenant_quota=tenant_quota,
         )
 
     def _cleanup(self) -> None:
@@ -515,6 +543,7 @@ class Supervisor:
                 cgroup.delete(getattr(thread, "_cgroup_path", None))
                 recovery.cleanup_temp_dir(getattr(thread, "_temp_dir", n))
                 recovery.drop_sandbox(n)
+                self._release_tenant_reservation(thread)
                 del self._sandboxes[n]
             self._warm_pool = [t for t in self._warm_pool if t.is_alive()]
 

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -237,23 +237,87 @@ def test_sandbox_termination_reason_passthrough():
         sup.shutdown()
 
 
-def test_tenant_quota_is_durable(tmp_path, monkeypatch):
+def test_tenant_quota_released_after_close_allows_same_tenant_respawn(
+    tmp_path, monkeypatch
+):
     ledger = tmp_path / "quota.log"
     monkeypatch.setenv("PYISOLATE_QUOTA_LEDGER", str(ledger))
 
-    sup1 = iso.Supervisor()
+    sup = iso.Supervisor()
     try:
-        sb = sup1.spawn("t1", tenant="acme", tenant_quota=1)
-        sb.close()
-    finally:
-        sup1.shutdown()
+        first = sup.spawn("t1", tenant="acme", tenant_quota=1)
+        assert first._thread._tenant == "acme"
+        assert first._thread._tenant_quota_reserved is True
+        first.close()
 
-    sup2 = iso.Supervisor()
-    try:
-        with pytest.raises(iso.TenantQuotaExceeded):
-            sup2.spawn("t2", tenant="acme", tenant_quota=1)
+        second = sup.spawn("t2", tenant="acme", tenant_quota=1)
+        assert second._thread._tenant == "acme"
+        assert sup._tenant_usage.get("acme", 0) == 1
     finally:
-        sup2.shutdown()
+        sup.shutdown()
+
+    assert ledger.read_text(encoding="utf-8").splitlines() == [
+        "acme,1",
+        "acme,-1",
+        "acme,1",
+        "acme,-1",
+    ]
+
+
+def test_quarantine_releases_tenant_reservation(tmp_path, monkeypatch):
+    ledger = tmp_path / "quota.log"
+    monkeypatch.setenv("PYISOLATE_QUOTA_LEDGER", str(ledger))
+
+    sup = iso.Supervisor()
+    try:
+        sb = sup.spawn("qt", tenant="acme", tenant_quota=1)
+        sb.quarantine("bad")
+        assert sup._tenant_usage.get("acme", 0) == 0
+
+        again = sup.spawn("qt2", tenant="acme", tenant_quota=1)
+        assert again._thread._tenant_quota_reserved is True
+    finally:
+        sup.shutdown()
+
+
+def test_quota_ledger_replay_balances_positive_and_negative_entries(
+    tmp_path, monkeypatch
+):
+    ledger = tmp_path / "quota.log"
+    ledger.write_text("acme,1\nacme,1\nacme,-1\nacme,-1\nbeta,1\nbeta,-1\n")
+    monkeypatch.setenv("PYISOLATE_QUOTA_LEDGER", str(ledger))
+
+    sup = iso.Supervisor()
+    try:
+        assert sup._tenant_usage.get("acme", 0) == 0
+        assert sup._tenant_usage.get("beta", 0) == 0
+        sup.spawn("ledger-ok", tenant="acme", tenant_quota=1)
+        assert sup._tenant_usage.get("acme", 0) == 1
+    finally:
+        sup.shutdown()
+
+
+def test_recycle_reacquires_tenant_reservation(tmp_path, monkeypatch):
+    ledger = tmp_path / "quota.log"
+    monkeypatch.setenv("PYISOLATE_QUOTA_LEDGER", str(ledger))
+
+    sup = iso.Supervisor()
+    try:
+        sb = sup.spawn("tenant-recycle", tenant="acme", tenant_quota=1)
+        recycled = sb.recycle()
+        assert recycled._thread._tenant == "acme"
+        assert recycled._thread._tenant_quota == 1
+        assert recycled._thread._tenant_quota_reserved is True
+        assert sup._tenant_usage.get("acme", 0) == 1
+    finally:
+        sup.shutdown()
+
+    assert ledger.read_text(encoding="utf-8").splitlines() == [
+        "acme,1",
+        "acme,-1",
+        "acme,1",
+        "acme,-1",
+    ]
 
 
 def test_spawn_start_failure_rolls_back_tenant_usage_and_ledger(tmp_path, monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure tenant quota reservations made by `Supervisor.spawn(..., tenant=..., tenant_quota=...)` are tracked on the sandbox thread so the supervisor can release them exactly once when the sandbox is removed. 
- Prevent double-decrements and inconsistent ledger state across spawn rollback, cleanup, quarantine, and recycle code paths. 
- Preserve existing rollback semantics on spawn failure while making recycle preserve or consistently re-acquire tenant metadata.

### Description
- Add per-thread tenant metadata on `SandboxThread`: `_tenant`, `_tenant_quota`, and `_tenant_quota_reserved`, and deserialize provided capabilities earlier when wiring authorities. 
- Add supervisor helpers `_mark_tenant_reservation()` and `_release_tenant_reservation()` that use the thread-owned `_tenant_quota_reserved` flag to ensure release happens at most once. 
- Update `Supervisor.spawn()` to mark the thread with the tenant reservation when a reservation is made and to use the release helper in exception rollback only if needed. 
- Update `Supervisor._cleanup()`, `Supervisor.quarantine()`, and `Supervisor.recycle()` to release reservations via the new helper; `recycle()` now snapshots tenant metadata and passes `tenant`/`tenant_quota` through to the newly spawned sandbox so the reservation is reacquired consistently. 
- Add and adapt tests in `tests/test_supervisor.py` to cover: spawn under quota then close and spawn again for same tenant; quarantine releasing reservation; spawn failure rolling back reservation only once; ledger replay balancing positive/negative entries; and recycle reacquiring reservation.

### Testing
- Ran `pytest tests/test_supervisor.py -q` which passed (all supervisor tests including the new ones succeeded). 
- Ran `pytest tests/test_supervisor.py tests/test_checkpoint.py::test_checkpoint_restores_capabilities -q` which passed. 
- Targeted test runs were used to validate the changes and the added tests; they succeeded after the implemented fixes (full-suite runs earlier in development exposed unrelated environment/tooling failures that were not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3426e32bdc83289b1c4a25dd39b2ae)