### PR TITLE
Serialize the _child_work counter with a lock

### DIFF
--- a/pyisolate/runtime/thread.py
+++ b/pyisolate/runtime/thread.py
@@ -746,21 +746,26 @@ def _guarded_urandom(n: int) -> bytes:
 def _make_sandbox_thread_class(sandbox: "SandboxThread"):
     class SandboxedThread(threading.Thread):
         def start(self, *args, **kwargs):
-            sandbox._check_child_work_quota()
             original_run = self.run
 
             def _run_with_accounting(*r_args, **r_kwargs):
                 try:
                     return original_run(*r_args, **r_kwargs)
                 finally:
-                    sandbox._child_work = max(0, sandbox._child_work - 1)
+                    sandbox._release_child_work()
 
+            # Reserve the slot (quota check + increment) atomically before the
+            # accounting wrapper is installed, so concurrent starts cannot both
+            # pass the check, the increment cannot be lost against a child
+            # thread's concurrent decrement, and a start that is rejected (or
+            # fails) does not leave a wrapper stacked on self.run.
+            sandbox._reserve_child_work()
             self.run = _run_with_accounting  # type: ignore[assignment]
-            sandbox._child_work += 1
             try:
                 return _ORIG_THREAD_START(self, *args, **kwargs)
             except Exception:
-                sandbox._child_work = max(0, sandbox._child_work - 1)
+                self.run = original_run  # type: ignore[assignment]
+                sandbox._release_child_work()
                 raise
 
     return SandboxedThread
@@ -1197,6 +1202,12 @@ class SandboxThread(threading.Thread):
             enforcement_status=enforcement_status,
         )
         self._reset_runtime_state()
+        # Guards the cross-thread _child_work counter: it is incremented on the
+        # sandbox thread (reserving a slot) and decremented on each child thread
+        # as it finishes, so those read-modify-writes must be serialized -- doubly
+        # so on free-threaded builds where ``+= 1`` is not atomic. Created once
+        # here (not in _reset_runtime_state) so it survives warm-thread reuse.
+        self._child_work_lock = threading.Lock()
         self._tenant: str | None = None
         self._tenant_quota: int | None = None
         self._tenant_quota_reserved = False
@@ -1307,9 +1318,20 @@ class SandboxThread(threading.Thread):
         if self.open_files_max is not None and self._open_files >= self.open_files_max:
             raise errors.OpenFilesExceeded()
 
-    def _check_child_work_quota(self) -> None:
-        if self.child_work_max is not None and self._child_work >= self.child_work_max:
-            raise errors.ChildWorkExceeded()
+    def _reserve_child_work(self) -> None:
+        """Atomically enforce the child-work quota and claim a slot."""
+        with self._child_work_lock:
+            if (
+                self.child_work_max is not None
+                and self._child_work >= self.child_work_max
+            ):
+                raise errors.ChildWorkExceeded()
+            self._child_work += 1
+
+    def _release_child_work(self) -> None:
+        """Atomically release a previously reserved child-work slot."""
+        with self._child_work_lock:
+            self._child_work = max(0, self._child_work - 1)
 
     def _trace_guard(self, frame, event, arg):
         if self.wall_time_ms is None:

--- a/tests/test_thread_quota.py
+++ b/tests/test_thread_quota.py
@@ -1,4 +1,5 @@
 import signal
+import threading
 
 import pytest
 
@@ -162,3 +163,78 @@ def test_child_work_quota_hard_stop():
         assert sb.termination_reason == "child_work_exceeded"
     finally:
         sb.stop()
+
+
+def test_reserve_release_child_work_contract():
+    # The atomic reserve/release pair enforces the quota and floors at zero.
+    sb = thread.SandboxThread("rr", child_work_max=2)
+    sb._reserve_child_work()
+    sb._reserve_child_work()
+    assert sb._child_work == 2
+    with pytest.raises(errors.ChildWorkExceeded):
+        sb._reserve_child_work()
+    sb._release_child_work()
+    assert sb._child_work == 1
+    sb._reserve_child_work()  # a freed slot can be reused
+    assert sb._child_work == 2
+    for _ in range(5):  # release never drives the counter negative
+        sb._release_child_work()
+    assert sb._child_work == 0
+
+
+def test_child_work_counter_is_mutated_only_under_its_lock():
+    # The counter is incremented on the sandbox thread (start) and decremented on
+    # each child thread (completion); those read-modify-writes must be serialized
+    # by _child_work_lock or they race and lose updates. Rather than chase the
+    # rare lost update (the inline += is "mostly" atomic under the GIL, so a
+    # natural-race test is unreliable), assert the invariant directly: every
+    # mutation of _child_work must happen while _child_work_lock is held. Driving
+    # real child-thread starts through the inline, unlocked accounting trips this.
+    sb = thread.SandboxThread("locked", child_work_max=None)
+    sandboxed_cls = thread._make_sandbox_thread_class(sb)
+    lock = sb._child_work_lock
+    backing = {"value": sb._child_work}
+    violations: list[str] = []
+
+    class _Probe(type(sb)):
+        @property
+        def _child_work(self):
+            return backing["value"]
+
+        @_child_work.setter
+        def _child_work(self, value):
+            # A non-reentrant lock that acquires here means no one (including the
+            # current thread) holds it -- i.e. this mutation is happening outside
+            # the lock, which is the bug.
+            if lock.acquire(blocking=False):
+                lock.release()
+                violations.append(f"unlocked write -> {value}")
+            backing["value"] = value
+
+    sb.__class__ = _Probe
+
+    starters = 4
+    per_starter = 25
+    ready = threading.Barrier(starters)
+    errors_seen: list[BaseException] = []
+
+    def starter() -> None:
+        try:
+            ready.wait()
+            children = [sandboxed_cls(target=lambda: None) for _ in range(per_starter)]
+            for child in children:
+                child.start()
+            for child in children:
+                child.join()
+        except BaseException as exc:  # pragma: no cover - surfaced via list
+            errors_seen.append(exc)
+
+    workers = [threading.Thread(target=starter) for _ in range(starters)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert not errors_seen
+    assert violations == []
+    assert backing["value"] == 0


### PR DESCRIPTION
## Summary
The child-work quota counter `_child_work` was incremented on the **sandbox thread** (in `SandboxedThread.start`) and decremented on **each child thread** (in the run wrapper's `finally`), with no shared lock:

```python
            def _run_with_accounting(*r_args, **r_kwargs):
                try:
                    return original_run(*r_args, **r_kwargs)
                finally:
                    sandbox._child_work = max(0, sandbox._child_work - 1)   # child thread
            ...
            sandbox._child_work += 1                                        # sandbox thread
```

Those read-modify-writes race: an increment for a starting child and a decrement for a finishing one can interleave and **lose an update**, leaving `_child_work` permanently skewed. A downward skew lets a guest exceed `child_work_max`; the `max(0, …)` only masks the negative direction. On the **free-threaded builds this project targets**, the hazard is worse — `+= 1` isn't atomic at all. The separate quota *check* (line 749) and *increment* (line 759) were also a check-then-act TOCTOU, so two concurrent starts could both pass the check.

## Fix
- Add a per-thread `_child_work_lock` (created in `__init__`, so it survives warm-thread reuse).
- Route accounting through atomic helpers: `_reserve_child_work()` (quota check **and** increment under the lock) and `_release_child_work()` (floored decrement under the lock).
- Reserve *before* installing the run wrapper, so a rejected (over-quota) or failed start cannot stack accounting wrappers on `self.run`; restore the original `run` on start failure.

Existing behavior is preserved: `child_work_max=0` still rejects the first child with `ChildWorkExceeded`; `child_work_max=1` still allows one concurrent child.

## Testing
- `test_reserve_release_child_work_contract` — deterministic: quota enforcement, floor-at-zero, and slot reuse.
- `test_child_work_counter_is_mutated_only_under_its_lock` — asserts the invariant directly: every mutation of `_child_work` must happen while `_child_work_lock` is held (a non-reentrant `acquire(blocking=False)` probe in a counter setter). The natural lost update is "mostly" hidden by the GIL and so makes an unreliable test; this invariant instead **fails 10/10 on the old inline, unlocked accounting and passes on the fix**, and also catches a partial revert (lock kept, `start()` reverted).
- Existing `test_child_work_quota_hard_stop` and the `child_work_max=1` test still pass.
- Full non-soak suite: `390 passed, 2 skipped`.
- `isort`/`black`/`flake8` clean; pylint 8.53/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_