### PR TITLE
Fix compiled read/write filesystem policy semantics

### DIFF
--- a/pyisolate/policy/model.py
+++ b/pyisolate/policy/model.py
@@ -15,14 +15,30 @@ from typing import Any, Mapping
 
 @dataclass(frozen=True)
 class FilesystemRule:
-    """A canonical filesystem rule for one sandbox."""
+    """A canonical filesystem rule for one sandbox.
+
+    ``access`` is meaningful for allow rules: ``read`` permits only non-writing
+    opens, ``write`` permits only writing opens, and ``readwrite`` permits both.
+    Legacy ``allow`` and ``deny`` rules default to ``readwrite`` so existing
+    policies keep their previous behavior.
+    """
 
     action: str
     path: str
+    access: str = "readwrite"
 
     def __post_init__(self) -> None:
-        if self.action not in {"allow", "deny"}:
+        action = self.action
+        access = self.access
+        if action in {"read", "write"}:
+            access = action
+            action = "allow"
+            object.__setattr__(self, "action", action)
+            object.__setattr__(self, "access", access)
+        if action not in {"allow", "deny"}:
             raise ValueError(f"invalid filesystem action: {self.action}")
+        if access not in {"read", "write", "readwrite"}:
+            raise ValueError(f"invalid filesystem access mode: {self.access}")
         if not isinstance(self.path, str) or not self.path:
             raise ValueError("filesystem rule path must be a non-empty string")
 
@@ -111,10 +127,15 @@ class RuntimePolicySet:
 def _coerce_compiled_fs(rule: Any) -> FilesystemRule:
     action = getattr(rule, "action", None)
     path = getattr(rule, "path", None)
+    access = getattr(rule, "access", "readwrite")
     if isinstance(rule, Mapping):
         action = rule.get("action")
         path = rule.get("path")
-    return FilesystemRule(action=str(action), path=str(path))
+        access = rule.get("access", access)
+    if action in {"read", "write"}:
+        access = action
+        action = "allow"
+    return FilesystemRule(action=str(action), path=str(path), access=str(access))
 
 
 def _coerce_compiled_tcp(rule: Any) -> NetworkRule:

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -478,6 +478,8 @@ def _blocked_open(file, *args, **kwargs):
                 rule
                 for rule in runtime_policy.allow_fs
                 if _fs_rule_matches(rule.path, path)
+                and rule.access
+                in ({"write", "readwrite"} if wants_write else {"read", "readwrite"})
             ]
             if not matching_allow_rules:
                 raise _deny(

--- a/tests/test_policy_enforcement.py
+++ b/tests/test_policy_enforcement.py
@@ -458,3 +458,62 @@ def test_runtime_policy_network_missing_allow_rule_records_event():
         )
     finally:
         sb.close()
+
+
+def test_compiled_read_filesystem_rule_allows_reads_only(tmp_path):
+    readable_dir = tmp_path / "readable"
+    readable_dir.mkdir()
+    readable_file = readable_dir / "data.txt"
+    readable_file.write_text("ok")
+
+    runtime_policy = policy.from_sandbox_policy(
+        policy.compiler.SandboxPolicy(
+            fs=[policy.compiler.FSRule("read", str(readable_dir))],
+            tcp=[],
+            imports=[],
+            capabilities=[],
+        )
+    )
+
+    sb = iso.spawn("compiled-fs-read", policy=runtime_policy)
+    try:
+        sb.exec(f"post(open({str(readable_file)!r}).read())")
+        assert sb.recv(timeout=1) == "ok"
+
+        sb.exec(f"open({str(readable_file)!r}, 'w').write('blocked')")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        assert readable_file.read_text() == "ok"
+    finally:
+        sb.close()
+
+
+def test_compiled_write_filesystem_rule_allows_writes_only(tmp_path):
+    writable_dir = tmp_path / "writable"
+    writable_dir.mkdir()
+    writable_file = writable_dir / "data.txt"
+    writable_file.write_text("old")
+
+    runtime_policy = policy.from_sandbox_policy(
+        policy.compiler.SandboxPolicy(
+            fs=[policy.compiler.FSRule("write", str(writable_dir))],
+            tcp=[],
+            imports=[],
+            capabilities=[],
+        )
+    )
+
+    sb = iso.spawn("compiled-fs-write", policy=runtime_policy)
+    try:
+        sb.exec(
+            f"with open({str(writable_file)!r}, 'w') as fh:\n"
+            "    post(fh.write('new'))"
+        )
+        assert sb.recv(timeout=1) == 3
+        assert writable_file.read_text() == "new"
+
+        sb.exec(f"post(open({str(writable_file)!r}).read())")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+    finally:
+        sb.close()


### PR DESCRIPTION
### Motivation
- Compiled `FSRule(action="read")` and `FSRule(action="write")` were being treated as generic deny/allow rules downstream, causing read-only compiled rules to inadvertently permit writes and vice versa.
- The runtime needs explicit access-mode semantics so allow rules can be enforced according to the requested open mode instead of inferring behavior from loosely shaped lists.

### Description
- Added an `access` field to `FilesystemRule` with valid values `"read"`, `"write"`, and legacy `"readwrite"`, and normalize compiled `read`/`write` actions into allow-side rules with the corresponding `access`. (`pyisolate/policy/model.py`)
- Updated `_coerce_compiled_fs()` to map compiled `FSRule` `action` values `"read"`/`"write"` into `FilesystemRule(action="allow", access=...)` and to accept an optional `access` key from compiled mappings. (`pyisolate/policy/model.py`)
- Enforced access-mode checks in the runtime so matching `allow_fs` rules must permit the requested open mode (`read` vs write modes) by filtering `runtime_policy.allow_fs` according to `rule.access` and the computed `wants_write` flag. (`pyisolate/runtime/thread.py`)
- Added regression tests that construct `SandboxPolicy` with compiled `FSRule("read", path)` and `FSRule("write", path)` and verify that reads succeed while writes are blocked for read rules and writes succeed while reads are blocked for write rules. (`tests/test_policy_enforcement.py`)

### Testing
- Ran `pytest -q tests/test_policy.py tests/test_policy_enforcement.py` and all tests passed. (`56 passed`)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344cb9815c8328a74d222ee986130c)