### PR TITLE
Decrypt inside the recv lock in SecureChannel

### DIFF
--- a/pyisolate/broker/channel.py
+++ b/pyisolate/broker/channel.py
@@ -113,7 +113,14 @@ class SecureChannel:
             if length < 1:
                 raise ValueError("declared frame length is zero")
             frame = self._recv_exact(length)
-        return self._broker.unframe(frame)
+            # Decrypt while still holding the lock. ``unframe`` validates the
+            # receive nonce counter in strictly increasing order, so it must run
+            # in the same order frames were read off the wire. Releasing the lock
+            # before decrypting would let a second reader that pulled the *next*
+            # frame call ``unframe`` first, present an out-of-order counter, and
+            # trip a spurious replay/decrypt failure that drops a valid message.
+            # This mirrors the send path, which holds the lock across framing.
+            return self._broker.unframe(frame)
 
     def _recv_exact(self, count: int) -> bytes:
         """Read exactly ``count`` bytes or raise :class:`EOFError`."""

--- a/tests/test_secure_channel.py
+++ b/tests/test_secure_channel.py
@@ -1,6 +1,7 @@
 """Tests for the length-framed :class:`SecureChannel` transport wiring."""
 
 import threading
+import time
 
 import pytest
 from cryptography.hazmat.primitives import serialization
@@ -194,3 +195,61 @@ def test_concurrent_senders_preserve_frame_integrity():
 
     assert not errors
     assert sorted(received) == sorted(f"payload-{i:03d}".encode() for i in range(count))
+
+
+def test_concurrent_recv_decrypts_in_counter_order():
+    # ``unframe`` validates the receive nonce counter in strictly increasing
+    # order, so decryption must happen in the same order frames are read off the
+    # wire. This forces the hazardous interleave deterministically: reader "a"
+    # takes the recv lock, reads frame 0, and parks inside ``unframe``; reader
+    # "b" is then started and tries to read frame 1. If decryption ran outside
+    # the recv lock, reader "b" would unframe frame 1 while the broker still
+    # expects frame 0 and raise a spurious replay/decrypt error, silently
+    # dropping a valid message.
+    client, server = secure_channel_pair()
+    client.send_message(b"first")
+    client.send_message(b"second")
+
+    real_unframe = server._broker.unframe
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    seen = []
+    seen_lock = threading.Lock()
+
+    def gated_unframe(frame):
+        with seen_lock:
+            index = len(seen)
+            seen.append(frame)
+        if index == 0:
+            # Announce that the first decrypt has begun, then wait so a second
+            # reader has a chance to overtake us.
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+        return real_unframe(frame)
+
+    server._broker.unframe = gated_unframe
+
+    results = {}
+
+    def reader(key):
+        try:
+            results[key] = server.recv_message()
+        except Exception as exc:  # noqa: BLE001 - recorded for the assertion
+            results[key] = exc
+
+    reader_a = threading.Thread(target=reader, args=("a",))
+    reader_a.start()
+    # Reader "a" has now read frame 0 and is parked inside the first unframe.
+    assert first_entered.wait(timeout=5)
+
+    reader_b = threading.Thread(target=reader, args=("b",))
+    reader_b.start()
+    # Give reader "b" the opportunity to read frame 1 and reach unframe (with the
+    # bug) or block on the recv lock (once fixed).
+    time.sleep(0.2)
+    release_first.set()
+    reader_a.join(timeout=5)
+    reader_b.join(timeout=5)
+
+    assert results.get("a") == b"first"
+    assert results.get("b") == b"second"


### PR DESCRIPTION
## Summary
`SecureChannel._recv_lock` serialises the **wire reads** so frames are pulled off the transport in counter order — but `recv_message` decrypted the frame *after* the `with self._recv_lock:` block exited:

```python
        frame = self._recv_exact(length)
    return self._broker.unframe(frame)   # ← outside the lock
```

`CryptoBroker.unframe` validates the receive nonce counter in **strictly increasing order**. So two concurrent readers can read frames N and N+1 in order under the lock, then have the OS schedule the `unframe` of N+1 *before* N. The broker sees an out-of-order counter and raises a spurious `ValueError("replay detected")` / `"decryption failed"`, **silently dropping a valid, authenticated message**.

This is the multi-tenant transport layer, and `_recv_lock` exists specifically to support concurrent receivers — so the hazard is real for exactly the workload the lock was added for. The send path already documents and handles the symmetric requirement (it holds the lock across both framing/counter-assignment and the wire write); the receive side was missing the mirror.

## Fix
Move `unframe` inside the `with self._recv_lock:` block so decryption runs in the same order frames are read off the wire.

## Testing
- New deterministic regression test `test_concurrent_recv_decrypts_in_counter_order`: parks the first reader inside `unframe` and releases a second reader to overtake it.
  - **Before the fix:** fails with `AssertionError: assert ValueError('replay detected') == b'second'` (reader "b" dropped a valid frame).
  - **After the fix:** passes (the second reader blocks on the recv lock until the first fully completes).
- Full non-soak suite: `382 passed, 2 skipped`.
- `black`/`isort`/`flake8` clean; pylint 9.67/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_