### PR TITLE
Enforce runtime filesystem denies before allows

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -421,6 +421,16 @@ def _blocked_open(file, *args, **kwargs):
         fs_cap = getattr(_thread_local, "fs_capability", None)
         allowed = getattr(_thread_local, "fs", None)
         runtime_policy = getattr(_thread_local, "runtime_policy", None)
+        if runtime_policy is not None and any(
+            _fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs
+        ):
+            raise _deny(
+                "filesystem",
+                f"open:{path}",
+                "runtime_policy:deny_fs",
+                "file access blocked",
+            )
+
         if fs_cap is not None:
             safe_roots = fs_cap.roots
             if not any(
@@ -465,15 +475,6 @@ def _blocked_open(file, *args, **kwargs):
                     "file access blocked",
                 )
         elif runtime_policy is not None:
-            if any(
-                _fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs
-            ):
-                raise _deny(
-                    "filesystem",
-                    f"open:{path}",
-                    "runtime_policy:deny_fs",
-                    "file access blocked",
-                )
             matching_allow_rules = [
                 rule
                 for rule in runtime_policy.allow_fs

--- a/tests/test_policy_enforcement.py
+++ b/tests/test_policy_enforcement.py
@@ -360,6 +360,42 @@ def test_runtime_policy_allow_fs_blocks_final_component_replacement_race(
     assert replaced
 
 
+def test_runtime_policy_deny_fs_preempts_filesystem_capability_allow(tmp_path):
+    allowed_dir = tmp_path / "allowed"
+    allowed_dir.mkdir()
+    allowed_file = allowed_dir / "allowed.txt"
+    allowed_file.write_text("ok")
+    denied_file = allowed_dir / "secret.txt"
+    denied_file.write_text("nope")
+    denied_path = denied_file.resolve(strict=False)
+
+    runtime_policy = policy.RuntimePolicy(
+        allow_fs=(policy.FilesystemRule("allow", str(allowed_dir)),),
+        deny_fs=(policy.FilesystemRule("deny", str(denied_file)),),
+    )
+
+    sb = iso.spawn(
+        "runtime-deny-preempts-fs-cap",
+        policy=runtime_policy,
+        capabilities={"filesystem": iso.FilesystemCapability.from_paths(allowed_dir)},
+    )
+    try:
+        sb.exec(f"post(open({str(allowed_file)!r}).read())")
+        assert sb.recv(timeout=1) == "ok"
+
+        sb.exec(f"open({str(denied_path)!r}).read()")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="runtime-deny-preempts-fs-cap",
+            capability="filesystem",
+            attempted_action=f"open:{denied_path}",
+            policy_rule="runtime_policy:deny_fs",
+        )
+    finally:
+        sb.close()
+
 def test_runtime_policy_filesystem_deny_rule_records_event(tmp_path):
     allowed_dir = tmp_path / "allowed"
     denied_dir = tmp_path / "denied"


### PR DESCRIPTION
### Motivation

- Ensure explicit runtime filesystem `deny_fs` rules take precedence over any allow surface so a denied path cannot be accessed even if a capability, legacy `allow_fs`, or authority would otherwise permit it.

### Description

- Move the `runtime_policy.deny_fs` check in `_blocked_open` to immediately after path resolution and thread-local policy lookup so denies are evaluated before `fs_cap`, legacy `allow_fs`, or `authority` branches.
- Keep the deny check independent of `ReadPath`/`WritePath` or `FilesystemCapability` by raising a `PolicyError` via `_deny` when a runtime deny rule matches the requested path.
- Add a regression test `test_runtime_policy_deny_fs_preempts_filesystem_capability_allow` that constructs a `RuntimePolicy` which allows a directory but denies a nested file and verifies opening the denied nested file raises `PolicyError` and records the runtime deny event.

### Testing

- Ran the new regression test and the existing deny rule test with `pytest tests/test_policy_enforcement.py::test_runtime_policy_deny_fs_preempts_filesystem_capability_allow tests/test_policy_enforcement.py::test_runtime_policy_filesystem_deny_rule_records_event`, and both passed.
- Ran the full `tests/test_policy_enforcement.py` suite with `pytest tests/test_policy_enforcement.py`, which completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344cbba8c08328a5040310046cd181)