### PR TITLE
Harden runtime-policy filesystem opens and add symlink/race tests

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -389,6 +389,18 @@ def _fs_rule_matches(pattern: str, path: Path) -> bool:
     )
 
 
+def _fs_rule_safe_root(pattern: str) -> Path | None:
+    """Return the descriptor-broker root for a filesystem rule, if representable."""
+    if pattern.endswith("/**"):
+        root_pattern = pattern[:-3]
+        if any(char in root_pattern for char in "*?["):
+            return None
+        return Path(root_pattern).resolve(strict=False)
+    if any(char in pattern for char in "*?["):
+        return None
+    return Path(pattern).resolve(strict=False)
+
+
 def _blocked_open(file, *args, **kwargs):
     """Restrict file access based on the current thread's policy."""
 
@@ -411,10 +423,6 @@ def _blocked_open(file, *args, **kwargs):
         runtime_policy = getattr(_thread_local, "runtime_policy", None)
         if fs_cap is not None:
             safe_roots = fs_cap.roots
-            if not any(
-                lexical_path == root or lexical_path.is_relative_to(root)
-                for root in fs_cap.roots
-            ):
             if not fs_cap.allows(path):
                 raise _deny(
                     "filesystem",
@@ -439,17 +447,6 @@ def _blocked_open(file, *args, **kwargs):
             )
             if candidate_roots:
                 safe_roots = tuple(candidate_roots)
-                permitted = any(
-                    lexical_path == root or lexical_path.is_relative_to(root)
-                    for root in candidate_roots
-                )
-                if not permitted:
-                    raise _deny(
-                        "filesystem",
-                        f"open:{path}",
-                        f"authority:{'write' if wants_write else 'read'} roots={_format_roots(candidate_roots)}",
-                        "file access blocked",
-                    )
             else:
                 raise errors.PolicyError("file access blocked")
             if wants_write:
@@ -473,15 +470,29 @@ def _blocked_open(file, *args, **kwargs):
                     "runtime_policy:deny_fs",
                     "file access blocked",
                 )
-            if not any(
-                _fs_rule_matches(rule.path, path) for rule in runtime_policy.allow_fs
-            ):
+            matching_allow_rules = [
+                rule
+                for rule in runtime_policy.allow_fs
+                if _fs_rule_matches(rule.path, path)
+            ]
+            if not matching_allow_rules:
                 raise _deny(
                     "filesystem",
                     f"open:{path}",
                     "runtime_policy:allow_fs",
                     "file access blocked",
                 )
+            candidate_roots = tuple(
+                _fs_rule_safe_root(rule.path) for rule in matching_allow_rules
+            )
+            if any(root is None for root in candidate_roots):
+                raise _deny(
+                    "filesystem",
+                    f"open:{path}",
+                    "runtime_policy:allow_fs",
+                    "filesystem glob allow rules are not supported for brokered open",
+                )
+            safe_roots = tuple(root for root in candidate_roots if root is not None)
         elif getattr(_thread_local, "active", False):
             raise _deny(
                 "filesystem",

--- a/tests/test_policy_enforcement.py
+++ b/tests/test_policy_enforcement.py
@@ -189,6 +189,10 @@ def test_fs_policy_blocks_symlink_escape_reads(tmp_path):
         sb.exec(f"post(open({str(link)!r}).read())")
         with pytest.raises(iso.PolicyError):
             sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
 def _assert_denial_event(events, *, cell, capability, attempted_action, policy_rule):
     assert events
     event = events[-1]
@@ -296,6 +300,66 @@ def test_safe_brokered_open_blocks_final_component_replacement_race(
     with pytest.raises(iso.PolicyError):
         thread_mod._safe_brokered_open(target, "r", allowed_roots=(allowed_dir,))
     assert replaced
+
+
+def test_runtime_policy_allow_fs_blocks_symlink_escape_reads(tmp_path):
+    allowed_dir = tmp_path / "runtime-allowed"
+    allowed_dir.mkdir()
+    outside = tmp_path / "runtime-outside.txt"
+    outside.write_text("secret")
+    link = allowed_dir / "escape.txt"
+    link.symlink_to(outside)
+
+    runtime_policy = policy.RuntimePolicy(
+        allow_fs=(policy.FilesystemRule("allow", str(allowed_dir)),),
+    )
+    sb = iso.spawn("runtime-fs-symlink-read", policy=runtime_policy)
+    try:
+        sb.exec(f"post(open({str(link)!r}).read())")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+
+
+def test_runtime_policy_allow_fs_blocks_final_component_replacement_race(
+    tmp_path, monkeypatch
+):
+    import pyisolate.runtime.thread as thread_mod
+
+    allowed_dir = tmp_path / "runtime-allowed"
+    allowed_dir.mkdir()
+    target = allowed_dir / "target.txt"
+    target.write_text("safe")
+    outside = tmp_path / "runtime-outside.txt"
+    outside.write_text("secret")
+
+    original_os_open = thread_mod.os.open
+    replaced = False
+
+    def racing_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal replaced
+        if path == "target.txt" and dir_fd is not None and not replaced:
+            replaced = True
+            target.unlink()
+            target.symlink_to(outside)
+        return original_os_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(thread_mod.os, "open", racing_open)
+
+    runtime_policy = policy.RuntimePolicy(
+        allow_fs=(policy.FilesystemRule("allow", str(allowed_dir)),),
+    )
+    sb = iso.spawn("runtime-fs-symlink-swap", policy=runtime_policy)
+    try:
+        sb.exec(f"post(open({str(target)!r}).read())")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()
+    assert replaced
+
+
 def test_runtime_policy_filesystem_deny_rule_records_event(tmp_path):
     allowed_dir = tmp_path / "allowed"
     denied_dir = tmp_path / "denied"


### PR DESCRIPTION
### Motivation
- Ensure runtime `allow_fs` rules are represented as descriptor-broker-safe roots where possible so brokered opens can provide symlink-race protection. 
- Reject or surface unsupported glob forms for brokered access instead of silently falling back to insecure path-based opens. 
- Add regression tests that cover symlink escape and final-component replacement races for runtime-policy `allow_fs` entries.

### Description
- Added helper `_fs_rule_safe_root(pattern: str) -> Path | None` that returns a resolved root for simple directory or trailing `/**` rules and returns `None` for unsupported glob patterns. 
- Updated `_blocked_open` to preserve deny-before-allow semantics, collect matching `runtime_policy.allow_fs` rules, map them to safe roots (via `_fs_rule_safe_root`), set `safe_roots` for the descriptor-broker path, and reject matching allow rules that are not representable as safe roots. 
- Kept capability/authority handling intact while removing redundant lexical checks that previously leaked a different `policy_rule` string. 
- Fixed a missing `finally` cleanup in an existing symlink read test and added two tests: `test_runtime_policy_allow_fs_blocks_symlink_escape_reads` and `test_runtime_policy_allow_fs_blocks_final_component_replacement_race` to cover symlink swaps and the brokered-open race protection.

### Testing
- Ran `python -m py_compile pyisolate/runtime/thread.py tests/test_policy_enforcement.py` which succeeded. 
- Ran `pytest -q tests/test_policy_enforcement.py` and the file-level suite passed (including the two new tests). 
- Ran the two new tests specifically with `pytest -q tests/test_policy_enforcement.py::test_runtime_policy_allow_fs_blocks_symlink_escape_reads tests/test_policy_enforcement.py::test_runtime_policy_allow_fs_blocks_final_component_replacement_race` which both passed. 
- A full `pytest -q` run surfaced unrelated existing failures in other areas (reload/BPF hooks, default import policy expectations, and supervisor recovery state) that are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34372f218c8328a7db190b6fca2bea)