### PR TITLE
Fix filesystem capability lexical denial

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -415,6 +415,12 @@ def _blocked_open(file, *args, **kwargs):
                 lexical_path == root or lexical_path.is_relative_to(root)
                 for root in fs_cap.roots
             ):
+                raise _deny(
+                    "filesystem",
+                    f"open:{path}",
+                    f"capability:filesystem roots={_format_roots(fs_cap.roots)}",
+                    "file access blocked",
+                )
             if not fs_cap.allows(path):
                 raise _deny(
                     "filesystem",

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -188,3 +188,34 @@ def test_first_class_tcp_import_and_cpu_budget() -> None:
         assert sb.recv(timeout=1) == 3.0
     finally:
         sb.close()
+
+
+def test_filesystem_capability_lexical_root_denial_records_policy_rule(
+    tmp_path,
+) -> None:
+    import pyisolate.runtime.thread as thread_mod
+
+    allowed = tmp_path / "allowed"
+    denied = tmp_path / "denied"
+    allowed.mkdir()
+    denied.mkdir()
+    target = denied / "no.txt"
+    target.write_text("no")
+
+    thread_mod._thread_local.fs_capability = FilesystemCapability.from_paths(
+        str(allowed)
+    )
+    try:
+        with pytest.raises(iso.PolicyError) as excinfo:
+            thread_mod._blocked_open(target)
+    finally:
+        del thread_mod._thread_local.fs_capability
+
+    denial = excinfo.value.denial_event
+    assert denial is not None
+    assert denial.capability == "filesystem"
+    assert denial.attempted_action == f"open:{target.resolve(strict=False)}"
+    assert (
+        denial.policy_rule
+        == f"capability:filesystem roots={allowed.resolve(strict=False)}"
+    )

--- a/tests/test_runtime_static.py
+++ b/tests/test_runtime_static.py
@@ -1,0 +1,7 @@
+import py_compile
+from pathlib import Path
+
+
+def test_runtime_thread_module_compiles() -> None:
+    path = Path(__file__).resolve().parents[1] / "pyisolate" / "runtime" / "thread.py"
+    py_compile.compile(str(path), doraise=True)


### PR DESCRIPTION
### Motivation

- Ensure capability-backed file opens deny access when the lexical path is outside the capability `roots`, so lexically-incorrect accesses are blocked and produce a proper denial event.

### Description

- Add a lexical-root denial in `_blocked_open` so that when `fs_cap` is set and `lexical_path` is not within any `fs_cap.roots` the call raises `_deny(...)` with the capability rule set to `capability:filesystem roots=...`.
- Preserve the subsequent `if not fs_cap.allows(path):` resolved-path check as a separate symlink/normalization guard.
- Add a regression test `tests/test_capabilities.py::test_filesystem_capability_lexical_root_denial_records_policy_rule` that verifies the denial event metadata for the lexical-root failure.
- Add a static compilation test `tests/test_runtime_static.py` that runs `py_compile.compile(..., doraise=True)` on `pyisolate/runtime/thread.py` to catch future syntax failures.

### Testing

- Ran a static compile check with `py_compile.compile` on `pyisolate/runtime/thread.py` which succeeded.
- Ran `pytest` for the new and related tests (`tests/test_runtime_static.py` and the two filesystem capability tests) and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34372d8e088328b133bc4c09e1a76b)