### PR TITLE
Write BPF build artifacts to cache directory

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -8,9 +8,13 @@ available on the test system; any missing executables are therefore ignored.
 
 import json
 import logging
+import os
+import shlex
 import subprocess
 from pathlib import Path
 from typing import Literal
+
+from platformdirs import user_cache_dir
 
 from ..policy.compiler import PolicyCompilerError, compile_policy
 from ..policy.model import from_compiled_policy, to_bpf_map_entries
@@ -26,19 +30,46 @@ class BPFManager:
     """
 
     _SKEL_CACHE: dict[Path, str] = {}
+    _CACHE_ENV = "PYISOLATE_BPF_CACHE"
+
+    @classmethod
+    def _cache_dir(cls) -> Path:
+        """Return the writable cache directory for generated BPF artifacts."""
+
+        cache_root = os.environ.get(cls._CACHE_ENV)
+        path = (
+            Path(cache_root).expanduser()
+            if cache_root
+            else Path(user_cache_dir("pyisolate")) / "bpf"
+        )
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unable to create BPF cache directory {path!s}. "
+                "Set PYISOLATE_BPF_CACHE to a writable directory before loading BPF programs; "
+                f"hardened mode cannot continue without writable generated-artifact storage: {exc}"
+            ) from exc
+        if not path.is_dir():
+            raise RuntimeError(
+                f"BPF cache path {path!s} exists but is not a directory. "
+                "Set PYISOLATE_BPF_CACHE to a writable directory."
+            )
+        return path
 
     def __init__(self):
         self.loaded = False
         self.policy_maps: dict[str, object] = {}
         self._src = Path(__file__).with_name("dummy.bpf.c")
-        self._obj = Path(__file__).with_name("dummy.bpf.o")
-        self._skel = Path(__file__).with_name("dummy.skel.h")
+        self._cache = self._cache_dir()
+        self._obj = self._cache / "dummy.bpf.o"
+        self._skel = self._cache / "dummy.skel.h"
         self.skeleton = ""
         self._compiled_skeleton = False
         self._filter_src = Path(__file__).with_name("syscall_filter.bpf.c")
-        self._filter_obj = Path(__file__).with_name("syscall_filter.bpf.o")
+        self._filter_obj = self._cache / "syscall_filter.bpf.o"
         self._guard_src = Path(__file__).with_name("resource_guard.bpf.c")
-        self._guard_obj = Path(__file__).with_name("resource_guard.bpf.o")
+        self._guard_obj = self._cache / "resource_guard.bpf.o"
         self._bpffs_root = Path("/sys/fs/bpf/pyisolate")
         self._dummy_pin = Path("/sys/fs/bpf/dummy")
         self._filter_pin_dir = self._bpffs_root / "syscall_filter"
@@ -143,7 +174,7 @@ class BPFManager:
             skel_cmd = [
                 "sh",
                 "-c",
-                f"bpftool gen skeleton {self._obj} > {self._skel}",
+                f"bpftool gen skeleton {shlex.quote(str(self._obj))} > {shlex.quote(str(self._skel))}",
             ]
             ok &= self._run(skel_cmd, raise_on_error=strict_mode)
             if ok and self._skel.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "Prototype PyIsolate sandbox; kernel enforcement and no-GIL support are experimental roadmap items"
 authors = [{ name = "PyIsolate" }]
 requires-python = ">=3.11"
-dependencies = ["pyyaml", "cryptography"]
+dependencies = ["pyyaml", "cryptography", "platformdirs"]
 
 [build-system]
 requires = ["setuptools>=64"]

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -133,6 +133,56 @@ def test_load_lenient_mode_does_not_raise(monkeypatch):
     assert mgr.loaded
 
 
+def test_generated_bpf_artifacts_use_configured_cache(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "bpf-cache"
+    monkeypatch.setenv(BPFManager._CACHE_ENV, str(cache_dir))
+    BPFManager._SKEL_CACHE.clear()
+
+    calls = []
+
+    def record(self, cmd, *, raise_on_error=False):
+        calls.append(cmd)
+        return True
+
+    monkeypatch.setattr(BPFManager, "_run", record)
+    mgr = BPFManager()
+    mgr.load()
+
+    package_dir = Path(BPFManager.__module__.replace(".", "/"))
+    package_bpf_dir = ROOT / package_dir.parent
+    output_paths = {mgr._obj, mgr._skel, mgr._filter_obj, mgr._guard_obj}
+
+    assert output_paths == {
+        cache_dir / "dummy.bpf.o",
+        cache_dir / "dummy.skel.h",
+        cache_dir / "syscall_filter.bpf.o",
+        cache_dir / "resource_guard.bpf.o",
+    }
+    assert all(path.is_relative_to(cache_dir) for path in output_paths)
+    assert not any(path.is_relative_to(package_bpf_dir) for path in output_paths)
+    assert mgr._src == package_bpf_dir / "dummy.bpf.c"
+    assert mgr._filter_src == package_bpf_dir / "syscall_filter.bpf.c"
+    assert mgr._guard_src == package_bpf_dir / "resource_guard.bpf.c"
+
+    command_text = "\n".join(" ".join(map(str, cmd)) for cmd in calls)
+    assert str(cache_dir) in command_text
+    assert str(package_bpf_dir / "dummy.bpf.o") not in command_text
+    assert str(package_bpf_dir / "syscall_filter.bpf.o") not in command_text
+    assert str(package_bpf_dir / "resource_guard.bpf.o") not in command_text
+
+
+def test_cache_directory_creation_failure_is_descriptive(tmp_path, monkeypatch):
+    cache_file = tmp_path / "not-a-directory"
+    cache_file.write_text("not a directory")
+    monkeypatch.setenv(BPFManager._CACHE_ENV, str(cache_file))
+
+    with pytest.raises(RuntimeError) as exc:
+        BPFManager()
+
+    assert str(cache_file) in str(exc.value)
+    assert "writable directory" in str(exc.value)
+
+
 def test_hot_reload_updates_maps(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "subprocess.run", lambda *a, **k: subprocess.CompletedProcess([], 0)


### PR DESCRIPTION
### Motivation
- Prevent writing generated BPF artifacts into the package tree by placing compiled outputs in a writable cache directory instead. 
- Keep packaged `.bpf.c` source files as read-only inputs while allowing tools to emit `.o`/`.h` into a configurable cache. 
- Surface clear errors when cache creation fails so `hardened` mode can fail fast and give actionable guidance.

### Description
- Add `BPFManager._CACHE_ENV = "PYISOLATE_BPF_CACHE"` and a `_cache_dir()` classmethod that returns `Path(os.environ.get(...))` or `platformdirs.user_cache_dir("pyisolate") / "bpf"` and ensures the directory exists, raising descriptive `RuntimeError` on failure. 
- Move generated artifact paths to the cache: `dummy.bpf.o`, `dummy.skel.h`, `syscall_filter.bpf.o`, and `resource_guard.bpf.o` are now created under the cache directory while `dummy.bpf.c`, `syscall_filter.bpf.c`, and `resource_guard.bpf.c` remain as package-source `Path`s. 
- Quote the skeleton-generation shell command using `shlex.quote(...)` to safely reference cache paths. 
- Add `platformdirs` to runtime dependencies so a per-user cache directory is available. 
- Add tests in `tests/test_bpf_manager.py` that monkeypatch the cache environment and assert generated outputs are under the configured cache (not the package tree), and that cache-creation failures produce descriptive errors.

### Testing
- Ran unit tests: `pytest -q tests/test_bpf_manager.py tests/test_bpf_manager_extra.py`, and the full test suite `pytest -q`; all tests passed (`341 passed, 1 skipped` in this environment). 
- The changed tests `test_generated_bpf_artifacts_use_configured_cache` and `test_cache_directory_creation_failure_is_descriptive` were executed and succeeded as part of the runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3583d04eb883289060edb9d83962ca)