### PR TITLE
Validate serialized policy in checkpoint restore before spawn

### DIFF
--- a/pyisolate/checkpoint.py
+++ b/pyisolate/checkpoint.py
@@ -11,12 +11,23 @@ import os
 
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
+from .policy.model import RuntimePolicy, from_compiled_policy
 from .runtime.thread import deserialize_capabilities
 from .supervisor import Sandbox, spawn
 
 _MAGIC = b"PYISOCP1"
 _NONCE_LEN = 12
 _LEN_SIZE = 4
+
+
+_CANONICAL_RUNTIME_POLICY_KEYS = {
+    "allow_fs",
+    "deny_fs",
+    "allow_tcp",
+    "deny_tcp",
+    "imports",
+    "cpu_ms",
+}
 
 
 def _encode_envelope(blob: bytes) -> bytes:
@@ -130,6 +141,47 @@ def _validate_serialized_capability(capability: object) -> None:
         raise ValueError("unknown serialized capability kind")
 
 
+def _select_policy_from_set(policy_set, name: str) -> RuntimePolicy:
+    if name in policy_set.sandboxes:
+        return policy_set.sandbox(name)
+    if "default" in policy_set.sandboxes:
+        return policy_set.sandbox("default")
+    if len(policy_set.sandboxes) == 1:
+        return next(iter(policy_set.sandboxes.values()))
+    raise ValueError("policy set does not contain a matching sandbox policy")
+
+
+def _require_optional_policy(state: dict) -> RuntimePolicy | None:
+    """Validate and normalize the serialized checkpoint policy field.
+
+    Checkpoints intentionally support only JSON-compatible policy shapes that
+    are documented as serialized runtime policy data: ``None``, a canonical
+    ``RuntimePolicy.to_dict()`` mapping, or a canonical
+    ``RuntimePolicySet.to_dict()``/compiled-policy mapping with ``sandboxes``.
+    """
+    value = state.get("policy")
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(
+            "invalid checkpoint payload: 'policy' must be None or a serialized policy mapping"
+        )
+
+    try:
+        if "sandboxes" in value:
+            policy_set = from_compiled_policy(value)
+            return _select_policy_from_set(policy_set, state["name"])
+
+        if not value.keys() <= _CANONICAL_RUNTIME_POLICY_KEYS:
+            raise ValueError("policy mapping contains unsupported keys")
+        policy_set = from_compiled_policy({"sandboxes": {"default": value}})
+        return policy_set.sandbox("default")
+    except (TypeError, ValueError, KeyError) as exc:
+        raise ValueError(
+            "invalid checkpoint payload: 'policy' must be None or a serialized policy mapping"
+        ) from exc
+
+
 def _require_optional_capabilities(state: dict) -> dict | None:
     value = state.get("capabilities")
     if value is None:
@@ -196,9 +248,10 @@ def restore(blob: bytes, key: bytes) -> Sandbox:
     allowed_imports = _require_optional_allowed_imports(state)
     numa_node = _require_optional_numa_node(state)
     capabilities = _require_optional_capabilities(state)
+    policy = _require_optional_policy(state)
     return spawn(
         name,
-        policy=state.get("policy"),
+        policy=policy,
         cpu_ms=cpu_ms,
         mem_bytes=mem_bytes,
         allowed_imports=allowed_imports,

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -298,6 +298,83 @@ def test_restore_rejects_malformed_capabilities_after_decrypt(monkeypatch, value
         iso.restore(blob, key)
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "readonly-fs",
+        [],
+        1,
+        True,
+    ],
+)
+def test_restore_rejects_invalid_policy_types_after_decrypt(monkeypatch, value):
+    key = os.urandom(32)
+    blob = _make_blob({"name": "bad-policy", "policy": value}, key)
+
+    def fail_spawn(*args, **kwargs):
+        raise AssertionError("spawn should not be called for invalid payloads")
+
+    monkeypatch.setattr(checkpoint_mod, "spawn", fail_spawn)
+    with pytest.raises(
+        ValueError,
+        match="invalid checkpoint payload: 'policy'.*serialized policy mapping",
+    ):
+        iso.restore(blob, key)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"version": "1.0", "sandboxes": {}},
+        {"allow_fs": "not-a-list"},
+        {"allow_fs": [{"action": "execute", "path": "/tmp"}]},
+        {"allow_tcp": [{"action": "connect"}]},
+        {"imports": [""]},
+        {"cpu_ms": 0},
+        {"unsupported": []},
+    ],
+)
+def test_restore_rejects_malformed_policy_mappings_after_decrypt(monkeypatch, value):
+    key = os.urandom(32)
+    blob = _make_blob({"name": "bad-policy-map", "policy": value}, key)
+
+    def fail_spawn(*args, **kwargs):
+        raise AssertionError("spawn should not be called for invalid payloads")
+
+    monkeypatch.setattr(checkpoint_mod, "spawn", fail_spawn)
+    with pytest.raises(
+        ValueError,
+        match="invalid checkpoint payload: 'policy'.*serialized policy mapping",
+    ):
+        iso.restore(blob, key)
+
+
+def test_restore_accepts_valid_serialized_policy_after_decrypt(tmp_path):
+    key = os.urandom(32)
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    target = allowed / "ok.txt"
+    target.write_text("ok", encoding="utf-8")
+    policy_payload = {
+        "allow_fs": [
+            {"action": "allow", "path": str(allowed), "access": "read"},
+        ],
+        "imports": ["math"],
+    }
+    blob = _make_blob({"name": "valid-policy", "policy": policy_payload}, key)
+
+    sb = iso.restore(blob, key)
+    try:
+        restored = sb.snapshot()["policy"]
+        assert restored.allow_fs[0].path == str(allowed)
+        assert restored.allow_fs[0].access == "read"
+        assert restored.imports == ("math",)
+        sb.exec(f"import math\npost((open({str(target)!r}).read(), math.sqrt(16)))")
+        assert sb.recv(timeout=0.5) == ("ok", 4.0)
+    finally:
+        sb.close()
+
+
 def test_checkpoint_closes_on_serialization_failure():
     key = os.urandom(32)
 


### PR DESCRIPTION
### Motivation
- Prevent malformed or unexpected `policy` checkpoint payloads from being forwarded directly to `spawn` which could cause runtime errors or misconfiguration.
- Limit accepted serialized shapes to documented, JSON-compatible runtime policy forms so restores are deterministic and safe.

### Description
- Import `from_compiled_policy` and add `_CANONICAL_RUNTIME_POLICY_KEYS` to recognize canonical runtime policy mappings.
- Add `_require_optional_policy(state)` which accepts only `None`, a canonical runtime `policy` mapping, or a policy-set/compiled mapping containing `sandboxes`, and normalizes it to a `RuntimePolicy` via `from_compiled_policy`.
- Use the normalized `policy` when calling `spawn` instead of `state.get("policy")`.
- Add tests in `tests/test_checkpoint.py` that assert rejects for invalid policy types, rejects for malformed policy mappings, and successful restore when provided a valid serialized policy.

### Testing
- Ran code formatting with `python -m black pyisolate/checkpoint.py tests/test_checkpoint.py` which completed successfully.
- Ran targeted tests with `pytest -q tests/test_checkpoint.py` and they passed.
- Compiled the module with `python -m compileall pyisolate/checkpoint.py` which succeeded.
- Ran the full test suite with `pytest -q` resulting in `351 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3583d45b908328900b76016ae8bf4e)