### PR TITLE
Ensure unique, debuggable sandbox names in SDK and Pipeline

### DIFF
--- a/pyisolate/sdk.py
+++ b/pyisolate/sdk.py
@@ -2,10 +2,46 @@
 
 from __future__ import annotations
 
+import re
+import secrets
 from typing import Any, Callable
 
+from . import supervisor
 from .policy import Policy, resolve_policy
-from .supervisor import spawn
+
+_SANDBOX_NAME_MAX_LEN = 64
+_SANDBOX_NAME_SUFFIX_BYTES = 4
+_INVALID_NAME_CHARS = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+def _sandbox_name_prefix(module: str, function: str, *parts: object) -> str:
+    """Return a debuggable sandbox-name prefix accepted by the supervisor."""
+    raw_parts = [module, *(str(part) for part in parts), function]
+    prefix = "-".join(part for part in raw_parts if part)
+    prefix = _INVALID_NAME_CHARS.sub("-", prefix).strip("-_")
+    prefix = re.sub(r"[-_]{2,}", "-", prefix)
+    return prefix or "sandbox"
+
+
+def _unique_sandbox_name(module: str, function: str, *parts: object) -> str:
+    """Build a unique supervisor-safe sandbox name no longer than 64 chars."""
+    suffix = secrets.token_hex(_SANDBOX_NAME_SUFFIX_BYTES)
+    separator = "-"
+    max_prefix_len = _SANDBOX_NAME_MAX_LEN - len(separator) - len(suffix)
+
+    prefix = _sandbox_name_prefix(module, function, *parts)
+    if len(prefix) > max_prefix_len:
+        # Keep the function/stage portion visible at the end of the prefix while
+        # retaining as much module context as fits before it.
+        prefix = prefix[-max_prefix_len:].lstrip("-_") or prefix[:max_prefix_len]
+
+    name = f"{prefix}{separator}{suffix}"
+    if supervisor.NAME_PATTERN.fullmatch(name) is None:
+        # The default supervisor pattern permits the sanitized alphabet above.
+        # If callers have installed a stricter pattern, fail with the same kind
+        # of validation error spawn() would raise, but before starting work.
+        raise ValueError("Sandbox name contains invalid characters")
+    return name
 
 
 def sandbox(
@@ -27,8 +63,8 @@ def sandbox(
 
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             resolved_policy = resolve_policy(policy)
-            sb = spawn(
-                func.__name__,
+            sb = supervisor.spawn(
+                _unique_sandbox_name(func.__module__, func.__name__),
                 policy=resolved_policy,
                 allowed_imports=[func.__module__],
             )
@@ -64,10 +100,13 @@ class Pipeline:
     def run(self, data: Any) -> Any:
         """Run data through all stages sequentially."""
         value = data
-        for dotted, policy in self._stages:
+        for index, (dotted, policy) in enumerate(self._stages):
             module, _, name = dotted.rpartition(".")
             resolved_policy = resolve_policy(policy)
             allowed = [module] if module else None
-            with spawn(name, policy=resolved_policy, allowed_imports=allowed) as sb:
+            sandbox_name = _unique_sandbox_name(module, name, f"stage-{index}")
+            with supervisor.spawn(
+                sandbox_name, policy=resolved_policy, allowed_imports=allowed
+            ) as sb:
                 value = sb.call(dotted, value)
         return value

--- a/tests/helper_module.py
+++ b/tests/helper_module.py
@@ -8,3 +8,10 @@ def stage_one(x):
 
 def stage_two(x):
     return x * 2
+
+
+def slow_identity(x):
+    import time
+
+    time.sleep(0.05)
+    return x

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,11 +1,12 @@
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from helper_module import add as plain_add
-from helper_module import stage_one, stage_two
+from helper_module import slow_identity, stage_one, stage_two
 
 import pyisolate as iso
 
@@ -22,3 +23,22 @@ def test_pipeline_run():
     pipe.add_stage(stage_two)
     result = pipe.run(3)
     assert result == 8
+
+
+def test_sandbox_decorator_concurrent_calls_use_unique_names():
+    slow = iso.sandbox(timeout=1)(slow_identity)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(slow, range(8)))
+
+    assert results == list(range(8))
+
+
+def test_pipeline_run_concurrent_calls_use_unique_stage_names():
+    pipe = iso.Pipeline()
+    pipe.add_stage(slow_identity)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(pipe.run, range(8)))
+
+    assert results == list(range(8))


### PR DESCRIPTION
### Motivation
- Prevent sandbox-name collisions when the same decorated function or pipeline stage is invoked concurrently by generating unique names per invocation.
- Keep sandbox names useful for debugging by preserving the function/stage name in a sanitized prefix while respecting the supervisor's 64-character limit.

### Description
- Added `_sandbox_name_prefix` and `_unique_sandbox_name` helpers that sanitize module/function/stage parts, append a short `secrets.token_hex(4)` suffix, and enforce a 64-character maximum using the supervisor's `NAME_PATTERN` for validation.
- Updated `sandbox()` to call `supervisor.spawn()` with a unique, debuggable name instead of reusing the raw function name.
- Updated `Pipeline.run()` to use the same unique-naming helper and include the stage index in the name prefix for each stage.
- Added a slow helper `slow_identity` and two concurrent tests in `tests/test_sdk.py` to exercise repeated concurrent invocations of the decorated function and pipeline stage.

### Testing
- Ran `pytest tests/test_sdk.py -q`; tests passed: `4 passed`.
- Attempted `python -m flake8 pyisolate/sdk.py tests/test_sdk.py tests/helper_module.py` but the `flake8` runner was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3426e4ae3483288a4d46255490db44)