### PR TITLE
Reject remote sandbox migration until transport is implemented

### DIFF
--- a/pyisolate/migration.py
+++ b/pyisolate/migration.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 from .checkpoint import checkpoint, restore
 from .supervisor import Sandbox
 
+_LOCAL_HOSTS = {"", "localhost", "127.0.0.1", "::1"}
+
 
 def migrate(sandbox: Sandbox, host: str, key: bytes) -> Sandbox:
     """Migrate *sandbox* to *host* using an encrypted checkpoint.
 
-    This stub simply checkpoints and restores locally.
+    Only local checkpoint/restore migration is currently supported. Passing a
+    non-local *host* raises :class:`NotImplementedError` instead of silently
+    restoring the sandbox on the local machine.
     """
+    if host not in _LOCAL_HOSTS:
+        raise NotImplementedError("remote sandbox migration is not implemented")
+
     blob = checkpoint(sandbox, key)
-    # Real implementation would send *blob* to *host* securely
     return restore(blob, key)
 
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import importlib
+
+import pytest
+
+import pyisolate as iso
+
+migration_mod = importlib.import_module("pyisolate.migration")
+
+
+def test_migrate_rejects_non_local_host_without_local_restore(monkeypatch):
+    calls = []
+
+    def fail_checkpoint(*args, **kwargs):
+        calls.append("checkpoint")
+        raise AssertionError("checkpoint should not be called for remote hosts")
+
+    def fail_restore(*args, **kwargs):
+        calls.append("restore")
+        raise AssertionError("restore should not be called for remote hosts")
+
+    monkeypatch.setattr(migration_mod, "checkpoint", fail_checkpoint)
+    monkeypatch.setattr(migration_mod, "restore", fail_restore)
+
+    with pytest.raises(NotImplementedError, match="remote sandbox migration"):
+        iso.migrate(object(), "migration.example.com", b"k" * 32)
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("host", ["", "localhost", "127.0.0.1", "::1"])
+def test_migrate_allows_only_local_checkpoint_restore(monkeypatch, host):
+    sandbox = object()
+    key = b"k" * 32
+    restored = object()
+    calls = []
+
+    def fake_checkpoint(received_sandbox, received_key):
+        calls.append(("checkpoint", received_sandbox, received_key))
+        return b"checkpoint-blob"
+
+    def fake_restore(received_blob, received_key):
+        calls.append(("restore", received_blob, received_key))
+        return restored
+
+    monkeypatch.setattr(migration_mod, "checkpoint", fake_checkpoint)
+    monkeypatch.setattr(migration_mod, "restore", fake_restore)
+
+    assert iso.migrate(sandbox, host, key) is restored
+    assert calls == [
+        ("checkpoint", sandbox, key),
+        ("restore", b"checkpoint-blob", key),
+    ]


### PR DESCRIPTION
### Motivation
- Prevent silent local restore when a remote `host` is supplied by rejecting non-local hosts until a real migration transport is implemented.
- Make the intent explicit in the `migrate` API and provide tests that assert correct behavior for local vs non-local hosts.

### Description
- Update `pyisolate/migration.py` so `migrate` documents that only local checkpoint/restore is supported and raises `NotImplementedError` for non-local `host` values.
- Recognize the following local sentinels in `_LOCAL_HOSTS`: `""`, `"localhost"`, `"127.0.0.1"`, and `"::1"`.
- Keep the existing local behavior of calling `checkpoint` followed by `restore` when `host` is one of the local sentinels.
- Add `tests/test_migration.py` with tests that assert non-local hosts are rejected without calling `checkpoint`/`restore` and that local sentinels invoke `checkpoint` then `restore`.

### Testing
- Ran `pytest -q tests/test_migration.py` and it passed (`5 passed`).
- Ran `pytest -q tests/test_checkpoint.py tests/test_migration.py` and the suite passed (`38 passed`).
- Ran `python -m compileall pyisolate/migration.py tests/test_migration.py` to ensure bytecode compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3577c028f48328b901cad6f38b0957)