### PR TITLE
Reject contradictory rule actions in canonical policy buckets

### DIFF
--- a/pyisolate/policy/model.py
+++ b/pyisolate/policy/model.py
@@ -197,23 +197,53 @@ def _validate_imports(value: Any) -> tuple[str, ...]:
     return tuple(imports)
 
 
+def _canonical_fs_rules(
+    value: Any, field_name: str, *, expected: str
+) -> tuple[FilesystemRule, ...]:
+    rules: list[FilesystemRule] = []
+    for index, raw in enumerate(_require_mapping_list(value, field_name)):
+        rule = FilesystemRule(**raw)
+        # Enforcement keys off the bucket, not the rule action, so a rule whose
+        # action contradicts its bucket (e.g. a ``deny`` rule under ``allow_fs``)
+        # would silently be treated as the bucket's behavior -- turning a deny
+        # into an allow. Reject the contradiction instead of mis-enforcing it.
+        if rule.action != expected:
+            raise ValueError(
+                f"{field_name}[{index}] has action {rule.action!r}, "
+                f"but {field_name} only accepts {expected!r} rules"
+            )
+        rules.append(rule)
+    return tuple(rules)
+
+
+def _canonical_net_rules(
+    value: Any, field_name: str, *, expected: str
+) -> tuple[NetworkRule, ...]:
+    rules: list[NetworkRule] = []
+    for index, raw in enumerate(_require_mapping_list(value, field_name)):
+        rule = NetworkRule(**raw)
+        if rule.action != expected:
+            raise ValueError(
+                f"{field_name}[{index}] has action {rule.action!r}, "
+                f"but {field_name} only accepts {expected!r} rules"
+            )
+        rules.append(rule)
+    return tuple(rules)
+
+
 def _runtime_policy_from_canonical_mapping(policy: Mapping[str, Any]) -> RuntimePolicy:
     return RuntimePolicy(
-        allow_fs=tuple(
-            FilesystemRule(**rule)
-            for rule in _require_mapping_list(policy.get("allow_fs", []), "allow_fs")
+        allow_fs=_canonical_fs_rules(
+            policy.get("allow_fs", []), "allow_fs", expected="allow"
         ),
-        deny_fs=tuple(
-            FilesystemRule(**rule)
-            for rule in _require_mapping_list(policy.get("deny_fs", []), "deny_fs")
+        deny_fs=_canonical_fs_rules(
+            policy.get("deny_fs", []), "deny_fs", expected="deny"
         ),
-        allow_tcp=tuple(
-            NetworkRule(**rule)
-            for rule in _require_mapping_list(policy.get("allow_tcp", []), "allow_tcp")
+        allow_tcp=_canonical_net_rules(
+            policy.get("allow_tcp", []), "allow_tcp", expected="connect"
         ),
-        deny_tcp=tuple(
-            NetworkRule(**rule)
-            for rule in _require_mapping_list(policy.get("deny_tcp", []), "deny_tcp")
+        deny_tcp=_canonical_net_rules(
+            policy.get("deny_tcp", []), "deny_tcp", expected="deny"
         ),
         imports=_validate_imports(policy.get("imports", [])),
         cpu_ms=_validate_cpu_ms(policy.get("cpu_ms")),

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -742,3 +742,54 @@ def test_resolve_policy_path_deny_rule_remains_effective(tmp_path):
         assert sb._thread.cpu_quota_ms == 25
     finally:
         sb.close()
+
+
+@pytest.mark.parametrize(
+    "bucket, rule",
+    [
+        ("allow_fs", {"action": "deny", "path": "/etc"}),
+        ("allow_tcp", {"action": "deny", "destination": "10.0.0.1:22"}),
+        ("deny_fs", {"action": "allow", "path": "/etc"}),
+        ("deny_tcp", {"action": "connect", "destination": "10.0.0.1:22"}),
+    ],
+)
+def test_canonical_policy_rejects_contradictory_action(bucket, rule):
+    # Enforcement keys off the bucket, not the rule action, so a deny rule under
+    # allow_fs/allow_tcp would otherwise be enforced as an allow (deny -> allow).
+    # The canonical-mapping path must reject the contradiction. Reachable via the
+    # public from_compiled_policy (checkpoint restore / BPF JSON policy).
+    from pyisolate.policy.model import from_compiled_policy
+
+    blob = {"sandboxes": {"s1": {bucket: [rule]}}}
+    with pytest.raises(ValueError, match="only accepts"):
+        from_compiled_policy(blob)
+
+
+def test_canonical_policy_accepts_consistent_actions():
+    # The well-formed counterpart of the rejection test still parses, including
+    # the read/write -> allow access normalization.
+    from pyisolate.policy.model import from_compiled_policy
+
+    rendered = from_compiled_policy(
+        {
+            "sandboxes": {
+                "s1": {
+                    "allow_fs": [
+                        {"action": "allow", "path": "/tmp"},
+                        {"action": "read", "path": "/etc/hosts"},
+                    ],
+                    "deny_fs": [{"action": "deny", "path": "/secret"}],
+                    "allow_tcp": [{"action": "connect", "destination": "1.2.3.4:80"}],
+                    "deny_tcp": [{"action": "deny", "destination": "9.9.9.9:53"}],
+                }
+            }
+        }
+    )
+    rp = rendered.sandboxes["s1"]
+    assert [(r.action, r.access) for r in rp.allow_fs] == [
+        ("allow", "readwrite"),
+        ("allow", "read"),
+    ]
+    assert [r.action for r in rp.deny_fs] == ["deny"]
+    assert [r.action for r in rp.allow_tcp] == ["connect"]
+    assert [r.action for r in rp.deny_tcp] == ["deny"]


### PR DESCRIPTION
## Summary
`_runtime_policy_from_canonical_mapping` placed each rule into the bucket named by its dict key **without checking the rule's action**:

```python
allow_fs=tuple(FilesystemRule(**rule) for rule in _require_mapping_list(policy.get("allow_fs", []), "allow_fs")),
```

`FilesystemRule`/`NetworkRule` accept `action="deny"` as structurally valid, so a rule like `{"action": "deny", "path": "/etc"}` under `allow_fs` was happily stored **in the allow_fs bucket**. Enforcement (`runtime/thread.py`) iterates `allow_fs`/`allow_tcp` and matches on path/destination and access mode only — it **never inspects `rule.action`** — so a `deny` rule smuggled into an allow bucket is enforced as an **ALLOW**. A deny silently becomes a grant.

This path is reachable via the public `from_compiled_policy`, which is used by **checkpoint restore** and **BPF-JSON policy**. The asymmetry is specific to this path: `from_sandbox_policy` (the other entry point) already routes rules by action, so it doesn't have the hole.

### Verified end-to-end (before the fix)
```python
from_compiled_policy({"sandboxes": {"s1": {"allow_fs": [{"action": "deny", "path": "/etc"}]}}})
# -> a sandbox whose allow_fs *grants* /etc
```

## Fix
Validate that each rule's action matches its bucket and raise `ValueError` on a mismatch:

| bucket | required action |
|--------|-----------------|
| `allow_fs` | `allow` (incl. `read`/`write`, which normalize to `allow`) |
| `deny_fs` | `deny` |
| `allow_tcp` | `connect` |
| `deny_tcp` | `deny` |

Legitimate policies are unaffected — including the `read`/`write` → `allow` access normalization and `RuntimePolicy.to_dict()` round-trips (verified).

## Testing
- New parametrized `test_canonical_policy_rejects_contradictory_action` covering all four contradiction cases (deny→allow_fs, deny→allow_tcp, allow→deny_fs, connect→deny_tcp) — each **DID NOT RAISE** before the fix, all raise `ValueError` after.
- New `test_canonical_policy_accepts_consistent_actions` asserting well-formed policies (incl. access normalization) still parse.
- Full non-soak suite: `386 passed, 2 skipped` (no existing fixture relied on the lenient behavior).
- `isort`/`black`/`flake8` clean; pylint 9.61/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_