### PR TITLE
Implement authenticated migration transport

### DIFF
--- a/API.md
+++ b/API.md
@@ -102,7 +102,7 @@ Event types: `MEM_KILL`, `CPU_THROTTLE`, `POLICY_HOTLOAD`, `BROKER_ERROR`.
 |------|-------------|
 | `psi.checkpoint(sb, key:bytes) -> bytes` | Serialize and encrypt sandbox state. |
 | `psi.restore(blob:bytes, key:bytes) -> Sandbox` | Spawn sandbox from encrypted state. |
-| `psi.migrate(sb, host:str, key:bytes) -> Sandbox` | Send checkpoint to `host` and restore there. |
+| `psi.migrate(sb, host:str, key:bytes) -> MigrationResponse` | Send checkpoint to `host` and restore there. |
 | `policy.refresh_remote(url:str, token:str, timeout: float | None = None, max_retries: int = 0)` | Fetch YAML policy over HTTP with an optional timeout and retry budget, then apply it to prototype policy maps. Hardened deployments must fail closed if the BPF map update fails. |
 
 

--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -68,7 +68,14 @@ from .logging import setup_structured_logging  # noqa: F401
 from .telemetry import DenialEvent  # noqa: F401
 
 try:
-    from .migration import migrate
+    from .migration import (
+        MigrationProtocolError,
+        MigrationResponse,
+        handle_migration_connection,
+        migrate,
+        send_checkpoint,
+        serve_migration_once,
+    )
 except (
     ModuleNotFoundError,
     ImportError,
@@ -162,6 +169,11 @@ __all__ = [
     "checkpoint",
     "restore",
     "migrate",
+    "serve_migration_once",
+    "handle_migration_connection",
+    "send_checkpoint",
+    "MigrationProtocolError",
+    "MigrationResponse",
     "refresh_remote",
     "resolve_policy",
     "setup_structured_logging",

--- a/pyisolate/migration.py
+++ b/pyisolate/migration.py
@@ -2,18 +2,179 @@
 
 from __future__ import annotations
 
+import hmac
+import json
+import socket
+import struct
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Callable
+
 from .checkpoint import checkpoint, restore
 from .supervisor import Sandbox
 
+_MAGIC = b"PYISOMIG1"
+_HEADER_LIMIT = 16 * 1024
+_DEFAULT_PORT = 8765
 
-def migrate(sandbox: Sandbox, host: str, key: bytes) -> Sandbox:
-    """Migrate *sandbox* to *host* using an encrypted checkpoint.
 
-    This stub simply checkpoints and restores locally.
-    """
+@dataclass(frozen=True)
+class MigrationResponse:
+    """Response returned by a remote migration endpoint."""
+
+    ok: bool
+    error: str | None = None
+
+
+class MigrationProtocolError(ValueError):
+    """Raised when a peer sends an invalid migration protocol message."""
+
+
+def _parse_host(host: str) -> tuple[str, int]:
+    if not host:
+        raise ValueError("host must be a non-empty string")
+    if "://" in host:
+        raise ValueError("host must be in 'hostname[:port]' form")
+    if host.startswith("["):
+        end = host.find("]")
+        if end == -1:
+            raise ValueError("invalid IPv6 host")
+        address = host[1:end]
+        remainder = host[end + 1 :]
+        if not remainder:
+            return address, _DEFAULT_PORT
+        if not remainder.startswith(":"):
+            raise ValueError("invalid host")
+        port_text = remainder[1:]
+    else:
+        address, sep, port_text = host.rpartition(":")
+        if not sep:
+            return host, _DEFAULT_PORT
+        if ":" in address:
+            raise ValueError("IPv6 hosts with ports must use '[addr]:port' form")
+    try:
+        port = int(port_text)
+    except ValueError as exc:
+        raise ValueError("host port must be an integer") from exc
+    if not 0 < port <= 65535:
+        raise ValueError("host port must be between 1 and 65535")
+    return address, port
+
+
+def _mac(blob: bytes, key: bytes) -> str:
+    return hmac.new(key, blob, sha256).hexdigest()
+
+
+def _read_exact(conn: socket.socket, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = conn.recv(remaining)
+        if not chunk:
+            raise MigrationProtocolError("connection closed while reading message")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _send_json(conn: socket.socket, payload: dict[str, object]) -> None:
+    data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    conn.sendall(struct.pack("!I", len(data)) + data)
+
+
+def _recv_json(conn: socket.socket) -> dict[str, object]:
+    (size,) = struct.unpack("!I", _read_exact(conn, 4))
+    if size > _HEADER_LIMIT:
+        raise MigrationProtocolError("migration header is too large")
+    try:
+        payload = json.loads(_read_exact(conn, size).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise MigrationProtocolError("invalid migration JSON") from exc
+    if not isinstance(payload, dict):
+        raise MigrationProtocolError("invalid migration JSON")
+    return payload
+
+
+def send_checkpoint(
+    host: str, blob: bytes, key: bytes, *, timeout: float | None = 10.0
+) -> MigrationResponse:
+    """Send encrypted checkpoint *blob* to the migration endpoint at *host*."""
+    if len(key) != 32:
+        raise ValueError("key must be 32 bytes")
+    address = _parse_host(host)
+    header = {
+        "magic": _MAGIC.decode("ascii"),
+        "version": 1,
+        "blob_len": len(blob),
+        "auth": _mac(blob, key),
+    }
+    with socket.create_connection(address, timeout=timeout) as conn:
+        _send_json(conn, header)
+        conn.sendall(blob)
+        response = _recv_json(conn)
+    ok = response.get("ok")
+    if not isinstance(ok, bool):
+        raise MigrationProtocolError("invalid migration response")
+    error = response.get("error")
+    if error is not None and not isinstance(error, str):
+        raise MigrationProtocolError("invalid migration response")
+    return MigrationResponse(ok=ok, error=error)
+
+
+def handle_migration_connection(
+    conn: socket.socket,
+    key: bytes,
+    *,
+    restore_fn: Callable[[bytes, bytes], Sandbox] = restore,
+) -> MigrationResponse:
+    """Restore one checkpoint received from *conn* and send a response."""
+    if len(key) != 32:
+        raise ValueError("key must be 32 bytes")
+    try:
+        header = _recv_json(conn)
+        if header.get("magic") != _MAGIC.decode("ascii") or header.get("version") != 1:
+            raise MigrationProtocolError("unsupported migration protocol")
+        blob_len = header.get("blob_len")
+        auth = header.get("auth")
+        if isinstance(blob_len, bool) or not isinstance(blob_len, int) or blob_len < 0:
+            raise MigrationProtocolError("invalid checkpoint length")
+        if not isinstance(auth, str):
+            raise MigrationProtocolError("missing migration authenticator")
+        blob = _read_exact(conn, blob_len)
+        if not hmac.compare_digest(auth, _mac(blob, key)):
+            raise MigrationProtocolError("invalid migration authenticator")
+        restore_fn(blob, key)
+        response = MigrationResponse(ok=True)
+    except (
+        Exception
+    ) as exc:  # endpoint must convert all restore/protocol failures to a response
+        response = MigrationResponse(ok=False, error=str(exc))
+    _send_json(conn, {"ok": response.ok, "error": response.error})
+    return response
+
+
+def serve_migration_once(
+    host: str, key: bytes, *, restore_fn: Callable[[bytes, bytes], Sandbox] = restore
+) -> MigrationResponse:
+    """Listen on *host* and handle a single migration request."""
+    address = _parse_host(host)
+    with socket.create_server(address) as server:
+        conn, _peer = server.accept()
+        with conn:
+            return handle_migration_connection(conn, key, restore_fn=restore_fn)
+
+
+def migrate(sandbox: Sandbox, host: str, key: bytes) -> MigrationResponse:
+    """Migrate *sandbox* to *host* using an encrypted checkpoint."""
     blob = checkpoint(sandbox, key)
-    # Real implementation would send *blob* to *host* securely
-    return restore(blob, key)
+    return send_checkpoint(host, blob, key)
 
 
-__all__ = ["migrate"]
+__all__ = [
+    "MigrationProtocolError",
+    "MigrationResponse",
+    "handle_migration_connection",
+    "migrate",
+    "send_checkpoint",
+    "serve_migration_once",
+]

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,152 @@
+import socket
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from pyisolate import migration
+
+KEY = b"k" * 32
+
+
+class FakeClientSocket:
+    def __init__(self, response: bytes):
+        self.response = bytearray(response)
+        self.sent = bytearray()
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.extend(data)
+
+    def recv(self, size: int) -> bytes:
+        if not self.response:
+            return b""
+        chunk = self.response[:size]
+        del self.response[:size]
+        return bytes(chunk)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+
+def _encoded_response(ok: bool, error: str | None = None) -> bytes:
+    left, right = socket.socketpair()
+    try:
+        migration._send_json(left, {"ok": ok, "error": error})
+        return right.recv(4096)
+    finally:
+        left.close()
+        right.close()
+
+
+def test_migrate_uses_host_and_does_not_restore_locally(monkeypatch):
+    sandbox = object()
+    blob = b"encrypted-checkpoint"
+    fake = FakeClientSocket(_encoded_response(True))
+    calls = {}
+
+    def fake_checkpoint(seen_sandbox, seen_key):
+        calls["checkpoint"] = (seen_sandbox, seen_key)
+        return blob
+
+    def fake_create_connection(address, timeout=None):
+        calls["address"] = address
+        calls["timeout"] = timeout
+        return fake
+
+    def fail_restore(*args, **kwargs):  # pragma: no cover - should never run
+        raise AssertionError("migrate must not restore locally for remote hosts")
+
+    monkeypatch.setattr(migration, "checkpoint", fake_checkpoint)
+    monkeypatch.setattr(migration, "restore", fail_restore)
+    monkeypatch.setattr(migration.socket, "create_connection", fake_create_connection)
+
+    response = migration.migrate(sandbox, "migration.example:9443", KEY)
+
+    assert response == migration.MigrationResponse(ok=True, error=None)
+    assert calls["checkpoint"] == (sandbox, KEY)
+    assert calls["address"] == ("migration.example", 9443)
+    assert calls["timeout"] == 10.0
+    assert blob in fake.sent
+
+
+def test_endpoint_restores_authenticated_checkpoint():
+    server, client = socket.socketpair()
+    restored = []
+    result = []
+    blob = b"sealed"
+
+    def restore_fn(seen_blob, seen_key):
+        restored.append((seen_blob, seen_key))
+        return object()
+
+    def run_server():
+        with server:
+            result.append(
+                migration.handle_migration_connection(
+                    server, KEY, restore_fn=restore_fn
+                )
+            )
+
+    thread = threading.Thread(target=run_server)
+    thread.start()
+    try:
+        migration._send_json(
+            client,
+            {
+                "magic": "PYISOMIG1",
+                "version": 1,
+                "blob_len": len(blob),
+                "auth": migration._mac(blob, KEY),
+            },
+        )
+        client.sendall(blob)
+        response = migration._recv_json(client)
+    finally:
+        client.close()
+        thread.join(timeout=1)
+
+    assert response == {"ok": True, "error": None}
+    assert result == [migration.MigrationResponse(ok=True, error=None)]
+    assert restored == [(blob, KEY)]
+
+
+def test_endpoint_rejects_unauthenticated_checkpoint():
+    server, client = socket.socketpair()
+    restored = []
+    blob = b"sealed"
+
+    def restore_fn(seen_blob, seen_key):  # pragma: no cover - should never run
+        restored.append((seen_blob, seen_key))
+        return object()
+
+    thread = threading.Thread(
+        target=lambda: migration.handle_migration_connection(
+            server, KEY, restore_fn=restore_fn
+        )
+    )
+    thread.start()
+    try:
+        migration._send_json(
+            client,
+            {
+                "magic": "PYISOMIG1",
+                "version": 1,
+                "blob_len": len(blob),
+                "auth": "0" * 64,
+            },
+        )
+        client.sendall(blob)
+        response = migration._recv_json(client)
+    finally:
+        client.close()
+        server.close()
+        thread.join(timeout=1)
+
+    assert response["ok"] is False
+    assert "authenticator" in response["error"]
+    assert restored == []


### PR DESCRIPTION
### Motivation
- Replace the local-only migration stub with a real transport so encrypted checkpoints can be sent to a remote host and restored there. 
- Ensure migrations are authenticated and robust to malformed peers, and avoid performing a local `restore` when the target is remote.

### Description
- Implement a framed, authenticated client/server protocol in `pyisolate/migration.py` with `send_checkpoint`, `handle_migration_connection`, and `serve_migration_once`, and add `MigrationResponse` and `MigrationProtocolError` types. 
- Use HMAC-SHA256 for authenticators, a 4-byte length prefix for JSON headers, and `_parse_host` to accept `host[:port]` and IPv6 `[...]` forms. 
- Change `migrate` to call `checkpoint` and then `send_checkpoint(host, blob, key)` so remote hosts are used and local `restore` is not performed. 
- Export the new helpers from the package (`pyisolate.__init__`) and update `API.md` to reflect the new `MigrationResponse` return type, and add `tests/test_migration.py` with coverage for host usage, avoiding local restores, successful authenticated restores, and rejection of unauthenticated blobs. 

### Testing
- Ran `pytest -q tests/test_checkpoint.py tests/test_migration.py` and the migration-specific tests passed. 
- Ran the full test suite with `pytest -q` and all tests passed (`339 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a357a3841f48328959a6f73589df29f)