### PR TITLE
Validate checkpoint restore payloads

### DIFF
--- a/pyisolate/checkpoint.py
+++ b/pyisolate/checkpoint.py
@@ -11,6 +11,7 @@ import os
 
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
+from .runtime.thread import deserialize_capabilities
 from .supervisor import Sandbox, spawn
 
 _MAGIC = b"PYISOCP1"
@@ -35,6 +36,119 @@ def _decode_envelope(payload: bytes) -> bytes:
     if len(body) < _NONCE_LEN:
         raise ValueError("invalid checkpoint envelope length")
     return body
+
+
+def _require_optional_positive_int(state: dict, field: str) -> int | None:
+    value = state.get(field)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(
+            f"invalid checkpoint payload: {field!r} must be None or a positive integer"
+        )
+    return value
+
+
+def _require_optional_numa_node(state: dict) -> int | None:
+    value = state.get("numa_node")
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(
+            "invalid checkpoint payload: 'numa_node' must be None or a non-negative integer"
+        )
+    return value
+
+
+def _require_optional_allowed_imports(state: dict) -> list[str] | None:
+    value = state.get("allowed_imports")
+    if value is None:
+        return None
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise ValueError(
+            "invalid checkpoint payload: 'allowed_imports' must be None or a list of non-empty strings"
+        )
+    return value
+
+
+def _is_str_list(value: object, *, allow_empty_items: bool = False) -> bool:
+    return isinstance(value, list) and all(
+        isinstance(item, str) and (allow_empty_items or bool(item)) for item in value
+    )
+
+
+def _validate_serialized_capability(capability: object) -> None:
+    if isinstance(capability, list):
+        for item in capability:
+            _validate_serialized_capability(item)
+        return
+    if not isinstance(capability, dict):
+        raise ValueError("capability must be a serialized mapping")
+
+    kind = capability.get("__pyisolate_capability__")
+    if kind == "filesystem":
+        if not _is_str_list(capability.get("roots")):
+            raise ValueError("filesystem capability roots must be strings")
+    elif kind == "network":
+        if not _is_str_list(capability.get("destinations")):
+            raise ValueError("network capability destinations must be strings")
+    elif kind == "secrets":
+        values = capability.get("values")
+        if not isinstance(values, dict):
+            raise ValueError("secrets capability values must be a mapping")
+        for key, value in values.items():
+            if not isinstance(key, str) or not key or not isinstance(value, str):
+                raise ValueError("secrets capability values must be hex strings")
+            bytes.fromhex(value)
+    elif kind == "subprocess":
+        if not _is_str_list(capability.get("allowed_commands")):
+            raise ValueError("subprocess capability commands must be strings")
+        if not isinstance(capability.get("allow_shell", False), bool):
+            raise ValueError("subprocess capability allow_shell must be boolean")
+    elif kind in {"read_path", "write_path"}:
+        path = capability.get("path")
+        if not isinstance(path, str) or not path:
+            raise ValueError("path capability path must be a non-empty string")
+    elif kind == "connect_tcp":
+        host = capability.get("host")
+        port = capability.get("port")
+        if not isinstance(host, str) or not host:
+            raise ValueError("connect_tcp capability host must be a non-empty string")
+        if isinstance(port, bool) or not isinstance(port, int) or port <= 0:
+            raise ValueError("connect_tcp capability port must be a positive integer")
+    elif kind == "import":
+        module = capability.get("module")
+        if not isinstance(module, str) or not module:
+            raise ValueError("import capability module must be a non-empty string")
+    elif kind == "cpu_budget":
+        ms = capability.get("ms")
+        if isinstance(ms, bool) or not isinstance(ms, int) or ms <= 0:
+            raise ValueError("cpu_budget capability ms must be a positive integer")
+    elif kind not in {"clock", "random"}:
+        raise ValueError("unknown serialized capability kind")
+
+
+def _require_optional_capabilities(state: dict) -> dict | None:
+    value = state.get("capabilities")
+    if value is None:
+        return None
+    if not isinstance(value, dict) or any(
+        not isinstance(name, str) or not name for name in value
+    ):
+        raise ValueError(
+            "invalid checkpoint payload: 'capabilities' must be None or a serialized capability mapping"
+        )
+    try:
+        for capability in value.values():
+            _validate_serialized_capability(capability)
+        deserialize_capabilities(value)
+    except (TypeError, ValueError, KeyError) as exc:
+        raise ValueError(
+            "invalid checkpoint payload: 'capabilities' must be None or a serialized capability mapping"
+        ) from exc
+    return value
 
 
 def checkpoint(sandbox: Sandbox, key: bytes) -> bytes:
@@ -77,14 +191,19 @@ def restore(blob: bytes, key: bytes) -> Sandbox:
         raise ValueError(
             "invalid checkpoint payload: 'name' must be a non-empty string"
         )
+    cpu_ms = _require_optional_positive_int(state, "cpu_ms")
+    mem_bytes = _require_optional_positive_int(state, "mem_bytes")
+    allowed_imports = _require_optional_allowed_imports(state)
+    numa_node = _require_optional_numa_node(state)
+    capabilities = _require_optional_capabilities(state)
     return spawn(
         name,
         policy=state.get("policy"),
-        cpu_ms=state.get("cpu_ms"),
-        mem_bytes=state.get("mem_bytes"),
-        allowed_imports=state.get("allowed_imports"),
-        numa_node=state.get("numa_node"),
-        capabilities=state.get("capabilities"),
+        cpu_ms=cpu_ms,
+        mem_bytes=mem_bytes,
+        allowed_imports=allowed_imports,
+        numa_node=numa_node,
+        capabilities=capabilities,
     )
 
 

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -415,13 +415,13 @@ def _blocked_open(file, *args, **kwargs):
                 lexical_path == root or lexical_path.is_relative_to(root)
                 for root in fs_cap.roots
             ):
-            if not fs_cap.allows(path):
-                raise _deny(
-                    "filesystem",
-                    f"open:{path}",
-                    f"capability:filesystem roots={_format_roots(fs_cap.roots)}",
-                    "file access blocked",
-                )
+                if not fs_cap.allows(path):
+                    raise _deny(
+                        "filesystem",
+                        f"open:{path}",
+                        f"capability:filesystem roots={_format_roots(fs_cap.roots)}",
+                        "file access blocked",
+                    )
         elif allowed is not None:
             safe_roots = tuple(allowed)
             if not any(

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -4,6 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import importlib
 import json
 import os
 import types
@@ -51,6 +52,8 @@ import pytest
 import pyisolate as iso
 import pyisolate.policy as policy
 from pyisolate.capabilities import FilesystemCapability
+
+checkpoint_mod = importlib.import_module("pyisolate.checkpoint")
 
 
 def _make_blob(payload, key):
@@ -170,6 +173,91 @@ def test_restore_rejects_malformed_payload(payload, message):
     key = os.urandom(32)
     blob = _make_blob(payload, key)
     with pytest.raises(ValueError, match=message):
+        iso.restore(blob, key)
+
+
+@pytest.mark.parametrize(
+    "field, value, message",
+    [
+        ("cpu_ms", 0, "cpu_ms.*positive integer"),
+        ("cpu_ms", -1, "cpu_ms.*positive integer"),
+        ("cpu_ms", True, "cpu_ms.*positive integer"),
+        ("cpu_ms", "10", "cpu_ms.*positive integer"),
+        ("mem_bytes", 0, "mem_bytes.*positive integer"),
+        ("mem_bytes", 1.5, "mem_bytes.*positive integer"),
+        ("numa_node", -1, "numa_node.*non-negative integer"),
+        ("numa_node", False, "numa_node.*non-negative integer"),
+        ("numa_node", "0", "numa_node.*non-negative integer"),
+    ],
+)
+def test_restore_rejects_malformed_resource_fields_after_decrypt(
+    monkeypatch, field, value, message
+):
+    key = os.urandom(32)
+    payload = {"name": "bad-resource", field: value}
+    blob = _make_blob(payload, key)
+
+    def fail_spawn(*args, **kwargs):
+        raise AssertionError("spawn should not be called for invalid payloads")
+
+    monkeypatch.setattr(checkpoint_mod, "spawn", fail_spawn)
+    with pytest.raises(ValueError, match=f"invalid checkpoint payload: .*{message}"):
+        iso.restore(blob, key)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "math",
+        ["math", ""],
+        ["math", 1],
+        ["math", None],
+        {"0": "math"},
+    ],
+)
+def test_restore_rejects_malformed_allowed_imports_after_decrypt(monkeypatch, value):
+    key = os.urandom(32)
+    blob = _make_blob({"name": "bad-imports", "allowed_imports": value}, key)
+
+    def fail_spawn(*args, **kwargs):
+        raise AssertionError("spawn should not be called for invalid payloads")
+
+    monkeypatch.setattr(checkpoint_mod, "spawn", fail_spawn)
+    with pytest.raises(
+        ValueError,
+        match="invalid checkpoint payload: 'allowed_imports'.*list of non-empty strings",
+    ):
+        iso.restore(blob, key)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        [],
+        ["filesystem"],
+        {"": {}},
+        {"filesystem": {}},
+        {"filesystem": {"__pyisolate_capability__": "read_path"}},
+        {
+            "filesystem": {
+                "__pyisolate_capability__": "secrets",
+                "values": {"api": "zz"},
+            }
+        },
+    ],
+)
+def test_restore_rejects_malformed_capabilities_after_decrypt(monkeypatch, value):
+    key = os.urandom(32)
+    blob = _make_blob({"name": "bad-caps", "capabilities": value}, key)
+
+    def fail_spawn(*args, **kwargs):
+        raise AssertionError("spawn should not be called for invalid payloads")
+
+    monkeypatch.setattr(checkpoint_mod, "spawn", fail_spawn)
+    with pytest.raises(
+        ValueError,
+        match="invalid checkpoint payload: 'capabilities'.*serialized capability mapping",
+    ):
         iso.restore(blob, key)
 
 


### PR DESCRIPTION
### Motivation
- Harden checkpoint restore by strictly validating deserialized fields before spawning a sandbox to avoid passing malformed values into runtime paths.

### Description
- Add restore-time validators in `pyisolate/checkpoint.py` to require `cpu_ms` and `mem_bytes` be `None` or positive integers and `numa_node` be `None` or a non-negative integer, and to raise `ValueError` on failure.
- Add validation that `allowed_imports` is `None` or a list of non-empty strings and that `capabilities` is `None` or a serialized capability mapping, checking known capability shapes and verifying via `deserialize_capabilities`.
- Ensure any validation failure raises `ValueError("invalid checkpoint payload: ...")` before `spawn` is invoked.
- Implement a helper that verifies serialized capability shapes (roots, destinations, secrets hex values, subprocess commands, paths, ports, etc.) and integrates it into the capability validation path.
- Add unit tests in `tests/test_checkpoint.py` that create AEAD-sealed blobs and assert malformed payloads (resource fields, allowed imports, and capabilities) raise `ValueError` and do not call `spawn`.
- Fix an indentation bug in `pyisolate/runtime/thread.py` filesystem-checking branch so the module imports and tests load cleanly.

### Testing
- Ran `pytest -q tests/test_checkpoint.py` which passed (`33 passed`).
- Ran `python -m py_compile pyisolate/checkpoint.py tests/test_checkpoint.py pyisolate/runtime/thread.py` which succeeded.
- Ran full test collection with `pytest -q` which failed during collection due to an unrelated existing syntax error in `tests/test_policy_enforcement.py` (collection-time `SyntaxError`), so full-suite run is blocked by that existing test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3437332bc08328b76cebc18dd1084d)