### PR TITLE
Let the no-gil CI job run instead of failing at install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,13 @@ jobs:
         with:
           python-version: "3.13t"
       - name: Install dependencies
-        run: python -m pip install -e .[dev]
+        # cryptography/cffi cannot yet build wheels for the free-threaded 3.13
+        # build, so a normal ``.[dev]`` install aborts before any test runs.
+        # Install pyisolate without that dependency and rely on the suite's
+        # crypto stub (tests/conftest.py) so the race tests actually execute.
+        run: |
+          python -m pip install -e . --no-deps
+          python -m pip install pytest pyyaml
       - name: Run race tests under free-threaded build
         run: pytest -q tests/test_matrix_hardening.py -m "race and no_gil"
 


### PR DESCRIPTION
**Task 3 of 3** (one PR per task).

The `no-gil race / py3.13t` job has been permanently red on every PR because `cryptography`/`cffi` can't build wheels against the free-threaded CPython 3.13 build, so `pip install -e .[dev]` aborts *before any test runs*. The job is `continue-on-error: true`, so it never blocked — but it also never exercised the free-threaded race tests it exists for.

This installs pyisolate **without** `cryptography` (`--no-deps` + the minimal test deps) and relies on the crypto stub already present in `tests/conftest.py`, so the race tests actually execute under the free-threaded build.

Verified locally:
- With `cryptography` hidden from imports, the conftest stub fills in and `iso.spawn(...).exec(...)` works end-to-end.
- The `race and no_gil` tests in `test_matrix_hardening.py` import only stdlib + `pytest` + `pyisolate` (no other third-party deps), so the minimal install is sufficient.

The job stays `continue-on-error`, so if a genuine free-threaded race surfaces it's reported without blocking — which is the job actually doing its job instead of erroring at install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_