### PR TITLE
Add brokered safe open for sandbox file access

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -65,6 +65,7 @@ _ORIG_SOCKET_CONNECT = socket.socket.connect
 _ORIG_SOCKET_CONNECT_EX = socket.socket.connect_ex
 _ORIG_SOCKET_SENDTO = socket.socket.sendto
 _ORIG_THREAD_START = threading.Thread.start
+_ORIG_OS_OPEN = os.open
 _CAPABILITY_MARKER = "__pyisolate_capability__"
 # No modules are imported by default. Examples and tests must name every
 # module they need via Policy.allow_import(...) or allowed_imports=[...].
@@ -147,7 +148,11 @@ def _serialize_capability(capability: Any) -> Any:
     if isinstance(capability, WritePath):
         return {_CAPABILITY_MARKER: "write_path", "path": str(capability.path)}
     if isinstance(capability, ConnectTCP):
-        return {_CAPABILITY_MARKER: "connect_tcp", "host": capability.host, "port": capability.port}
+        return {
+            _CAPABILITY_MARKER: "connect_tcp",
+            "host": capability.host,
+            "port": capability.port,
+        }
     if isinstance(capability, Import):
         return {_CAPABILITY_MARKER: "import", "module": capability.module}
     if isinstance(capability, CpuBudget):
@@ -218,6 +223,131 @@ def deserialize_capabilities(capabilities: Optional[dict[str, Any]]) -> dict[str
     }
 
 
+def _open_flags_from_mode(mode: object) -> int:
+    """Translate Python open() modes to os.open() flags for brokered opens."""
+    text = str(mode or "r")
+    if "w" in text:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    elif "a" in text:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    elif "x" in text:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    else:
+        flags = os.O_RDONLY
+    if "+" in text:
+        flags &= ~(os.O_RDONLY | os.O_WRONLY)
+        flags |= os.O_RDWR
+    return flags
+
+
+def _same_file(left: os.stat_result, right: os.stat_result) -> bool:
+    return left.st_dev == right.st_dev and left.st_ino == right.st_ino
+
+
+def _safe_brokered_open(
+    file,
+    mode="r",
+    buffering=-1,
+    encoding=None,
+    errors=None,
+    newline=None,
+    closefd=True,
+    opener=None,
+    *,
+    allowed_roots: Iterable[Path],
+):
+    """Open *file* through a descriptor-relative sandbox broker.
+
+    On platforms with ``dir_fd`` support, parent directories are traversed from
+    an allowed root by file descriptor and every traversed component is opened
+    with ``O_NOFOLLOW`` where available.  The final component is opened with
+    ``os.open(..., dir_fd=parent_fd)`` and ``O_NOFOLLOW`` where available, then
+    re-checked with ``fstat`` against a descriptor-relative ``stat`` of the same
+    path.
+
+    Compatibility fallback is intentionally explicit: if the platform lacks the
+    required descriptor-relative primitives, access falls back to the previous
+    resolved-path check before calling the original ``open``.  That fallback
+    preserves portability but cannot provide the same symlink race protection.
+    """
+    if opener is not None:
+        raise ValueError("custom openers are not supported in sandboxed open")
+    if not closefd:
+        raise ValueError("closefd=False is not supported in sandboxed open")
+
+    policy_errors = sys.modules[__package__.rsplit(".", 1)[0] + ".errors"]
+    roots = tuple(Path(root).resolve(strict=False) for root in allowed_roots)
+    raw_path = Path(os.fsdecode(file) if isinstance(file, bytes) else os.fspath(file))
+    lexical_path = Path(os.path.abspath(raw_path))
+    root = next(
+        (
+            candidate
+            for candidate in roots
+            if lexical_path == candidate or lexical_path.is_relative_to(candidate)
+        ),
+        None,
+    )
+    if root is None:
+        raise policy_errors.PolicyError("file access blocked")
+
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    dir_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow
+    have_dir_fd = _ORIG_OS_OPEN in getattr(
+        os, "supports_dir_fd", set()
+    ) and os.stat in getattr(os, "supports_dir_fd", set())
+    have_follow = os.stat in getattr(os, "supports_follow_symlinks", set())
+    if nofollow and have_dir_fd and have_follow:
+        root_fd = os.open(root, dir_flags)
+        current_fd = root_fd
+        fds = [root_fd]
+        fd = -1
+        try:
+            rel_parts = lexical_path.relative_to(root).parts
+            for part in rel_parts[:-1]:
+                if part in ("", ".", ".."):
+                    raise policy_errors.PolicyError("file access blocked")
+                next_fd = os.open(part, dir_flags, dir_fd=current_fd)
+                fds.append(next_fd)
+                current_fd = next_fd
+            final = rel_parts[-1] if rel_parts else "."
+            flags = _open_flags_from_mode(mode) | nofollow
+            fd = os.open(final, flags, 0o666, dir_fd=current_fd)
+            opened_stat = os.fstat(fd)
+            checked_stat = os.stat(final, dir_fd=current_fd, follow_symlinks=False)
+            if not _same_file(opened_stat, checked_stat):
+                os.close(fd)
+                fd = -1
+                raise policy_errors.PolicyError("file access blocked")
+            return _ORIG_OPEN(
+                fd, mode, buffering, encoding, errors, newline, closefd=True
+            )
+        except OSError as exc:
+            if fd >= 0:
+                os.close(fd)
+            raise policy_errors.PolicyError("file access blocked") from exc
+        finally:
+            for descriptor in reversed(fds):
+                os.close(descriptor)
+
+    resolved = raw_path.resolve(strict=False)
+    if not any(
+        resolved == candidate or resolved.is_relative_to(candidate)
+        for candidate in roots
+    ):
+        raise policy_errors.PolicyError("file access blocked")
+    opened = _ORIG_OPEN(
+        file, mode, buffering, encoding, errors, newline, closefd=closefd
+    )
+    try:
+        final_stat = os.fstat(opened.fileno())
+        resolved_stat = os.stat(resolved)
+        if not _same_file(final_stat, resolved_stat):
+            opened.close()
+            raise policy_errors.PolicyError("file access blocked")
+    except Exception:
+        opened.close()
+        raise
+    return opened
 
 
 def _iter_authorities(policy, capabilities: Optional[dict[str, Any]]) -> list[object]:
@@ -234,13 +364,16 @@ def _iter_authorities(policy, capabilities: Optional[dict[str, Any]]) -> list[ob
         for module in getattr(policy, "imports", []) or []:
             authorities.append(Import(module))
     if capabilities:
-        values = capabilities.values() if isinstance(capabilities, dict) else capabilities
+        values = (
+            capabilities.values() if isinstance(capabilities, dict) else capabilities
+        )
         for capability in values:
             if isinstance(capability, (list, tuple, set, frozenset)):
                 authorities.extend(capability)
             else:
                 authorities.append(capability)
     return authorities
+
 
 def _fs_rule_matches(pattern: str, path: Path) -> bool:
     path_text = str(path)
@@ -260,25 +393,26 @@ def _blocked_open(file, *args, **kwargs):
     if isinstance(file, os.PathLike):
         file = os.fspath(file)
 
-    if isinstance(file, (str, bytes)):
-        path = Path(file).resolve(strict=False)
+    mode = args[0] if args else kwargs.get("mode", "r")
+    text_mode = str(mode)
+    wants_write = any(flag in text_mode for flag in ("w", "a", "x", "+"))
+    safe_roots: tuple[Path, ...] | None = None
 
-        mode = args[0] if args else kwargs.get("mode", "r")
-        text_mode = str(mode)
-        wants_write = any(flag in text_mode for flag in ("w", "a", "x", "+"))
+    if isinstance(file, (str, bytes)):
+        display_path = Path(os.fsdecode(file) if isinstance(file, bytes) else file)
+        lexical_path = Path(os.path.abspath(display_path))
+        path = display_path.resolve(strict=False)
+
         authority = getattr(_thread_local, "authority", None)
         fs_cap = getattr(_thread_local, "fs_capability", None)
         allowed = getattr(_thread_local, "fs", None)
         runtime_policy = getattr(_thread_local, "runtime_policy", None)
-        if authority is not None:
-            if wants_write:
-                permitted = authority.allows_write(path)
-            else:
-                permitted = authority.allows_read(path)
-            if not permitted:
-                raise errors.PolicyError("file access blocked")
-        elif fs_cap is not None:
-            if not fs_cap.allows(path):
+        if fs_cap is not None:
+            safe_roots = fs_cap.roots
+            if not any(
+                lexical_path == root or lexical_path.is_relative_to(root)
+                for root in fs_cap.roots
+            ):
                 raise _deny(
                     "filesystem",
                     f"open:{path}",
@@ -286,15 +420,39 @@ def _blocked_open(file, *args, **kwargs):
                     "file access blocked",
                 )
         elif allowed is not None:
-            if not any(path.is_relative_to(a) for a in allowed):
+            safe_roots = tuple(allowed)
+            if not any(
+                lexical_path == a or lexical_path.is_relative_to(a) for a in allowed
+            ):
                 raise _deny(
                     "filesystem",
                     f"open:{path}",
                     f"allow_fs:{_format_roots(allowed)}",
                     "file access blocked",
                 )
+        elif authority is not None:
+            candidate_roots = (
+                authority.write_paths if wants_write else authority.read_paths
+            )
+            if candidate_roots:
+                safe_roots = tuple(candidate_roots)
+                permitted = any(
+                    lexical_path == root or lexical_path.is_relative_to(root)
+                    for root in candidate_roots
+                )
+                if not permitted:
+                    raise _deny(
+                        "filesystem",
+                        f"open:{path}",
+                        f"authority:{'write' if wants_write else 'read'} roots={_format_roots(candidate_roots)}",
+                        "file access blocked",
+                    )
+            else:
+                raise errors.PolicyError("file access blocked")
         elif runtime_policy is not None:
-            if any(_fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs):
+            if any(
+                _fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs
+            ):
                 raise errors.PolicyError("file access blocked")
             if not any(
                 _fs_rule_matches(rule.path, path) for rule in runtime_policy.allow_fs
@@ -311,7 +469,14 @@ def _blocked_open(file, *args, **kwargs):
     sandbox = getattr(_thread_local, "sandbox", None)
     if sandbox is not None:
         sandbox._check_open_files_quota()
-    opened = _ORIG_OPEN(file, *args, **kwargs)
+    if safe_roots is not None and isinstance(file, (str, bytes)):
+        mode_arg = args[0] if args else kwargs.pop("mode", "r")
+        rest = args[1:] if args else ()
+        opened = _safe_brokered_open(
+            file, mode_arg, *rest, allowed_roots=safe_roots, **kwargs
+        )
+    else:
+        opened = _ORIG_OPEN(file, *args, **kwargs)
     if sandbox is None:
         return opened
     sandbox._open_files += 1
@@ -321,6 +486,7 @@ def _blocked_open(file, *args, **kwargs):
 
     weakref.finalize(opened, _release)
     return opened
+
 
 def _check_network_destination(address: Iterable[str]) -> None:
     authority = getattr(_thread_local, "authority", None)
@@ -354,7 +520,9 @@ def _check_network_destination(address: Iterable[str]) -> None:
     elif runtime_policy is not None:
         if any(rule.destination == destination for rule in runtime_policy.deny_tcp):
             raise errors.PolicyError(f"connect blocked: {destination}")
-        if not any(rule.destination == destination for rule in runtime_policy.allow_tcp):
+        if not any(
+            rule.destination == destination for rule in runtime_policy.allow_tcp
+        ):
             raise errors.PolicyError(f"connect blocked: {destination}")
     elif getattr(_thread_local, "active", False):
         raise _deny(
@@ -707,7 +875,11 @@ class SandboxThread(threading.Thread):
         if policy is not None and getattr(policy, "imports", None):
             imports.update(policy.imports)
         if policy is not None:
-            imports.update(AuthoritySet.from_authorities(getattr(policy, "capabilities", []) or []).imports)
+            imports.update(
+                AuthoritySet.from_authorities(
+                    getattr(policy, "capabilities", []) or []
+                ).imports
+            )
         runtime_policy = from_sandbox_policy(policy) if policy is not None else None
         if runtime_policy is not None and runtime_policy.imports:
             imports.update(runtime_policy.imports)
@@ -737,9 +909,13 @@ class SandboxThread(threading.Thread):
         enforcement_status: Any = None,
     ) -> None:
         self.policy = policy
-        self._authority = AuthoritySet.from_authorities(_iter_authorities(policy, capabilities))
+        self._authority = AuthoritySet.from_authorities(
+            _iter_authorities(policy, capabilities)
+        )
         self.cpu_quota_ms = cpu_ms if cpu_ms is not None else self._authority.cpu_ms
-        self.runtime_policy = from_sandbox_policy(policy) if policy is not None else None        
+        self.runtime_policy = (
+            from_sandbox_policy(policy) if policy is not None else None
+        )
         self.mem_quota_bytes = mem_bytes
         self.wall_time_ms = wall_time_ms
         self.open_files_max = open_files_max
@@ -1036,7 +1212,9 @@ class SandboxThread(threading.Thread):
         if not self.cancel(timeout=timeout):
             self.kill(timeout=timeout)
 
-    def enforce_quota_breach(self, exc: Exception, reason: str, timeout: float = 0.05) -> bool:
+    def enforce_quota_breach(
+        self, exc: Exception, reason: str, timeout: float = 0.05
+    ) -> bool:
         """Record a kernel/watchdog quota breach and stop guest execution.
 
         The watchdog calls this path from outside the sandbox thread, so it does

--- a/tests/test_policy_enforcement.py
+++ b/tests/test_policy_enforcement.py
@@ -173,3 +173,71 @@ def test_policy_blocks_side_effect_import_escape_surfaces(name, source, imports)
             sb.recv(timeout=1)
     finally:
         sb.close()
+
+
+def test_fs_policy_blocks_symlink_escape_reads(tmp_path):
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+    link = allowed_dir / "escape.txt"
+    link.symlink_to(outside)
+
+    p = policy.Policy().allow_fs(str(allowed_dir))
+    sb = iso.spawn("pifs-symlink-read", policy=p)
+    try:
+        sb.exec(f"post(open({str(link)!r}).read())")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
+def test_fs_policy_blocks_symlink_escape_writes(tmp_path):
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("unchanged")
+    link = allowed_dir / "escape.txt"
+    link.symlink_to(outside)
+
+    p = policy.Policy().allow_fs(str(allowed_dir))
+    sb = iso.spawn("pifs-symlink-write", policy=p)
+    try:
+        sb.exec(f"open({str(link)!r}, 'w').write('changed')")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+    assert outside.read_text() == "unchanged"
+
+
+def test_safe_brokered_open_blocks_final_component_replacement_race(
+    tmp_path, monkeypatch
+):
+    import pyisolate.runtime.thread as thread_mod
+
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    target = allowed_dir / "target.txt"
+    target.write_text("safe")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+
+    original_os_open = thread_mod.os.open
+    replaced = False
+
+    def racing_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal replaced
+        if path == "target.txt" and dir_fd is not None and not replaced:
+            replaced = True
+            target.unlink()
+            target.symlink_to(outside)
+        return original_os_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(thread_mod.os, "open", racing_open)
+
+    with pytest.raises(iso.PolicyError):
+        thread_mod._safe_brokered_open(target, "r", allowed_roots=(allowed_dir,))
+    assert replaced


### PR DESCRIPTION
### Motivation
- Prevent symlink-escape and TOCTOU races when sandboxed code opens files by performing descriptor-relative traversal from an allowed root and re-checking the final opened object.  
- Route sandboxed `open` through a brokered helper so filesystem capability and allow_fs/authority checks are evaluated together with a safer open sequence.

### Description
- Add a brokered open helper `_safe_brokered_open` plus helpers `_open_flags_from_mode` and `_same_file` in `pyisolate/runtime/thread.py` and capture the original `os.open` as `_ORIG_OS_OPEN`.  
- Implement descriptor-relative traversal using `os.open(..., dir_fd=...)` and `O_NOFOLLOW` where supported, and re-check the opened descriptor with `os.fstat` and a descriptor-relative `os.stat(..., follow_symlinks=False)`.  
- Provide an explicit compatibility fallback that checks the resolved `Path` and then verifies the opened file via `fstat` when descriptor-relative primitives or `O_NOFOLLOW` are not available.  
- Route the sandboxed builtin `_blocked_open` to call `_safe_brokered_open` for `FilesystemCapability` roots, `allow_fs` roots, and read/write `Authority` roots, and add tests for symlink escape reads/writes and a final-component replacement race in `tests/test_policy_enforcement.py`.

### Testing
- Ran `python -m py_compile pyisolate/runtime/thread.py` which succeeded.  
- Ran `pytest -q tests/test_policy_enforcement.py` (includes the new symlink/race tests) which passed in the test runs.  
- Ran targeted `pytest` invocations including `tests/test_alerts.py::test_denied_operation_emits_structured_telemetry` and other focused suites which passed in isolation; a full `pytest -q` in this container surfaced unrelated environment-dependent failures (BPF/cgroup/tooling and other pre-existing policy/import expectations) that are not caused by the new brokered open logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3426e3bc6c8328ba6040b7d437dd65)