### PR TITLE
Encode BPF map keys/values as fixed-width bytes for bpftool

### DIFF
--- a/pyisolate/bpf/manager.py
+++ b/pyisolate/bpf/manager.py
@@ -6,6 +6,7 @@ concept used by the tests.  ``bpftool`` and ``llvm-objdump`` may not be
 available on the test system; any missing executables are therefore ignored.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -20,6 +21,22 @@ from ..policy.compiler import PolicyCompilerError, compile_policy
 from ..policy.model import from_compiled_policy, to_bpf_map_entries
 
 logger = logging.getLogger(__name__)
+
+# BPF hash maps require fixed-width keys and values. The logical entries from
+# ``to_bpf_map_entries`` (e.g. ``"default:0"`` -> ``"/tmp/**"``) are therefore
+# encoded to fixed-width little-endian byte strings before being handed to
+# ``bpftool``, which consumes them as space-separated hex tokens. A blake2b
+# digest gives a deterministic, collision-resistant fixed-width encoding for the
+# variable-length logical strings; the matching kernel-side derivation is a
+# separate concern from this user-space encoding.
+BPF_KEY_BYTES = 8
+BPF_VALUE_BYTES = 8
+
+
+def encode_map_field(text: str, width: int) -> list[str]:
+    """Encode *text* as *width* hex byte tokens (``["0x.."]``) for ``bpftool``."""
+    digest = hashlib.blake2b(text.encode("utf-8"), digest_size=width).digest()
+    return [f"0x{byte:02x}" for byte in digest]
 
 
 class BPFManager:
@@ -383,9 +400,9 @@ class BPFManager:
                 "pinned",
                 f"/sys/fs/bpf/{map_name}",
                 "key",
-                key,
+                *encode_map_field(key, BPF_KEY_BYTES),
                 "value",
-                value,
+                *encode_map_field(value, BPF_VALUE_BYTES),
                 "any",
             ],
             raise_on_error=True,

--- a/tests/test_bpf_manager.py
+++ b/tests/test_bpf_manager.py
@@ -9,7 +9,12 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from pyisolate.bpf.manager import BPFManager
+from pyisolate.bpf.manager import (
+    BPF_KEY_BYTES,
+    BPF_VALUE_BYTES,
+    BPFManager,
+    encode_map_field,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -46,6 +51,17 @@ def _canonical_policy(*, fs_path="/tmp/**", tcp_addr="1.1.1.1:80"):
         },
         "deny_log": [],
     }
+
+
+def test_encode_map_field_is_fixed_width_hex():
+    encoded = encode_map_field("default:0", BPF_KEY_BYTES)
+    assert len(encoded) == BPF_KEY_BYTES
+    assert all(tok.startswith("0x") and len(tok) == 4 for tok in encoded)
+    # Deterministic for the same input; distinct inputs differ.
+    assert encode_map_field("default:0", BPF_KEY_BYTES) == encoded
+    assert encode_map_field("default:1", BPF_KEY_BYTES) != encoded
+    # The requested width is honored.
+    assert len(encode_map_field("/tmp/**", BPF_VALUE_BYTES)) == BPF_VALUE_BYTES
 
 
 def test_load_runs_toolchain(monkeypatch):
@@ -244,9 +260,9 @@ def test_hot_reload_handles_nested_policy(tmp_path, monkeypatch):
         "pinned",
         "/sys/fs/bpf/policy_net_allow",
         "key",
-        "default:0",
+        *encode_map_field("default:0", BPF_KEY_BYTES),
         "value",
-        "1.1.1.1:80",
+        *encode_map_field("1.1.1.1:80", BPF_VALUE_BYTES),
         "any",
     ] in calls
 
@@ -501,8 +517,8 @@ def test_hot_reload_midway_failure_keeps_policy_maps_unchanged_and_rolls_back(
         "pinned",
         "/sys/fs/bpf/policy_fs_allow",
         "key",
-        "default:0",
+        *encode_map_field("default:0", BPF_KEY_BYTES),
         "value",
-        "/tmp/original/**",
+        *encode_map_field("/tmp/original/**", BPF_VALUE_BYTES),
         "any",
     ] in calls

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -515,7 +515,12 @@ def test_policy_objects_serialize_to_yaml_without_pyyaml(monkeypatch):
 def test_canonical_yaml_policy_drives_sandbox_and_bpf_maps(tmp_path, monkeypatch):
     import pyisolate as iso
     import pyisolate.policy as policy
-    from pyisolate.bpf.manager import BPFManager
+    from pyisolate.bpf.manager import (
+        BPF_KEY_BYTES,
+        BPF_VALUE_BYTES,
+        BPFManager,
+        encode_map_field,
+    )
     from pyisolate.policy import from_compiled_policy
 
     allowed_dir = tmp_path / "allowed"
@@ -586,9 +591,9 @@ def test_canonical_yaml_policy_drives_sandbox_and_bpf_maps(tmp_path, monkeypatch
         "pinned",
         "/sys/fs/bpf/policy_fs_allow",
         "key",
-        "default:0",
+        *encode_map_field("default:0", BPF_KEY_BYTES),
         "value",
-        f"{allowed_dir}/**",
+        *encode_map_field(f"{allowed_dir}/**", BPF_VALUE_BYTES),
         "any",
     ] in calls
     assert [
@@ -598,9 +603,9 @@ def test_canonical_yaml_policy_drives_sandbox_and_bpf_maps(tmp_path, monkeypatch
         "pinned",
         "/sys/fs/bpf/policy_net_allow",
         "key",
-        "default:0",
+        *encode_map_field("default:0", BPF_KEY_BYTES),
         "value",
-        "127.0.0.1:9",
+        *encode_map_field("127.0.0.1:9", BPF_VALUE_BYTES),
         "any",
     ] in calls
 


### PR DESCRIPTION
**Task 2 of 3** (one PR per task).

`BPFManager` passed the logical entry strings from `to_bpf_map_entries` straight to `bpftool map update`:

```
bpftool map update pinned /sys/fs/bpf/policy_net_allow key default:0 value 1.1.1.1:80 any
```

But `bpftool` consumes `key`/`value` as **fixed-width byte sequences** (e.g. `key 0x.. 0x.. value 0x.. 0x..`), so single tokens like `default:0` / `/tmp/**` could never load — the encoding was a placeholder.

This adds a documented `encode_map_field(text, width)` that turns each logical field into a fixed-width little-endian byte string (a blake2b digest, since BPF hash maps require fixed-size cells and the logical strings are variable length) emitted as space-separated hex tokens, and splices those into the `bpftool` argv. The human-readable strings are kept for `policy_maps` and the error/rollback messages.

Scope note (as flagged): this makes the **user-space encoding** real and well-formed. Two things remain genuine follow-ups that need a kernel/`bpftool` environment to validate: deriving the same bytes kernel-side, and reconciling the abstract `policy_*_allow` maps with the cgroup-keyed `sandbox_policy`/`syscall_policy` maps the `.bpf.c` programs actually define.

Adds a fixed-width/deterministic encoding test and updates the command-shape assertions in `test_bpf_manager.py` / `test_policy.py`. Local: 367 passed / 2 skipped, flake8/black/isort/pylint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_