### PR TITLE
Release open-file quota on explicit close

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -414,8 +414,7 @@ def _blocked_open(file, *args, **kwargs):
             if not any(
                 lexical_path == root or lexical_path.is_relative_to(root)
                 for root in fs_cap.roots
-            ):
-            if not fs_cap.allows(path):
+            ) or not fs_cap.allows(path):
                 raise _deny(
                     "filesystem",
                     f"open:{path}",
@@ -504,10 +503,26 @@ def _blocked_open(file, *args, **kwargs):
     if sandbox is None:
         return opened
     sandbox._open_files += 1
+    released = False
+    release_lock = threading.Lock()
 
     def _release():
-        sandbox._open_files = max(0, sandbox._open_files - 1)
+        nonlocal released
+        with release_lock:
+            if released:
+                return
+            released = True
+            sandbox._open_files = max(0, sandbox._open_files - 1)
 
+    original_close = opened.close
+
+    def _close_once(*close_args, **close_kwargs):
+        try:
+            return original_close(*close_args, **close_kwargs)
+        finally:
+            _release()
+
+    opened.close = _close_once
     weakref.finalize(opened, _release)
     return opened
 

--- a/tests/test_thread_quota.py
+++ b/tests/test_thread_quota.py
@@ -83,6 +83,50 @@ def test_open_files_quota_hard_stop(tmp_path):
         sb.stop()
 
 
+def test_open_files_quota_releases_on_explicit_close(tmp_path):
+    target = tmp_path / "data.txt"
+    target.write_text("ok", encoding="utf-8")
+
+    policy = type("Policy", (), {"fs": {str(tmp_path)}})()
+    sb = thread.SandboxThread("files-close", policy=policy, open_files_max=1)
+    sb.start()
+    try:
+        sb.exec(
+            f"path = {str(target)!r}\n"
+            "for _ in range(10):\n"
+            "    fh = open(path, 'r')\n"
+            "    assert fh.read() == 'ok'\n"
+            "    fh.close()\n"
+            "post('ok')"
+        )
+        assert sb.recv(timeout=1) == "ok"
+    finally:
+        sb.stop()
+
+
+def test_open_files_quota_close_is_idempotent(tmp_path):
+    target = tmp_path / "data.txt"
+    target.write_text("ok", encoding="utf-8")
+
+    policy = type("Policy", (), {"fs": {str(tmp_path)}})()
+    sb = thread.SandboxThread("files-close-idempotent", policy=policy, open_files_max=1)
+    sb.start()
+    try:
+        sb.exec(
+            f"path = {str(target)!r}\n"
+            "fh = open(path, 'r')\n"
+            "fh.close()\n"
+            "fh.close()\n"
+            "fh = open(path, 'r')\n"
+            "fh.close()\n"
+            "post('ok')"
+        )
+        assert sb.recv(timeout=1) == "ok"
+        assert sb._open_files == 0
+    finally:
+        sb.stop()
+
+
 def test_output_quota_hard_stop():
     sb = thread.SandboxThread("output", output_bytes_max=4)
     sb.start()


### PR DESCRIPTION
### Motivation

- Prevent the sandbox open-file counter from being decremented more than once when a file is explicitly closed or when the object is finalized. 
- Ensure that explicit `close()` calls immediately free an open-file slot so repeated open/close loops work under tight `open_files_max` limits. 
- Keep `weakref.finalize` as a safe fallback for leaked file objects while making explicit close the primary release path.

### Description

- Added an idempotent release guard (`released` flag + `threading.Lock`) in `_blocked_open` so the release action runs at most once. 
- Wrapped the returned file object’s `close` method with a `_close_once` wrapper that calls the original `close` then invokes the guarded `_release`. 
- Retained `weakref.finalize(opened, _release)` as a fallback and combined the `fs_cap` checks into a single condition to fix a small syntax/logic issue. 
- Added two regression tests under `tests/test_thread_quota.py`: `test_open_files_quota_releases_on_explicit_close` and `test_open_files_quota_close_is_idempotent` to exercise repeated open/close behavior with `open_files_max=1`.

### Testing

- Ran `python -m py_compile pyisolate/runtime/thread.py` and the module compiled successfully. 
- Ran `PYTHONPATH=. pytest tests/test_thread_quota.py::test_open_files_quota_releases_on_explicit_close tests/test_thread_quota.py::test_open_files_quota_close_is_idempotent -q` and both tests passed. 
- Ran `PYTHONPATH=. pytest tests/test_thread_quota.py::test_open_files_quota_hard_stop tests/test_thread_quota.py::test_open_files_quota_releases_on_explicit_close tests/test_thread_quota.py::test_open_files_quota_close_is_idempotent -q` and the three targeted tests passed. 
- A full run of `PYTHONPATH=. pytest tests/test_thread_quota.py -q` surfaced two pre-existing failures unrelated to this change (import-policy checks raising `PolicyError`), which were observed during collection but did not indicate regressions in the new open/close behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3437318e5483289773e39ed266f008)