### PR TITLE
Fix top-level CLI command parsing

### DIFF
--- a/pyisolate/cli.py
+++ b/pyisolate/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from . import doctor
 
@@ -11,11 +12,16 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="pyisolate")
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("doctor", help="Run installation and no-GIL diagnostics")
-    args, rest = parser.parse_known_args(argv)
+
+    argv = sys.argv[1:] if argv is None else argv
+    args = parser.parse_args(argv[:1])
+    if args.command is None:
+        parser.print_help()
+        raise SystemExit(2)
     if args.command == "doctor":
-        doctor.main(rest)
+        doctor.main(argv[1:])
         return
-    parser.print_help()
+    parser.error(f"unknown command: {args.command}")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,35 @@
+import pytest
+
+from pyisolate import cli
+
+
+def test_pyisolate_doctor_delegates_to_doctor_main(monkeypatch):
+    calls = []
+
+    def fake_doctor_main(argv):
+        calls.append(argv)
+
+    monkeypatch.setattr(cli.doctor, "main", fake_doctor_main)
+
+    cli.main(["doctor", "gil", "--json"])
+
+    assert calls == [["gil", "--json"]]
+
+
+def test_pyisolate_no_command_exits_nonzero(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main([])
+
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    assert "usage: pyisolate" in captured.out
+
+
+def test_pyisolate_unknown_command_exits_nonzero(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["doctro"])
+
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    assert "invalid choice" in captured.err
+    assert "doctro" in captured.err


### PR DESCRIPTION
### Motivation
- The top-level CLI used `parse_known_args`, which allowed unknown top-level tokens to slip through and prevented proper erroring for missing or misspelled subcommands. 
- The CLI should print help and exit non-zero when no subcommand is provided and produce a clear error for unknown subcommands.

### Description
- Replace `parse_known_args(argv)` with command-first parsing by using `argv = sys.argv[1:] if argv is None else argv` and `parser.parse_args(argv[:1])` so the first token is validated as a command. 
- If `args.command` is `None`, call `parser.print_help()` and `raise SystemExit(2)`. 
- When `args.command == "doctor"`, forward the remaining arguments with `doctor.main(argv[1:])`. 
- Call `parser.error(f"unknown command: {args.command}")` to ensure unknown subcommands produce a clear message and non-zero exit.

### Testing
- Added `tests/test_cli.py` containing tests that verify `doctor` delegates to `doctor.main`, that no command exits non-zero, and that an unknown command exits non-zero. 
- Ran `pytest tests/test_cli.py tests/test_provenance.py::test_top_level_pyisolate_doctor_gil -q` and the targeted tests passed. 
- Ran the full test suite with `pytest -q` and observed `317 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3577b409e0832883bc784ed279ff2b)