### PR TITLE
Snapshot _start_time in SandboxThread.stats to avoid a metrics-crashing race

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -1483,9 +1483,16 @@ class SandboxThread(threading.Thread):
 
     @property
     def stats(self):
+        # ``stats`` is read from other threads (the metrics scraper, supervisor)
+        # while the sandbox thread concurrently flips ``_start_time`` between a
+        # float and ``None`` in its run loop. Snapshot it once so the value
+        # cannot change between the ``is not None`` check and the subtraction --
+        # otherwise a concurrent reset turns the subtraction into
+        # ``monotonic() - None`` and raises ``TypeError``, aborting the scrape.
+        start_time = self._start_time
         cpu_ms = self._cpu_time
-        if self._start_time is not None:
-            cpu_ms += (time.monotonic() - self._start_time) * 1000
+        if start_time is not None:
+            cpu_ms += (time.monotonic() - start_time) * 1000
         cost = cpu_ms * 0.0001 + self._mem_peak * 1e-9
         return Stats(
             cpu_ms=cpu_ms,

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 import pyisolate as iso
+from pyisolate.runtime import thread as thread_mod
 
 
 def test_stats_property_updates():
@@ -35,3 +36,34 @@ def test_cpu_ms_stops_after_failed_exec():
         assert second == pytest.approx(first, abs=0.1)
     finally:
         sb.close()
+
+
+def test_stats_tolerates_concurrent_start_time_reset(monkeypatch):
+    # `stats` is read from other threads (the metrics scraper, the supervisor)
+    # while the sandbox thread flips `_start_time` between a float and None in
+    # its run loop. Snapshotting it must keep the computation from racing into
+    # `monotonic() - None`, which raised TypeError and aborted the whole scrape.
+    sb = object.__new__(thread_mod.SandboxThread)
+    sb._cpu_time = 7.0
+    sb._start_time = 123.0
+    sb._mem_peak = 0
+    sb._latency = {}
+    sb._latency_sum = 0.0
+    sb._errors = 0
+    sb._ops = 0
+    sb._denial_events = []
+
+    # Emulate the run loop nulling `_start_time` *during* the stats computation:
+    # the first `monotonic()` call inside `stats` resets it, exactly as a
+    # concurrent reset on the sandbox thread would between the two reads.
+    def resetting_monotonic():
+        sb._start_time = None
+        return 200.0
+
+    monkeypatch.setattr(thread_mod.time, "monotonic", resetting_monotonic)
+
+    # Must not raise. Before the fix this raised:
+    #   TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
+    result = sb.stats
+    # The snapshotted start (123.0) is used rather than the reset None.
+    assert result.cpu_ms == pytest.approx(7.0 + (200.0 - 123.0) * 1000)


### PR DESCRIPTION
## Summary
`SandboxThread.stats` (and `profile()`, which delegates to it) is read from **other** threads — the Prometheus metrics scraper iterating live sandboxes (`observability/metrics.py`), the supervisor, tests — while the sandbox thread concurrently flips `self._start_time` between a float and `None` in its run loop. The property read `_start_time` **twice**:

```python
        cpu_ms = self._cpu_time
        if self._start_time is not None:          # read #1
            cpu_ms += (time.monotonic() - self._start_time) * 1000   # read #2
```

If the sandbox thread sets `_start_time = None` between read #1 and read #2, the subtraction becomes `monotonic() - None` and raises:

```
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```

The metrics scrape has no `try/except` around the per-sandbox `stats` call, so a single racy scrape aborts the **entire** Prometheus render for all sandboxes. And `list_active()` returns only *running* sandboxes — i.e. exactly the ones with a non-`None` `_start_time` at risk of the flip.

## Fix
Snapshot `_start_time` into a local once and use it for both the check and the subtraction. A `None` captured at read time simply yields the last accumulated `_cpu_time`, which is correct.

The structurally identical check in `_trace_guard` is intentionally left unchanged — it only ever runs *on the sandbox thread itself*, so `_start_time` cannot change underneath it.

## Testing
- New deterministic regression test `test_stats_tolerates_concurrent_start_time_reset`: nulls `_start_time` during the stats computation (via the first `monotonic()` call), exactly as a concurrent reset would between the two reads.
  - **Before the fix:** `TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'` at the subtraction.
  - **After the fix:** passes; the snapshotted start is used.
- Full non-soak suite: `382 passed, 2 skipped`.
- `isort`/`black`/`flake8` clean; pylint 8.51/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_