### PR TITLE
Enforce runtime deny precedence

### DIFF
--- a/pyisolate/policy/model.py
+++ b/pyisolate/policy/model.py
@@ -63,6 +63,8 @@ class RuntimePolicy:
 
     Rules are split by behavior so the runtime can apply deny-before-allow
     semantics explicitly instead of inferring behavior from loosely shaped lists.
+    Explicit runtime deny rules override all allow sources, including runtime
+    allow rules, legacy allow lists, capabilities, and AuthoritySet grants.
     """
 
     allow_fs: tuple[FilesystemRule, ...] = ()

--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -417,10 +417,9 @@ def _blocked_open(file, *args, **kwargs):
         lexical_path = Path(os.path.abspath(display_path))
         path = display_path.resolve(strict=False)
 
-        authority = getattr(_thread_local, "authority", None)
-        fs_cap = getattr(_thread_local, "fs_capability", None)
-        allowed = getattr(_thread_local, "fs", None)
         runtime_policy = getattr(_thread_local, "runtime_policy", None)
+        # Explicit runtime denies take precedence over every allow source,
+        # including capabilities, legacy allow lists, and AuthoritySet grants.
         if runtime_policy is not None and any(
             _fs_rule_matches(rule.path, path) for rule in runtime_policy.deny_fs
         ):
@@ -431,6 +430,9 @@ def _blocked_open(file, *args, **kwargs):
                 "file access blocked",
             )
 
+        authority = getattr(_thread_local, "authority", None)
+        fs_cap = getattr(_thread_local, "fs_capability", None)
+        allowed = getattr(_thread_local, "fs", None)
         if fs_cap is not None:
             safe_roots = fs_cap.roots
             if not any(
@@ -558,15 +560,27 @@ def _blocked_open(file, *args, **kwargs):
 
 
 def _check_network_destination(address: Iterable[str]) -> None:
-    authority = getattr(_thread_local, "authority", None)
-    net_cap = getattr(_thread_local, "net_capability", None)
-    allowed = getattr(_thread_local, "tcp", None)
     runtime_policy = getattr(_thread_local, "runtime_policy", None)
     if isinstance(address, tuple):
         host, port, *_ = address
     else:
         host, port = address
     destination = f"{host}:{port}"
+    # Explicit runtime denies take precedence over every allow source,
+    # including capabilities, legacy allow lists, and AuthoritySet grants.
+    if runtime_policy is not None and any(
+        rule.destination == destination for rule in runtime_policy.deny_tcp
+    ):
+        raise _deny(
+            "network",
+            f"connect:{destination}",
+            "runtime_policy:deny_tcp",
+            f"connect blocked: {destination}",
+        )
+
+    authority = getattr(_thread_local, "authority", None)
+    net_cap = getattr(_thread_local, "net_capability", None)
+    allowed = getattr(_thread_local, "tcp", None)
     if net_cap is not None:
         if not net_cap.allows(str(host), int(port)):
             raise _deny(
@@ -592,13 +606,6 @@ def _check_network_destination(address: Iterable[str]) -> None:
                 f"connect blocked: {destination}",
             )
     elif runtime_policy is not None:
-        if any(rule.destination == destination for rule in runtime_policy.deny_tcp):
-            raise _deny(
-                "network",
-                f"connect:{destination}",
-                "runtime_policy:deny_tcp",
-                f"connect blocked: {destination}",
-            )
         if not any(
             rule.destination == destination for rule in runtime_policy.allow_tcp
         ):
@@ -1007,9 +1014,11 @@ class SandboxThread(threading.Thread):
         self.cpu_quota_ms = (
             cpu_ms
             if cpu_ms is not None
-            else self._authority.cpu_ms
-            if self._authority.cpu_ms is not None
-            else policy_cpu_ms
+            else (
+                self._authority.cpu_ms
+                if self._authority.cpu_ms is not None
+                else policy_cpu_ms
+            )
         )
         self.mem_quota_bytes = mem_bytes
         self.wall_time_ms = wall_time_ms

--- a/tests/test_policy_enforcement.py
+++ b/tests/test_policy_enforcement.py
@@ -397,6 +397,88 @@ def test_runtime_policy_deny_fs_preempts_filesystem_capability_allow(tmp_path):
         sb.close()
 
 
+def test_runtime_policy_deny_fs_preempts_authority_allow(tmp_path):
+    allowed_dir = tmp_path / "authority-allowed"
+    allowed_dir.mkdir()
+    denied_file = allowed_dir / "secret.txt"
+    denied_file.write_text("nope")
+    denied_path = denied_file.resolve(strict=False)
+
+    runtime_policy = policy.RuntimePolicy(
+        deny_fs=(policy.FilesystemRule("deny", str(denied_file)),),
+    )
+    sb = iso.spawn(
+        "runtime-deny-preempts-fs-authority",
+        policy=runtime_policy,
+        capabilities=[iso.ReadPath(allowed_dir)],
+    )
+    try:
+        sb.exec(f"open({str(denied_path)!r}).read()")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="runtime-deny-preempts-fs-authority",
+            capability="filesystem",
+            attempted_action=f"open:{denied_path}",
+            policy_rule="runtime_policy:deny_fs",
+        )
+    finally:
+        sb.close()
+
+
+def test_runtime_policy_deny_tcp_preempts_network_capability_allow():
+    runtime_policy = policy.RuntimePolicy(
+        deny_tcp=(policy.NetworkRule("deny", "127.0.0.1:2"),),
+        imports=("socket",),
+    )
+    sb = iso.spawn(
+        "runtime-deny-preempts-net-cap",
+        policy=runtime_policy,
+        capabilities={
+            "network": iso.NetworkCapability.from_destinations("127.0.0.1:2")
+        },
+    )
+    try:
+        sb.exec("import socket; s=socket.socket(); s.connect(('127.0.0.1', 2))")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="runtime-deny-preempts-net-cap",
+            capability="network",
+            attempted_action="connect:127.0.0.1:2",
+            policy_rule="runtime_policy:deny_tcp",
+        )
+    finally:
+        sb.close()
+
+
+def test_runtime_policy_deny_tcp_preempts_authority_allow():
+    runtime_policy = policy.RuntimePolicy(
+        deny_tcp=(policy.NetworkRule("deny", "127.0.0.1:2"),),
+        imports=("socket",),
+    )
+    sb = iso.spawn(
+        "runtime-deny-preempts-net-authority",
+        policy=runtime_policy,
+        capabilities=[iso.ConnectTCP("127.0.0.1", 2), iso.Import("socket")],
+    )
+    try:
+        sb.exec("import socket; s=socket.socket(); s.connect(('127.0.0.1', 2))")
+        with pytest.raises(iso.PolicyError):
+            sb.recv(timeout=1)
+        _assert_denial_event(
+            sb.get_denial_events(),
+            cell="runtime-deny-preempts-net-authority",
+            capability="network",
+            attempted_action="connect:127.0.0.1:2",
+            policy_rule="runtime_policy:deny_tcp",
+        )
+    finally:
+        sb.close()
+
+
 def test_runtime_policy_filesystem_deny_rule_records_event(tmp_path):
     allowed_dir = tmp_path / "allowed"
     denied_dir = tmp_path / "denied"


### PR DESCRIPTION
### Motivation
- Ensure explicit runtime deny rules always override any allow source so a sandbox cannot circumvent a runtime deny via capabilities, legacy allow lists, or AuthoritySet grants.
- Make the deny-before-allow semantics explicit in enforcement points for both filesystem opens and TCP connects.

### Description
- In `pyisolate/runtime/thread.py` moved evaluation of `runtime_policy.deny_fs` to the start of `_blocked_open()` and added a clarifying comment that runtime denies take precedence over capabilities, legacy allows, and `AuthoritySet` grants.
- In `pyisolate/runtime/thread.py` moved evaluation of `runtime_policy.deny_tcp` to the start of `_check_network_destination()` and added the same precedence comment for network denies.
- Documented the precedence rule in the `RuntimePolicy` docstring in `pyisolate/policy/model.py` to state that explicit runtime deny rules override all allow sources.
- Added regression tests in `tests/test_policy_enforcement.py` that assert runtime `deny_fs` and `deny_tcp` win when a sandbox is granted both an authority/capability allow and an explicit runtime deny.

### Testing
- Ran `pytest -q tests/test_policy_enforcement.py` which completed successfully with `30 passed`.
- Ran the full test suite with `pytest -q` which completed successfully with `317 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3577b02610832887fce4a175e978f0)