### PR TITLE
Fix structured-logging JSON escaping and operator reconcile handling

### DIFF
--- a/pyisolate/logging.py
+++ b/pyisolate/logging.py
@@ -2,14 +2,33 @@
 
 from __future__ import annotations
 
+import json
 import logging
+
+
+class JSONFormatter(logging.Formatter):
+    """Render each log record as one valid JSON object.
+
+    Building the JSON by string-templating ``%(message)s`` (and the logger
+    name) produced invalid JSON whenever a value contained a quote, backslash,
+    or newline, which downstream log pipelines would fail to parse.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "timestamp": self.formatTime(record),
+            "level": record.levelname,
+            "component": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload)
 
 
 def setup_structured_logging(level: int = logging.INFO) -> None:
     """Configure the root logger to emit JSON formatted messages."""
 
-    logging.basicConfig(
-        level=level,
-        format='{"timestamp": "%(asctime)s", "level": "%(levelname)s", '
-        '"component": "%(name)s", "message": "%(message)s"}',
-    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(JSONFormatter())
+    logging.basicConfig(level=level, handlers=[handler])

--- a/pyisolate/operator/__init__.py
+++ b/pyisolate/operator/__init__.py
@@ -32,8 +32,19 @@ def run_operator(namespace: str = "default") -> None:
         name = obj["metadata"]["name"]
         logger.info("received %s for sandbox %s", op, name)
         try:
-            if op == "ADDED":
-                sandboxes[name] = sup.spawn(name)
+            if op in ("ADDED", "MODIFIED"):
+                existing = sandboxes.get(name)
+                if existing is None:
+                    # New object, or a watch relist re-announcing one we do not
+                    # track yet.
+                    sandboxes[name] = sup.spawn(name)
+                elif op == "MODIFIED":
+                    # Reconcile a spec change by replacing the sandbox.
+                    existing.close()
+                    sandboxes[name] = sup.spawn(name)
+                # A re-delivered ADDED for a sandbox we already run is a no-op;
+                # Kubernetes relists re-send every object as ADDED, and spawning
+                # again would raise "already exists".
             elif op == "DELETED":
                 sb = sandboxes.pop(name, None)
                 if sb:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,24 @@
+import json
 import logging
 
-from pyisolate.logging import setup_structured_logging
+from pyisolate.logging import JSONFormatter, setup_structured_logging
+
+
+def test_structured_log_output_is_valid_json():
+    record = logging.LogRecord(
+        name='comp"x',
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='he said "hi"\nsecond line \\ backslash',
+        args=(),
+        exc_info=None,
+    )
+    line = JSONFormatter().format(record)
+    parsed = json.loads(line)  # must not raise on quotes/newlines/backslashes
+    assert parsed["message"] == 'he said "hi"\nsecond line \\ backslash'
+    assert parsed["component"] == 'comp"x'
+    assert parsed["level"] == "INFO"
 
 
 def test_setup_structured_logging():

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -34,6 +34,69 @@ def test_operator_module():
     assert hasattr(op, "scale_sandboxes")
 
 
+def test_operator_handles_relisted_added_and_modified(monkeypatch):
+    op = load_operator()
+    events = [
+        {"type": "ADDED", "object": {"metadata": {"name": "sb"}}},
+        {"type": "ADDED", "object": {"metadata": {"name": "sb"}}},  # watch relist
+        {"type": "MODIFIED", "object": {"metadata": {"name": "sb"}}},
+    ]
+
+    class FakeWatch:
+        def stream(self, *args, **kwargs):
+            for ev in events:
+                yield ev
+
+    fake_client = types.SimpleNamespace(
+        CustomObjectsApi=lambda: types.SimpleNamespace(
+            list_namespaced_custom_object=lambda *a, **kw: None
+        )
+    )
+    fake_config = types.SimpleNamespace(load_incluster_config=lambda: None)
+    fake_watch_module = types.SimpleNamespace(Watch=lambda: FakeWatch())
+    fake_k8s = types.SimpleNamespace(
+        client=fake_client, config=fake_config, watch=fake_watch_module
+    )
+    monkeypatch.setitem(sys.modules, "kubernetes", fake_k8s)
+    monkeypatch.setitem(sys.modules, "kubernetes.client", fake_client)
+    monkeypatch.setitem(sys.modules, "kubernetes.config", fake_config)
+    monkeypatch.setitem(sys.modules, "kubernetes.watch", fake_watch_module)
+
+    spawns = []
+    closed = []
+
+    class FakeSandbox:
+        def __init__(self, name, sup):
+            self.name = name
+            self._sup = sup
+
+        def close(self):
+            self._sup.active.pop(self.name, None)
+            closed.append(self.name)
+
+    class FakeSupervisor:
+        def __init__(self):
+            self.active = {}
+
+        def spawn(self, name):
+            # Mirror the real supervisor, which rejects a duplicate name.
+            if name in self.active:
+                raise RuntimeError(f"sandbox '{name}' already exists")
+            sb = FakeSandbox(name, self)
+            self.active[name] = sb
+            spawns.append(sb)
+            return sb
+
+    monkeypatch.setattr(op, "Supervisor", FakeSupervisor)
+
+    op.run_operator("default")
+
+    # Initial ADDED spawns once; the relisted ADDED is a no-op (not an error);
+    # MODIFIED closes the existing sandbox and respawns it.
+    assert len(spawns) == 2
+    assert closed == ["sb"]
+
+
 def test_operator_add_delete(monkeypatch):
     op = load_operator()
     events = [


### PR DESCRIPTION
Two independent correctness bugs in the operability modules. Verified locally on current `main`: full suite **365 passed / 2 skipped**, flake8/black/isort/pylint all clean.

## `logging.py` — invalid JSON output

`setup_structured_logging` built each line by interpolating `%(message)s`, `%(name)s`, etc. directly into a JSON template:

```python
format='{"timestamp": "%(asctime)s", ... "message": "%(message)s"}'
```

Any message containing a `"`, `\`, or newline produced **invalid JSON** (e.g. `logger.info('he said "hi"')` → `... "message": "he said "hi""}`), which downstream log pipelines drop or misparse. Replaced with a `json.dumps`-based `JSONFormatter` that escapes values correctly (and includes `exc_info` when present).

## `operator/__init__.py` — reconcile loop

The watch loop only handled `ADDED`/`DELETED`:
- **`MODIFIED` was ignored**, so spec changes were never applied.
- On a re-delivered `ADDED` (Kubernetes watch relists re-send every existing object as `ADDED`), `sup.spawn(name)` raised `RuntimeError("sandbox '…' already exists")`, which was silently swallowed by the broad `except`.

Now `ADDED` is idempotent (no-op if already tracked) and `MODIFIED` reconciles by closing and respawning the sandbox.

Each fix adds a regression test (valid-JSON-under-tricky-characters; relisted-`ADDED`-is-a-no-op plus `MODIFIED`-reconciles with a supervisor fake that rejects duplicate names like the real one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_