### PR TITLE
Validate CryptoBroker max_frame_len

### DIFF
--- a/pyisolate/broker/crypto.py
+++ b/pyisolate/broker/crypto.py
@@ -26,6 +26,7 @@ except Exception:  # pragma: no cover - library optional
 
 CTR_LIMIT = 0xFFFFFFFFFFFFFFFFFFFF  # 2^96 - 1
 DEFAULT_MAX_FRAME_LEN = 1 << 20  # 1 MiB
+MIN_FRAME_LEN = 12 + 16  # nonce + ChaCha20-Poly1305 tag
 
 
 def kyber_keypair() -> tuple[bytes, bytes]:
@@ -67,6 +68,10 @@ class CryptoBroker:
         max_frame_len: int = DEFAULT_MAX_FRAME_LEN,
     ):
         self._lock = Lock()
+        if type(max_frame_len) is not int:
+            raise ValueError("max_frame_len must be an integer")
+        if max_frame_len < MIN_FRAME_LEN:
+            raise ValueError("max_frame_len must be at least 28 bytes")
         self._max_frame_len = max_frame_len
         self.rotate(private_key, peer_key, pq_secret=pq_secret)
 

--- a/tests/test_crypto_extra.py
+++ b/tests/test_crypto_extra.py
@@ -6,32 +6,43 @@ from pyisolate.broker.crypto import CTR_LIMIT, CryptoBroker
 from pyisolate.libsodium import constant_compare
 
 
+def _private_bytes(private_key):
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _public_bytes(private_key):
+    return private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+
+def make_broker(max_frame_len=4096):
+    private_key = x25519.X25519PrivateKey.generate()
+    peer_key = x25519.X25519PrivateKey.generate()
+    return CryptoBroker(
+        _private_bytes(private_key),
+        _public_bytes(peer_key),
+        max_frame_len=max_frame_len,
+    )
+
+
 def make_pair():
     priv_a = x25519.X25519PrivateKey.generate()
     priv_b = x25519.X25519PrivateKey.generate()
     max_len = 4096
     a = CryptoBroker(
-        priv_a.private_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PrivateFormat.Raw,
-            encryption_algorithm=serialization.NoEncryption(),
-        ),
-        priv_b.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw,
-        ),
+        _private_bytes(priv_a),
+        _public_bytes(priv_b),
         max_frame_len=max_len,
     )
     b = CryptoBroker(
-        priv_b.private_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PrivateFormat.Raw,
-            encryption_algorithm=serialization.NoEncryption(),
-        ),
-        priv_a.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw,
-        ),
+        _private_bytes(priv_b),
+        _public_bytes(priv_a),
         max_frame_len=max_len,
     )
     return a, b
@@ -47,33 +58,35 @@ def test_unframe_short_frame():
         b.unframe(b"short")
 
 
+def test_max_frame_len_rejects_zero():
+    with pytest.raises(ValueError, match="max_frame_len must be at least 28 bytes"):
+        make_broker(max_frame_len=0)
+
+
+def test_max_frame_len_rejects_negative():
+    with pytest.raises(ValueError, match="max_frame_len must be at least 28 bytes"):
+        make_broker(max_frame_len=-1)
+
+
+def test_max_frame_len_rejects_too_small():
+    with pytest.raises(ValueError, match="max_frame_len must be at least 28 bytes"):
+        make_broker(max_frame_len=27)
+
+
+def test_max_frame_len_accepts_minimum_valid_limit():
+    broker = make_broker(max_frame_len=28)
+    assert broker._max_frame_len == 28
+
+
+def test_max_frame_len_rejects_non_integer():
+    with pytest.raises(ValueError, match="max_frame_len must be an integer"):
+        make_broker(max_frame_len="28")
+
+
 def test_unframe_frame_too_long():
-    priv_a = x25519.X25519PrivateKey.generate()
-    priv_b = x25519.X25519PrivateKey.generate()
-    a = CryptoBroker(
-        priv_a.private_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PrivateFormat.Raw,
-            encryption_algorithm=serialization.NoEncryption(),
-        ),
-        priv_b.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw,
-        ),
-    )
-    b = CryptoBroker(
-        priv_b.private_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PrivateFormat.Raw,
-            encryption_algorithm=serialization.NoEncryption(),
-        ),
-        priv_a.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw,
-        ),
-        max_frame_len=20,
-    )
-    frame = a.frame(b"0123456789")
+    a, _ = make_pair()
+    b = make_broker(max_frame_len=28)
+    frame = a.frame(b"x")
     with pytest.raises(ValueError):
         b.unframe(frame)
 


### PR DESCRIPTION
### Motivation
- Ensure the `max_frame_len` constructor argument is sane to avoid misconfiguration and potential unbounded allocations or misuse of the AEAD framing API.

### Description
- Add `MIN_FRAME_LEN = 12 + 16` to document the minimum frame size (12-byte nonce + 16-byte ChaCha20-Poly1305 tag). 
- Validate `max_frame_len` in `CryptoBroker.__init__` to require an exact integer type by raising `ValueError("max_frame_len must be an integer")` for non-integers. 
- Enforce a lower bound of `MIN_FRAME_LEN` and raise `ValueError("max_frame_len must be at least 28 bytes")` for smaller values. 
- Add tests in `tests/test_crypto_extra.py` (helper `make_broker` and new tests) covering zero, negative, too-small (27), non-integer, and minimum-valid (28) limits, and adjust the existing oversized-frame test to use the new minimum valid limit.

### Testing
- Ran bytecode checks with `PYTHONPATH=. python -m py_compile pyisolate/broker/crypto.py tests/test_crypto_extra.py tests/test_crypto.py`, which succeeded. 
- Ran `git diff --check` to verify whitespace/issues, which reported no problems. 
- Attempted `PYTHONPATH=. pytest tests/test_crypto_extra.py tests/test_crypto.py`, but collection failed due to an unrelated `IndentationError` in `pyisolate/runtime/thread.py` (outside these changes), so the new tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3437359af88328b2a58d57fcc24ee8)