### PR TITLE
Preserve compiled policy semantics during resolution

### DIFF
--- a/pyisolate/policy/__init__.py
+++ b/pyisolate/policy/__init__.py
@@ -337,86 +337,20 @@ def _select_sandbox_policy(compiled, selector: str | None = None):
     )
 
 
-def _runtime_policy_from_sandbox(sandbox_policy: SandboxPolicy) -> Policy:
-    runtime = Policy()
-    for rule in sandbox_policy.fs:
-        if rule.action == "allow":
-            runtime.allow_fs(rule.path)
-    for rule in sandbox_policy.tcp:
-        if rule.action == "connect":
-            runtime.allow_tcp(rule.addr)
-    for module in sandbox_policy.imports:
-        runtime.allow_import(module)
-    return runtime
+def _runtime_policy_from_sandbox(sandbox_policy: SandboxPolicy) -> RuntimePolicy:
+    return from_sandbox_policy(sandbox_policy)
 
 
-def _runtime_policy_from_dict(data: dict) -> Policy:
-    if "sandboxes" in data:
-        sandboxes = data.get("sandboxes")
-        if not isinstance(sandboxes, dict):
-            raise PolicyCompilerError("missing or invalid 'sandboxes' section")
-        selector = "default" if "default" in sandboxes else None
-        if selector is None and len(sandboxes) == 1:
-            selector = next(iter(sandboxes))
-        if selector is None:
-            available = ", ".join(sorted(str(k) for k in sandboxes))
-            raise PolicyCompilerError(
-                "policy mapping contains multiple sandboxes; "
-                f"select one of: {available}"
-            )
-        selected = sandboxes[selector]
-        if not isinstance(selected, dict):
-            raise PolicyCompilerError(f"sandbox '{selector}' must be a mapping")
-        merged = dict(data.get("defaults") or {})
-        merged.update(selected)
-        data = merged
-
-    runtime = Policy()
-    fs_rules = data.get("fs", []) or []
-    if not isinstance(fs_rules, list):
-        raise PolicyCompilerError("'fs' must be a list")
-    for rule in fs_rules:
-        if isinstance(rule, str):
-            runtime.allow_fs(rule)
-        elif isinstance(rule, dict) and len(rule) == 1:
-            action, path = next(iter(rule.items()))
-            if action == "allow" and isinstance(path, str):
-                runtime.allow_fs(path)
-            elif action not in {"allow", "deny"}:
-                raise PolicyCompilerError(f"invalid fs action '{action}'")
-        else:
-            raise PolicyCompilerError(f"invalid fs rule: {rule!r}")
-
-    net_rules = data.get("net", data.get("tcp", [])) or []
-    if not isinstance(net_rules, list):
-        raise PolicyCompilerError("'net' must be a list")
-    for rule in net_rules:
-        if isinstance(rule, str):
-            runtime.allow_tcp(rule)
-        elif isinstance(rule, dict) and len(rule) == 1:
-            action, addr = next(iter(rule.items()))
-            if action == "connect":
-                addresses = addr if isinstance(addr, list) else [addr]
-                for address in addresses:
-                    if not isinstance(address, str):
-                        raise PolicyCompilerError(
-                            f"net addresses must be strings: {address!r}"
-                        )
-                    runtime.allow_tcp(address)
-            elif action != "deny":
-                raise PolicyCompilerError(f"invalid net action '{action}'")
-        else:
-            raise PolicyCompilerError(f"invalid net rule: {rule!r}")
-
-    imports = data.get("imports", []) or []
-    if not isinstance(imports, list):
-        raise PolicyCompilerError("'imports' must be a list")
-    for module in imports:
-        if not isinstance(module, str):
-            raise PolicyCompilerError(f"import rules must be strings: {module!r}")
-        runtime.allow_import(module)
-    return runtime
-
+def _runtime_policy_from_dict(data: dict) -> RuntimePolicy:
+    policy_set = from_yaml_dict(data)
+    if "default" in policy_set.sandboxes:
+        return policy_set.sandbox("default")
+    if len(policy_set.sandboxes) == 1:
+        return next(iter(policy_set.sandboxes.values()))
+    available = ", ".join(sorted(policy_set.sandboxes))
+    raise PolicyCompilerError(
+        "policy mapping contains multiple sandboxes; " f"select one of: {available}"
+    )
 
 def _resolve_policy_path(name: str) -> Path:
     candidate = Path(name)

--- a/pyisolate/policy/model.py
+++ b/pyisolate/policy/model.py
@@ -54,6 +54,7 @@ class RuntimePolicy:
     allow_tcp: tuple[NetworkRule, ...] = ()
     deny_tcp: tuple[NetworkRule, ...] = ()
     imports: tuple[str, ...] = ()
+    cpu_ms: int | None = None
 
     @property
     def fs(self) -> list[str]:
@@ -72,13 +73,16 @@ class RuntimePolicy:
         return tuple(rule.destination for rule in self.allow_tcp)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        data = {
             "allow_fs": [asdict(rule) for rule in self.allow_fs],
             "deny_fs": [asdict(rule) for rule in self.deny_fs],
             "allow_tcp": [asdict(rule) for rule in self.allow_tcp],
             "deny_tcp": [asdict(rule) for rule in self.deny_tcp],
             "imports": list(self.imports),
         }
+        if self.cpu_ms is not None:
+            data["cpu_ms"] = self.cpu_ms
+        return data
 
 
 @dataclass(frozen=True)
@@ -143,10 +147,10 @@ def from_sandbox_policy(policy: Any) -> RuntimePolicy:
             allow_fs.append(FilesystemRule("allow", item))
             continue
         rule = _coerce_compiled_fs(item)
-        if rule.action == "allow":
-            allow_fs.append(rule)
-        else:
+        if rule.action == "deny":
             deny_fs.append(rule)
+        else:
+            allow_fs.append(FilesystemRule("allow", rule.path))
 
     tcp_rules = getattr(policy, "tcp", None) or []
     for item in tcp_rules:
@@ -166,6 +170,7 @@ def from_sandbox_policy(policy: Any) -> RuntimePolicy:
         allow_tcp=tuple(allow_tcp),
         deny_tcp=tuple(deny_tcp),
         imports=imports,
+        cpu_ms=getattr(policy, "cpu_ms", None),
     )
 
 
@@ -208,6 +213,7 @@ def from_compiled_policy(compiled: Any) -> RuntimePolicySet:
                 allow_tcp=tuple(NetworkRule(**rule) for rule in policy.get("allow_tcp", [])),
                 deny_tcp=tuple(NetworkRule(**rule) for rule in policy.get("deny_tcp", [])),
                 imports=tuple(str(module) for module in policy.get("imports", [])),
+                cpu_ms=policy.get("cpu_ms"),
             )
         else:
             sandboxes[str(name)] = from_sandbox_policy(policy)

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -950,7 +950,9 @@ class SandboxThread(threading.Thread):
                     getattr(policy, "capabilities", []) or []
                 ).imports
             )
-        runtime_policy = from_sandbox_policy(policy) if policy is not None else None
+        runtime_policy = (
+            from_sandbox_policy(policy) if isinstance(policy, RuntimePolicy) else None
+        )
         if runtime_policy is not None and runtime_policy.imports:
             imports.update(runtime_policy.imports)
 
@@ -982,9 +984,18 @@ class SandboxThread(threading.Thread):
         self._authority = AuthoritySet.from_authorities(
             _iter_authorities(policy, capabilities)
         )
-        self.cpu_quota_ms = cpu_ms if cpu_ms is not None else self._authority.cpu_ms
         self.runtime_policy = (
-            from_sandbox_policy(policy) if policy is not None else None
+            from_sandbox_policy(policy) if isinstance(policy, RuntimePolicy) else None
+        )
+        policy_cpu_ms = (
+            self.runtime_policy.cpu_ms if self.runtime_policy is not None else None
+        )
+        self.cpu_quota_ms = (
+            cpu_ms
+            if cpu_ms is not None
+            else self._authority.cpu_ms
+            if self._authority.cpu_ms is not None
+            else policy_cpu_ms
         )
         self.mem_quota_bytes = mem_bytes
         self.wall_time_ms = wall_time_ms

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -589,3 +589,86 @@ def test_canonical_yaml_policy_drives_sandbox_and_bpf_maps(tmp_path, monkeypatch
         "127.0.0.1:9",
         "any",
     ] in calls
+
+
+def test_resolve_policy_path_preserves_deny_and_cpu_ms(tmp_path):
+    import pyisolate.policy as policy
+
+    allowed = tmp_path / "allowed"
+    denied = tmp_path / "allowed" / "secret.txt"
+    policy_path = tmp_path / "policy.yml"
+    policy_path.write_text(
+        "version: 1.0\n"
+        "sandboxes:\n"
+        "  default:\n"
+        "    fs:\n"
+        f'      - allow: "{allowed}/**"\n'
+        f'      - deny: "{denied}"\n'
+        "    cpu_ms: 25\n"
+    )
+
+    resolved = policy.resolve_policy(str(policy_path))
+
+    assert resolved.cpu_ms == 25
+    assert [rule.path for rule in resolved.allow_fs] == [f"{allowed}/**"]
+    assert [rule.path for rule in resolved.deny_fs] == [str(denied)]
+
+
+def test_resolve_policy_dict_preserves_deny_and_cpu_ms(tmp_path):
+    import pyisolate.policy as policy
+
+    allowed = tmp_path / "allowed"
+    denied = tmp_path / "allowed" / "secret.txt"
+    resolved = policy.resolve_policy(
+        {
+            "version": "1.0",
+            "sandboxes": {
+                "default": {
+                    "fs": [
+                        {"allow": f"{allowed}/**"},
+                        {"deny": str(denied)},
+                    ],
+                    "cpu_ms": 30,
+                }
+            },
+        }
+    )
+
+    assert resolved.cpu_ms == 30
+    assert [rule.path for rule in resolved.allow_fs] == [f"{allowed}/**"]
+    assert [rule.path for rule in resolved.deny_fs] == [str(denied)]
+
+
+def test_resolve_policy_path_deny_rule_remains_effective(tmp_path):
+    import pytest
+    import pyisolate as iso
+    import pyisolate.policy as policy
+
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    denied = allowed / "secret.txt"
+    denied.write_text("secret")
+    policy_path = tmp_path / "policy.yml"
+    policy_path.write_text(
+        "version: 1.0\n"
+        "sandboxes:\n"
+        "  default:\n"
+        "    imports:\n"
+        "      - pathlib\n"
+        "    fs:\n"
+        f'      - allow: "{allowed}/**"\n'
+        f'      - deny: "{denied}"\n'
+        "    cpu_ms: 25\n"
+    )
+
+    sb = iso.spawn("resolved-deny", policy=policy.resolve_policy(str(policy_path)))
+    try:
+        sb.exec(
+            "import pathlib\n"
+            f"post(pathlib.Path({str(denied)!r}).read_text())\n"
+        )
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        assert sb._thread.cpu_quota_ms == 25
+    finally:
+        sb.close()


### PR DESCRIPTION
### Motivation
- The existing `resolve_policy` rebuilt a legacy `Policy` that lost deny/read/write semantics and `cpu_ms` from compiled policies. 
- Consumers (runtime threads and BPF maps) expect the canonical `RuntimePolicy` semantics (deny-before-allow and CPU budgets) to survive resolution. 

### Description
- Resolve `SandboxPolicy`, `CompiledPolicy`, YAML/path, and dict inputs through the canonical runtime conversion by returning `RuntimePolicy` via `from_sandbox_policy` / `from_yaml_dict` instead of constructing a lossy legacy `Policy`. 
- Extend `RuntimePolicy` with a `cpu_ms` field and carry `cpu_ms` through `from_sandbox_policy` and `from_compiled_policy` conversions and serialization. 
- Update `_runtime_policy_from_dict` to compile dict inputs via `from_yaml_dict` so `deny`, `read`, `write`, and `cpu_ms` are validated and preserved consistently with `compile_policy()`. 
- Wire the resolved `RuntimePolicy.cpu_ms` into sandbox initialization so `SandboxThread` uses the policy `cpu_ms` as a fallback when no explicit `cpu_ms` argument or authority budget is provided. 
- Add regression tests `test_resolve_policy_path_preserves_deny_and_cpu_ms`, `test_resolve_policy_dict_preserves_deny_and_cpu_ms`, and `test_resolve_policy_path_deny_rule_remains_effective` to assert deny rules and CPU budgets survive resolution and are enforced. 

### Testing
- Ran `python -m pytest tests/test_policy.py -q` and the policy test suite passed (`33 passed`).
- Ran the three new focused tests with `python -m pytest tests/test_policy.py::test_resolve_policy_path_preserves_deny_and_cpu_ms tests/test_policy.py::test_resolve_policy_dict_preserves_deny_and_cpu_ms tests/test_policy.py::test_resolve_policy_path_deny_rule_remains_effective -q` and they passed (`3 passed`).
- A full `python -m pytest -q` was attempted but encountered environment-sensitive failures (missing BPF tooling and restricted cgroup access) unrelated to the policy changes; these failures prevented a full-suite clean run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344cbabe4083289e022e301297b813)