### PR TITLE
Validate canonical runtime policy input

### DIFF
--- a/pyisolate/policy/model.py
+++ b/pyisolate/policy/model.py
@@ -151,6 +151,73 @@ def _coerce_compiled_tcp(rule: Any) -> NetworkRule:
     return NetworkRule(action=str(action), destination=str(destination))
 
 
+_CANONICAL_RUNTIME_POLICY_KEYS = {
+    "allow_fs",
+    "deny_fs",
+    "allow_tcp",
+    "deny_tcp",
+    "imports",
+    "cpu_ms",
+}
+
+
+def _validate_cpu_ms(cpu_ms: Any) -> int | None:
+    if cpu_ms is None:
+        return None
+    if isinstance(cpu_ms, bool) or not isinstance(cpu_ms, int) or cpu_ms <= 0:
+        raise ValueError("cpu_ms must be absent, null, or a positive integer")
+    return cpu_ms
+
+
+def _require_mapping_list(value: Any, field_name: str) -> list[Mapping[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list of mappings")
+    rules: list[Mapping[str, Any]] = []
+    for index, rule in enumerate(value):
+        if not isinstance(rule, Mapping):
+            raise ValueError(f"{field_name}[{index}] must be a mapping")
+        rules.append(rule)
+    return rules
+
+
+def _validate_imports(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("imports must be a list of non-empty strings")
+    imports: list[str] = []
+    for index, module in enumerate(value):
+        if not isinstance(module, str) or not module:
+            raise ValueError(f"imports[{index}] must be a non-empty string")
+        imports.append(module)
+    return tuple(imports)
+
+
+def _runtime_policy_from_canonical_mapping(policy: Mapping[str, Any]) -> RuntimePolicy:
+    return RuntimePolicy(
+        allow_fs=tuple(
+            FilesystemRule(**rule)
+            for rule in _require_mapping_list(policy.get("allow_fs", []), "allow_fs")
+        ),
+        deny_fs=tuple(
+            FilesystemRule(**rule)
+            for rule in _require_mapping_list(policy.get("deny_fs", []), "deny_fs")
+        ),
+        allow_tcp=tuple(
+            NetworkRule(**rule)
+            for rule in _require_mapping_list(policy.get("allow_tcp", []), "allow_tcp")
+        ),
+        deny_tcp=tuple(
+            NetworkRule(**rule)
+            for rule in _require_mapping_list(policy.get("deny_tcp", []), "deny_tcp")
+        ),
+        imports=_validate_imports(policy.get("imports", [])),
+        cpu_ms=_validate_cpu_ms(policy.get("cpu_ms")),
+    )
+
+
 def from_sandbox_policy(policy: Any) -> RuntimePolicy:
     """Convert a legacy ``Policy`` or compiler ``SandboxPolicy`` into runtime form."""
 
@@ -227,28 +294,10 @@ def from_compiled_policy(compiled: Any) -> RuntimePolicySet:
 
     sandboxes: dict[str, RuntimePolicy] = {}
     for name, policy in sandboxes_raw.items():
-        if isinstance(policy, Mapping) and {
-            "allow_fs",
-            "deny_fs",
-            "allow_tcp",
-            "deny_tcp",
-        }.intersection(policy.keys()):
-            sandboxes[str(name)] = RuntimePolicy(
-                allow_fs=tuple(
-                    FilesystemRule(**rule) for rule in policy.get("allow_fs", [])
-                ),
-                deny_fs=tuple(
-                    FilesystemRule(**rule) for rule in policy.get("deny_fs", [])
-                ),
-                allow_tcp=tuple(
-                    NetworkRule(**rule) for rule in policy.get("allow_tcp", [])
-                ),
-                deny_tcp=tuple(
-                    NetworkRule(**rule) for rule in policy.get("deny_tcp", [])
-                ),
-                imports=tuple(str(module) for module in policy.get("imports", [])),
-                cpu_ms=policy.get("cpu_ms"),
-            )
+        if isinstance(policy, Mapping) and _CANONICAL_RUNTIME_POLICY_KEYS.intersection(
+            policy.keys()
+        ):
+            sandboxes[str(name)] = _runtime_policy_from_canonical_mapping(policy)
         else:
             sandboxes[str(name)] = from_sandbox_policy(policy)
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -605,6 +605,59 @@ def test_canonical_yaml_policy_drives_sandbox_and_bpf_maps(tmp_path, monkeypatch
     ] in calls
 
 
+@pytest.mark.parametrize("cpu_ms", [0, -1, True, False, 1.5, "100"])
+def test_from_compiled_policy_rejects_invalid_canonical_cpu_ms(cpu_ms):
+    from pyisolate.policy import from_compiled_policy
+
+    with pytest.raises(ValueError, match="cpu_ms"):
+        from_compiled_policy(
+            {
+                "schema_version": "1.0",
+                "semantics_version": 1,
+                "sandboxes": {"default": {"imports": [], "cpu_ms": cpu_ms}},
+            }
+        )
+
+
+@pytest.mark.parametrize("imports", [[123], [""], [None], "math"])
+def test_from_compiled_policy_rejects_invalid_canonical_imports(imports):
+    from pyisolate.policy import from_compiled_policy
+
+    with pytest.raises(ValueError, match="imports"):
+        from_compiled_policy(
+            {
+                "schema_version": "1.0",
+                "semantics_version": 1,
+                "sandboxes": {"default": {"imports": imports}},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("rule_field", "rules"),
+    [
+        ("allow_fs", ["not-a-mapping"]),
+        ("deny_fs", [None]),
+        ("allow_tcp", ["not-a-mapping"]),
+        ("deny_tcp", [None]),
+        ("allow_fs", {"action": "allow", "path": "/tmp"}),
+    ],
+)
+def test_from_compiled_policy_rejects_non_mapping_canonical_rule_entries(
+    rule_field, rules
+):
+    from pyisolate.policy import from_compiled_policy
+
+    with pytest.raises(ValueError, match=rule_field):
+        from_compiled_policy(
+            {
+                "schema_version": "1.0",
+                "semantics_version": 1,
+                "sandboxes": {"default": {rule_field: rules}},
+            }
+        )
+
+
 def test_resolve_policy_path_preserves_deny_and_cpu_ms(tmp_path):
     import pyisolate.policy as policy
 


### PR DESCRIPTION
### Motivation
- Ensure canonical (JSON/dict) runtime policies are strictly validated before constructing `RuntimePolicy` to avoid silent coercions and unsafe values.
- Prevent malformed fields such as non-integer or boolean `cpu_ms`, non-string/empty `imports` entries, and non-mapping rule entries from being accepted.

### Description
- Add `_CANONICAL_RUNTIME_POLICY_KEYS` and helper validators: `_validate_cpu_ms`, `_require_mapping_list`, and `_validate_imports` to validate CPU budgets, rule lists, and imports respectively.
- Introduce `_runtime_policy_from_canonical_mapping` that constructs a `RuntimePolicy` only after validating canonical fields and uses `FilesystemRule(**rule)` and `NetworkRule(**rule)` only for verified mappings.
- Update `from_compiled_policy()` to detect mappings containing canonical runtime keys (including `imports` or `cpu_ms`) and route them through the strict validation path rather than legacy coercion.
- Add tests in `tests/test_policy.py` that assert malformed canonical JSON policies are rejected for invalid `cpu_ms`, invalid `imports`, and non-mapping rule entries.

### Testing
- Ran `python -m pytest tests/test_policy.py -q`, all tests in that file passed (`48 passed`).
- Ran formatting/check with `python -m black --fast --check pyisolate/policy/model.py tests/test_policy.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3577a98dc48328bf0c289c40ecd291)