### PR TITLE
Make BPF hot reload state updates atomic

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -298,32 +298,98 @@ class BPFManager:
                 f"Unable to read policy file {policy_path}: {exc}"
             ) from exc
 
-        # Replace the active policy entirely to drop removed entries. Store the
-        # canonical structure, not the source JSON shape, so the userspace and BPF
-        # paths have one representation.
-        self.policy_maps = runtime_policy.to_dict()
+        # Build the replacement policy first, but only publish it after every
+        # kernel map update succeeds. This keeps userspace state aligned with the
+        # last fully-applied BPF policy if a partial hot reload fails.
+        new_policy_maps = runtime_policy.to_dict()
+        attempted_updates: list[tuple[str, str, str]] = []
+        previous_entries: dict[tuple[str, str], str] = {}
+        if self.policy_maps:
+            try:
+                previous_entries = {
+                    (map_name, key): value
+                    for map_name, key, value in to_bpf_map_entries(
+                        from_compiled_policy(self.policy_maps)
+                    )
+                }
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "unable to build rollback entries from current policy maps: %s",
+                    exc,
+                )
+
         for map_name, key, value in to_bpf_map_entries(runtime_policy):
             logger.info("updating map %s[%s] -> %s", map_name, key, value)
             try:
-                self._run(
-                    [
-                        "bpftool",
-                        "map",
-                        "update",
-                        "pinned",
-                        f"/sys/fs/bpf/{map_name}",
-                        "key",
-                        key,
-                        "value",
-                        value,
-                        "any",
-                    ],
-                    raise_on_error=True,
-                )
+                self._update_bpf_map(map_name, key, value)
             except RuntimeError as exc:
+                rollback_errors = self._rollback_bpf_map_updates(
+                    attempted_updates, previous_entries
+                )
+                rollback_context = ""
+                if rollback_errors:
+                    rollback_context = (
+                        f"; rollback errors: {'; '.join(rollback_errors)}"
+                    )
                 raise RuntimeError(
-                    f"BPF map update failed for {map_name}[{key}]: {exc}"
+                    f"BPF map update failed for {map_name}[{key}] with value {value!r} "
+                    f"after {len(attempted_updates)} successful update(s): {exc}"
+                    f"{rollback_context}"
                 ) from exc
+            attempted_updates.append((map_name, key, value))
+
+        # Replace the active policy entirely to drop removed entries. Store the
+        # canonical structure, not the source JSON shape, so the userspace and BPF
+        # paths have one representation.
+        self.policy_maps = new_policy_maps
+
+    def _update_bpf_map(self, map_name: str, key: str, value: str) -> None:
+        self._run(
+            [
+                "bpftool",
+                "map",
+                "update",
+                "pinned",
+                f"/sys/fs/bpf/{map_name}",
+                "key",
+                key,
+                "value",
+                value,
+                "any",
+            ],
+            raise_on_error=True,
+        )
+
+    def _rollback_bpf_map_updates(
+        self,
+        attempted_updates: list[tuple[str, str, str]],
+        previous_entries: dict[tuple[str, str], str],
+    ) -> list[str]:
+        """Best-effort rollback for map entries changed during hot reload."""
+
+        rollback_errors: list[str] = []
+        for rollback_map, rollback_key, _ in reversed(attempted_updates):
+            previous_value = previous_entries.get((rollback_map, rollback_key))
+            if previous_value is None:
+                logger.warning(
+                    "no previous value available to rollback %s[%s]",
+                    rollback_map,
+                    rollback_key,
+                )
+                continue
+            try:
+                logger.info(
+                    "rolling back map %s[%s] -> %s",
+                    rollback_map,
+                    rollback_key,
+                    previous_value,
+                )
+                self._update_bpf_map(rollback_map, rollback_key, previous_value)
+            except RuntimeError as rollback_exc:
+                rollback_errors.append(
+                    f"{rollback_map}[{rollback_key}] -> {previous_value!r}: {rollback_exc}"
+                )
+        return rollback_errors
 
     def open_ring_buffer(self):
         """Return an iterator over resource guard events."""

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -394,3 +394,48 @@ def test_load_strict_missing_executable_raises_runtime_error(monkeypatch, missin
     assert "Command not found" in str(exc.value)
     assert missing_tool in str(exc.value)
     assert mgr.loaded is False
+
+
+def test_hot_reload_midway_failure_keeps_policy_maps_unchanged_and_rolls_back(
+    monkeypatch, tmp_path
+):
+    mgr = BPFManager()
+    mgr.loaded = True
+    original = _canonical_policy(fs_path="/tmp/original/**", tcp_addr="1.1.1.1:80")
+    mgr.policy_maps = original
+
+    replacement = _canonical_policy(
+        fs_path="/tmp/replacement/**", tcp_addr="2.2.2.2:443"
+    )
+    policy = tmp_path / "replacement.json"
+    policy.write_text(json.dumps(replacement))
+
+    calls = []
+
+    def fail_second_update(self, cmd, *, raise_on_error=False):
+        calls.append(cmd)
+        if "policy_net_allow" in cmd[4]:
+            raise RuntimeError("midway map failure")
+        return True
+
+    monkeypatch.setattr(BPFManager, "_run", fail_second_update)
+
+    with pytest.raises(RuntimeError) as exc:
+        mgr.hot_reload(str(policy))
+
+    assert mgr.policy_maps == original
+    assert "policy_net_allow[default:0]" in str(exc.value)
+    assert "2.2.2.2:443" in str(exc.value)
+    assert "after 1 successful update" in str(exc.value)
+    assert [
+        "bpftool",
+        "map",
+        "update",
+        "pinned",
+        "/sys/fs/bpf/policy_fs_allow",
+        "key",
+        "default:0",
+        "value",
+        "/tmp/original/**",
+        "any",
+    ] in calls


### PR DESCRIPTION
### Motivation
- Prevent userspace `policy_maps` from reflecting a partially-applied BPF policy when `bpftool map update` calls fail mid-way. 
- Provide best-effort rollback of map entries that were updated before a failure so the kernel maps are restored where possible. 
- Surface enough context in errors so callers can identify the failed `map/key` and the value that triggered the failure.

### Description
- Build the replacement maps up-front as `new_policy_maps = runtime_policy.to_dict()` and only assign to `self.policy_maps` after every kernel update succeeds. 
- Track successful updates in `attempted_updates` and capture previous values in `previous_entries` by converting `self.policy_maps` via `from_compiled_policy(...)` and `to_bpf_map_entries(...)`, logging a warning if rollback data cannot be built. 
- Add helpers ` _update_bpf_map()` to centralize a single map update and `_rollback_bpf_map_updates()` to attempt reverse-order rollback of updated entries and collect any rollback errors. 
- On failure, raise a `RuntimeError` that includes the failing `map_name[key]`, the attempted `value`, the number of successful updates applied, and any rollback error details, while keeping `self.policy_maps` unchanged.

### Testing
- Ran `python -m py_compile pyisolate/bpf/manager.py tests/test_bpf_manager.py` which succeeded. 
- Ran `pytest -q tests/test_bpf_manager.py tests/test_bpf_manager_extra.py` and the full suite passed (`21 passed`). 
- Added `test_hot_reload_midway_failure_keeps_policy_maps_unchanged_and_rolls_back` which monkeypatches `_run()` to raise mid-way and asserts `self.policy_maps` remains unchanged and rollback is attempted, and this test passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3577ad6d4483289735089411275088)