### PR TITLE
Derive directional broker crypto keys

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -68,10 +68,14 @@ frames are protected with ChaCha20-Poly1305.
 1. Each side generates an X25519 key pair.
 2. Public keys are exchanged out of band.
 3. A shared secret is derived via `X25519PrivateKey.exchange()`.
-4. The secret feeds HKDF-SHA256 with `info=b"pyisolate-channel"` to produce the
-   32 byte AEAD key.
+4. The secret feeds HKDF-SHA256 twice with direction-specific info strings:
+   `info=b"pyisolate-channel client->server"` and
+   `info=b"pyisolate-channel server->client"`. The client uses the
+   `client->server` key for transmit and the `server->client` key for receive;
+   the server uses the opposite mapping.
 5. The helper `pyisolate.broker.crypto.handshake()` wraps these steps and
-   returns `(public_key, broker)`.
+   returns `(public_key, broker)`. Pass `role="client"` or `role="server"` so
+   each peer selects the correct directional keys.
 6. Keys can be rotated by repeating steps 1‑5; counters reset to zero after a
    successful rotation.
 

--- a/pyisolate/broker/crypto.py
+++ b/pyisolate/broker/crypto.py
@@ -66,6 +66,7 @@ class CryptoBroker:
         *,
         pq_secret: bytes | None = None,
         max_frame_len: int = DEFAULT_MAX_FRAME_LEN,
+        role: str = "client",
     ):
         self._lock = Lock()
         if type(max_frame_len) is not int:
@@ -73,17 +74,41 @@ class CryptoBroker:
         if max_frame_len < MIN_FRAME_LEN:
             raise ValueError("max_frame_len must be at least 28 bytes")
         self._max_frame_len = max_frame_len
+        self._role = self._validate_role(role)
         self.rotate(private_key, peer_key, pq_secret=pq_secret)
 
     @staticmethod
     def _nonce(counter: int) -> bytes:
         return counter.to_bytes(12, "little")
 
+    @staticmethod
+    def _validate_role(role: str) -> str:
+        if role not in {"client", "server"}:
+            raise ValueError('role must be "client" or "server"')
+        return role
+
+    @staticmethod
+    def _derive_key(shared: bytes, info: bytes) -> bytes:
+        hkdf = HKDF(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=None,
+            info=info,
+        )
+        return hkdf.derive(shared)
+
     def rotate(
-        self, private_key: bytes, peer_key: bytes, *, pq_secret: bytes | None = None
+        self,
+        private_key: bytes,
+        peer_key: bytes,
+        *,
+        pq_secret: bytes | None = None,
+        role: str | None = None,
     ) -> None:
-        """Derive a new AEAD key and reset counters."""
+        """Derive new directional AEAD keys and reset counters."""
         with self._lock:
+            if role is not None:
+                self._role = self._validate_role(role)
             priv = x25519.X25519PrivateKey.from_private_bytes(private_key)
             try:
                 pub = x25519.X25519PublicKey.from_public_bytes(peer_key)
@@ -93,18 +118,24 @@ class CryptoBroker:
             shared = priv.exchange(pub)
             if pq_secret is not None:
                 shared += pq_secret
-            hkdf = HKDF(
-                algorithm=hashes.SHA256(),
-                length=32,
-                salt=None,
-                info=b"pyisolate-channel",
+            client_to_server = self._derive_key(
+                shared, b"pyisolate-channel client->server"
             )
-            self._key = hkdf.derive(shared)
+            server_to_client = self._derive_key(
+                shared, b"pyisolate-channel server->client"
+            )
+            if self._role == "client":
+                self._tx_key = client_to_server
+                self._rx_key = server_to_client
+            else:
+                self._tx_key = server_to_client
+                self._rx_key = client_to_server
             self.public_key = priv.public_key().public_bytes(
                 encoding=serialization.Encoding.Raw,
                 format=serialization.PublicFormat.Raw,
             )
-            self._aead = ChaCha20Poly1305(self._key)
+            self._tx_aead = ChaCha20Poly1305(self._tx_key)
+            self._rx_aead = ChaCha20Poly1305(self._rx_key)
             self._tx_ctr = 0
             self._rx_ctr = 0
 
@@ -115,7 +146,7 @@ class CryptoBroker:
                 raise OverflowError("send counter overflow")
             nonce = self._nonce(self._tx_ctr)
             self._tx_ctr += 1
-            return nonce + self._aead.encrypt(nonce, data, b"")
+            return nonce + self._tx_aead.encrypt(nonce, data, b"")
 
     def unframe(self, data: bytes) -> bytes:
         """Validate counter, decrypt, and return plaintext."""
@@ -125,7 +156,7 @@ class CryptoBroker:
             if len(data) > self._max_frame_len:
                 nonce = b"\x00" * 12
                 try:
-                    self._aead.decrypt(nonce, b"\x00" * 16, b"")
+                    self._rx_aead.decrypt(nonce, b"\x00" * 16, b"")
                 except Exception:
                     pass
                 raise ValueError("frame too large")
@@ -134,7 +165,7 @@ class CryptoBroker:
             if len(data) < 12:
                 nonce = b"\x00" * 12
                 try:
-                    self._aead.decrypt(nonce, b"\x00" * 16, b"")
+                    self._rx_aead.decrypt(nonce, b"\x00" * 16, b"")
                 except Exception:
                     pass
                 raise ValueError("invalid frame")
@@ -143,13 +174,13 @@ class CryptoBroker:
             expected_nonce = self._nonce(self._rx_ctr)
             if not constant_compare(nonce, expected_nonce):
                 try:
-                    self._aead.decrypt(nonce, data[12:], b"")
+                    self._rx_aead.decrypt(nonce, data[12:], b"")
                 except Exception:
                     pass
                 raise ValueError("replay detected")
 
             try:
-                plaintext = self._aead.decrypt(nonce, data[12:], b"")
+                plaintext = self._rx_aead.decrypt(nonce, data[12:], b"")
             except Exception:
                 raise ValueError("decryption failed") from None
             self._rx_ctr += 1
@@ -158,7 +189,11 @@ class CryptoBroker:
 
 
 def handshake(
-    peer_key: bytes, *, private_key: bytes | None = None, pq_secret: bytes | None = None
+    peer_key: bytes,
+    *,
+    private_key: bytes | None = None,
+    pq_secret: bytes | None = None,
+    role: str = "client",
 ) -> tuple[bytes, CryptoBroker]:
     """Perform a one-shot X25519 handshake and return ``(public_key, broker)``.
 
@@ -183,5 +218,5 @@ def handshake(
         format=serialization.PublicFormat.Raw,
     )
 
-    broker = CryptoBroker(priv_bytes, peer_key, pq_secret=pq_secret)
+    broker = CryptoBroker(priv_bytes, peer_key, pq_secret=pq_secret, role=role)
     return pub_bytes, broker

--- a/pyisolate/conformance.py
+++ b/pyisolate/conformance.py
@@ -451,8 +451,8 @@ class ConformanceSuite:
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
         )
-        broker_a = CryptoBroker(priv_a_bytes, pub_b, max_frame_len=64)
-        broker_b = CryptoBroker(priv_b_bytes, pub_a, max_frame_len=64)
+        broker_a = CryptoBroker(priv_a_bytes, pub_b, max_frame_len=64, role="client")
+        broker_b = CryptoBroker(priv_b_bytes, pub_a, max_frame_len=64, role="server")
         frame = broker_a.frame(b"doctor-grade")
         roundtrip = broker_b.unframe(frame) == b"doctor-grade"
         replay_blocked = False

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -22,6 +22,7 @@ def make_pair():
             format=serialization.PublicFormat.Raw,
         ),
         max_frame_len=max_len,
+        role="client",
     )
     b = CryptoBroker(
         priv_b.private_bytes(
@@ -34,6 +35,7 @@ def make_pair():
             format=serialization.PublicFormat.Raw,
         ),
         max_frame_len=max_len,
+        role="server",
     )
     return a, b
 
@@ -71,7 +73,7 @@ def test_handshake_helper():
         format=serialization.PublicFormat.Raw,
     )
 
-    pub_a, broker_a = handshake(pub_b)
+    pub_a, broker_a = handshake(pub_b, role="client")
     broker_b = CryptoBroker(
         priv_b.private_bytes(
             encoding=serialization.Encoding.Raw,
@@ -80,6 +82,7 @@ def test_handshake_helper():
         ),
         pub_a,
         max_frame_len=4096,
+        role="server",
     )
 
     msg = b"hi"
@@ -143,3 +146,55 @@ def test_concurrent_rotate():
 
     msg = b"rotated"
     assert b.unframe(a.frame(msg)) == msg
+
+
+def test_directional_keys_prevent_opposite_direction_key_nonce_reuse():
+    a, b = make_pair()
+
+    assert a._tx_key == b._rx_key
+    assert a._rx_key == b._tx_key
+    assert a._tx_key != a._rx_key
+    assert b._tx_key != b._rx_key
+
+    client_frame = a.frame(b"client to server")
+    server_frame = b.frame(b"server to client")
+
+    assert client_frame[:12] == server_frame[:12] == b"\x00" * 12
+    assert b.unframe(client_frame) == b"client to server"
+    assert a.unframe(server_frame) == b"server to client"
+
+
+def test_same_role_peers_cannot_decrypt_first_frame_despite_same_nonce():
+    priv_a = x25519.X25519PrivateKey.generate()
+    priv_b = x25519.X25519PrivateKey.generate()
+    a = CryptoBroker(
+        priv_a.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        priv_b.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ),
+        max_frame_len=4096,
+        role="client",
+    )
+    b = CryptoBroker(
+        priv_b.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        priv_a.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ),
+        max_frame_len=4096,
+        role="client",
+    )
+
+    frame = a.frame(b"same role")
+    assert frame[:12] == b"\x00" * 12
+    with pytest.raises(ValueError, match="decryption failed"):
+        b.unframe(frame)

--- a/tests/test_crypto_extra.py
+++ b/tests/test_crypto_extra.py
@@ -28,6 +28,7 @@ def make_broker(max_frame_len=4096):
         _private_bytes(private_key),
         _public_bytes(peer_key),
         max_frame_len=max_frame_len,
+        role="client",
     )
 
 
@@ -39,11 +40,13 @@ def make_pair():
         _private_bytes(priv_a),
         _public_bytes(priv_b),
         max_frame_len=max_len,
+        role="client",
     )
     b = CryptoBroker(
         _private_bytes(priv_b),
         _public_bytes(priv_a),
         max_frame_len=max_len,
+        role="server",
     )
     return a, b
 

--- a/tests/test_crypto_kyber.py
+++ b/tests/test_crypto_kyber.py
@@ -31,6 +31,7 @@ def make_pair():
         ),
         pq_secret=ss_a,
         max_frame_len=max_len,
+        role="client",
     )
     b = CryptoBroker(
         priv_b.private_bytes(
@@ -44,6 +45,7 @@ def make_pair():
         ),
         pq_secret=ss_b,
         max_frame_len=max_len,
+        role="server",
     )
     return a, b
 


### PR DESCRIPTION
### Motivation
- Prevent reuse of the same key/nonce pair in opposite directions by deriving distinct directional keys instead of a single shared AEAD key.
- Make the broker handshake explicit about each peer's role so both sides deterministically pick transmit/receive key material.

### Description
- Add a `role: "client" | "server"` parameter to `CryptoBroker.__init__`, `rotate` (optional override), and `handshake` so peers select a role-aware mapping of directional keys.
- Replace a single HKDF derivation with two HKDF derivations using `info=b"pyisolate-channel client->server"` and `info=b"pyisolate-channel server->client"`, then map those to `_tx_key`/`_rx_key` based on role.
- Instantiate separate AEAD objects ` _tx_aead` and `_rx_aead` (ChaCha20-Poly1305) and use them for `frame` (send) and `unframe` (receive) paths respectively.
- Update `rotate` to reset directional keys/counters and allow role change via the optional `role` parameter.
- Update tests to construct peers with explicit roles, add tests that assert `_tx_key`/`_rx_key` are opposite on peers and cannot be misused when both peers use the same role, and adjust Kyber/conformance fixtures and protocol docs to document the change.

### Testing
- Ran `python -m pytest tests/test_crypto.py tests/test_crypto_extra.py` and both test files passed (local targeted tests succeeded).
- Ran `python -m pytest tests/test_crypto_kyber.py` and the Kyber hybrid test passed.
- Ran the full test suite with `python -m pytest` and all tests passed (341 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3583cdabec83289b8bd00f3e9b7d67)