### PR TITLE
Install platformdirs for the no-gil CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,12 @@ jobs:
         # build, so a normal ``.[dev]`` install aborts before any test runs.
         # Install pyisolate without that dependency and rely on the suite's
         # crypto stub (tests/conftest.py) so the race tests actually execute.
+        # ``--no-deps`` skips *all* runtime deps, so re-add the pure-Python ones
+        # the import path needs (pyyaml, platformdirs) -- everything declared in
+        # ``project.dependencies`` except the unbuildable cryptography.
         run: |
           python -m pip install -e . --no-deps
-          python -m pip install pytest pyyaml
+          python -m pip install pytest pyyaml platformdirs
       - name: Run race tests under free-threaded build
         run: pytest -q tests/test_matrix_hardening.py -m "race and no_gil"
 


### PR DESCRIPTION
Follow-up to #250.

#250 got the `no-gil race / py3.13t` job **past** the cffi/cryptography build wall — it now actually starts the race tests instead of aborting at install. But it swapped one red for another: switching to `pip install -e . --no-deps` to skip the unbuildable `cryptography` also dropped `platformdirs`, which `pyisolate.bpf.manager` imports on the `Supervisor()`/`spawn` path. So the job now fails with:

```
ModuleNotFoundError: No module named 'platformdirs'
  pyisolate/bpf/manager.py:17: from platformdirs import user_cache_dir
FAILED tests/test_matrix_hardening.py::test_spawn_and_exec_race_under_parallel_load
```

(Genuine progress — it reached test execution — but still red.)

## Fix
Re-add `platformdirs` to the explicit install so it mirrors the full runtime dependency set (`pyyaml`, `cryptography`, `platformdirs`) **minus** the unbuildable `cryptography`, which the `tests/conftest.py` stub already provides under the free-threaded build.

## Why this is the complete list
An `import pyisolate` + `spawn` + `exec` audit of `sys.modules` shows the only third-party top-level modules the path pulls in are:
- `cryptography` → stubbed by `tests/conftest.py` on 3.13t
- `platformdirs` → added here
- `yaml` (pyyaml) → already installed

Everything else imported is stdlib or editable-install/setuptools machinery. With these three covered, the `race and no_gil` selection runs to completion.

The job stays `continue-on-error: true`, so a real free-threaded race is reported without blocking — the point being that the job now does its job instead of erroring before any test runs.

## Testing
- `pytest -q tests/test_matrix_hardening.py -m "race and no_gil"` passes locally (`1 passed, 7 deselected`).
- `ci.yml` validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_