### PR TITLE
Guard the watchdog against non-numeric quota counters

### DIFF
--- a/pyisolate/watchdog.py
+++ b/pyisolate/watchdog.py
@@ -58,6 +58,18 @@ class ResourceWatchdog(threading.Thread):
             name = event.get("name")
             cpu_ms = event.get("cpu_ms", 0)
             rss = event.get("rss_bytes", 0)
+            # The quota comparisons below run outside their try/except blocks, so
+            # a non-numeric counter (e.g. a malformed ring-buffer event with a
+            # string cpu_ms) would raise TypeError out of run(), killing the
+            # watchdog thread and silently disabling quota enforcement for every
+            # sandbox. Validate up front and skip the event instead.
+            if not isinstance(cpu_ms, (int, float)) or not isinstance(
+                rss, (int, float)
+            ):
+                logger.warning(
+                    "watchdog ignored event with non-numeric counters: %r", event
+                )
+                continue
             active = {t.name: t for t in self._supervisor.get_active_threads()}
             sb = active.get(name)
             if not sb:

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -105,6 +105,66 @@ def test_watchdog_ignores_malformed_event_payloads(caplog):
     assert "watchdog ignored non-mapping event payload" in caplog.text
 
 
+class _QuotaThread:
+    """Minimal active-thread stand-in with quotas so the comparisons run."""
+
+    def __init__(self):
+        self.name = "wd-bad"
+        self.cpu_quota_ms = 10
+        self.mem_quota_bytes = 1024
+        self.enforce_calls = 0
+
+    def enforce_quota_breach(self, *args, **kwargs):
+        self.enforce_calls += 1
+        return True
+
+
+class _ActiveSupervisor:
+    def __init__(self, iterator_factory, threads):
+        self._bpf = _FakeBPF(iterator_factory)
+        self._threads = list(threads)
+
+    def get_active_threads(self):
+        return self._threads
+
+    def quarantine(self, *args, **kwargs):  # pragma: no cover - not reached here
+        pass
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"name": "wd-bad", "cpu_ms": "lots", "rss_bytes": 0},
+        {"name": "wd-bad", "cpu_ms": 0, "rss_bytes": "huge"},
+    ],
+)
+def test_watchdog_survives_non_numeric_counters(event, caplog):
+    from pyisolate.watchdog import ResourceWatchdog
+
+    thread = _QuotaThread()
+
+    def fake_iter():
+        # The malformed event targets a real active sandbox with quotas set, so
+        # it reaches the quota comparison -- where a non-numeric counter used to
+        # raise TypeError out of run() and kill the watchdog thread.
+        yield event
+        while True:
+            time.sleep(0.01)
+            yield {"name": "noop", "cpu_ms": 0, "rss_bytes": 0}
+
+    caplog.set_level("WARNING")
+    wd = ResourceWatchdog(_ActiveSupervisor(fake_iter, [thread]), interval=0.01)
+    wd.start()
+    try:
+        time.sleep(0.08)
+        assert wd.is_alive()
+    finally:
+        wd.stop()
+
+    assert thread.enforce_calls == 0
+    assert "non-numeric counters" in caplog.text
+
+
 def test_watchdog_survives_ring_buffer_iterator_exceptions(caplog):
     from pyisolate.watchdog import ResourceWatchdog
 


### PR DESCRIPTION
## Summary
The watchdog consumes ring-buffer events and enforces CPU/memory quotas. Events were only validated with `isinstance(event, Mapping)` — but a Mapping whose `cpu_ms` or `rss_bytes` is **non-numeric** (e.g. a string) passes that check, and the quota comparisons run *outside* their `try/except` blocks:

```python
            cpu_ms = event.get("cpu_ms", 0)
            rss = event.get("rss_bytes", 0)
            ...
            if sb.cpu_quota_ms is not None and cpu_ms >= sb.cpu_quota_ms:   # line 65, unguarded
            ...
            if sb.mem_quota_bytes is not None and rss >= sb.mem_quota_bytes:  # line 80, unguarded
```

A non-numeric counter raises `TypeError: '>=' not supported between instances of 'str' and 'int'`, which propagates out of `run()`. The watchdog is a `threading.Thread`, so it then **exits permanently** — and CPU/memory quota enforcement (a security control in a multi-tenant sandbox) silently stops for **every** sandbox.

The existing `test_watchdog_ignores_malformed_event_payloads` didn't catch this because its fake supervisor returns no active threads, so events were skipped at the `if not sb: continue` line *before* reaching the comparison.

## Fix
Validate that `cpu_ms` and `rss` are numeric (`int`/`float`) up front; log and skip the malformed event otherwise, keeping the watchdog alive.

## Testing
- New parametrized `test_watchdog_survives_non_numeric_counters` (bad `cpu_ms` and bad `rss_bytes`) drives the event against an **active sandbox stand-in carrying quotas**, so it reaches the comparison.
  - **Before the fix:** both cases raise `TypeError` out of `run()`, the watchdog thread dies, and `assert wd.is_alive()` fails.
  - **After the fix:** the event is logged and skipped, the thread stays alive, and enforcement is never spuriously triggered.
- Full non-soak suite: `390 passed, 2 skipped`.
- `isort`/`black`/`flake8` clean; pylint 9.05/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_