### PR TITLE
Use argparse subparser dispatch for CLI

### DIFF
--- a/pyisolate/cli.py
+++ b/pyisolate/cli.py
@@ -8,20 +8,22 @@ import sys
 from . import doctor
 
 
+def _run_doctor(args: argparse.Namespace) -> None:
+    doctor.main(args.doctor_args)
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="pyisolate")
-    subparsers = parser.add_subparsers(dest="command")
-    subparsers.add_parser("doctor", help="Run installation and no-GIL diagnostics")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    doctor_parser = subparsers.add_parser(
+        "doctor", help="Run installation and no-GIL diagnostics"
+    )
+    doctor_parser.add_argument("doctor_args", nargs=argparse.REMAINDER)
+    doctor_parser.set_defaults(func=_run_doctor)
 
     argv = sys.argv[1:] if argv is None else argv
-    args = parser.parse_args(argv[:1])
-    if args.command is None:
-        parser.print_help()
-        raise SystemExit(2)
-    if args.command == "doctor":
-        doctor.main(argv[1:])
-        return
-    parser.error(f"unknown command: {args.command}")
+    args = parser.parse_args(argv)
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import pytest
 from pyisolate import cli
 
 
-def test_pyisolate_doctor_delegates_to_doctor_main(monkeypatch):
+def test_pyisolate_doctor_gil_json_delegates_to_doctor_main(monkeypatch):
     calls = []
 
     def fake_doctor_main(argv):
@@ -22,7 +22,8 @@ def test_pyisolate_no_command_exits_nonzero(capsys):
 
     assert excinfo.value.code != 0
     captured = capsys.readouterr()
-    assert "usage: pyisolate" in captured.out
+    assert "usage: pyisolate" in captured.err
+    assert "the following arguments are required: command" in captured.err
 
 
 def test_pyisolate_unknown_command_exits_nonzero(capsys):


### PR DESCRIPTION
### Motivation
- Replace ad-hoc one-argument parsing with normal argparse subparser dispatch so the CLI parses the full argument list and uses built-in command dispatch. 
- Preserve delegated arguments when handing control to the `doctor` implementation so subcommand flags like `gil --json` are forwarded intact. 
- Make test expectations match the new required-subparser error and unknown-command behavior from argparse.

### Description
- Switch `pyisolate` to use `subparsers = parser.add_subparsers(dest="command", required=True)` and register a `doctor` subparser. 
- Add a `_run_doctor` handler and register it with `doctor_parser.set_defaults(func=_run_doctor)` while accepting remaining doctor args via `doctor_parser.add_argument("doctor_args", nargs=argparse.REMAINDER)`. 
- Replace the previous `parser.parse_args(argv[:1])` flow with a single `args = parser.parse_args(argv)` and dispatch via `args.func(args)`. 
- Update `tests/test_cli.py` to assert `pyisolate doctor gil --json` is delegated, and to check no-command and unknown-command arg parsing/error output.

### Testing
- Ran `python -m pytest tests/test_cli.py -q` and it passed. 
- Ran the full test suite with `python -m pytest -q` and it completed successfully (`339 passed, 1 skipped`). 
- Updated CLI unit tests now assert delegation to `doctor.main`, the required-subparser error message, and unknown-command behavior and all pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3583d37d1c8328bc40dee791060ca2)