### PR TITLE
Return a borrowed warm thread to the pool on spawn failure

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -321,6 +321,7 @@ class Supervisor:
             cg_path = None
             temp_dir = None
             thread = None
+            reused_warm = False
             try:
                 cg_status = cgroup.create(
                     name, cpu_ms, mem_bytes, mode=self._rollout_mode
@@ -342,6 +343,7 @@ class Supervisor:
                 }
                 if self._warm_pool:
                     thread = self._warm_pool.pop()
+                    reused_warm = True
                     # Intentionally mirrors Sandbox.reset by sharing reset_config.
                     thread.reset(
                         name,
@@ -382,7 +384,14 @@ class Supervisor:
                 )
             except Exception:
                 self._sandboxes.pop(name, None)
-                if thread is not None and thread.is_alive():
+                if reused_warm and thread is not None and thread.is_alive():
+                    # Return the borrowed warm thread to the pool rather than
+                    # destroying it. The warm pool is only filled at startup and
+                    # never replenished, so stopping a reused thread on every
+                    # failed spawn would permanently shrink it. The next spawn
+                    # that pops it calls reset() again, reconfiguring it cleanly.
+                    self._warm_pool.append(thread)
+                elif thread is not None and thread.is_alive():
                     thread.stop()
                 cgroup.delete(cg_path)
                 if temp_dir is not None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -121,6 +121,32 @@ def test_shutdown_clears_warm_pool():
     assert sup._warm_pool == []
 
 
+def test_failed_spawn_returns_borrowed_warm_thread(monkeypatch):
+    # The warm pool is filled only at startup and never replenished, so a spawn
+    # that borrows a warm thread and then fails must return it to the pool rather
+    # than stop it -- otherwise every failed spawn permanently shrinks the pool.
+    from pyisolate import recovery
+
+    sup = iso.Supervisor(warm_pool=1)
+    try:
+        warm = sup._warm_pool[0]
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated recovery failure")
+
+        # update_sandbox runs after the warm thread has been popped and reset.
+        monkeypatch.setattr(recovery, "update_sandbox", boom)
+
+        with pytest.raises(RuntimeError, match="simulated recovery failure"):
+            sup.spawn("warm-fail")
+
+        assert len(sup._warm_pool) == 1
+        assert sup._warm_pool[0] is warm
+        assert warm.is_alive()
+    finally:
+        sup.shutdown()
+
+
 def test_shutdown_requires_root():
     sup = iso.Supervisor()
     try:


### PR DESCRIPTION
## Summary
When `spawn` reuses a thread from the warm pool and a later step fails, the rollback destroyed the borrowed thread without returning it:

```python
                if self._warm_pool:
                    thread = self._warm_pool.pop()      # borrow
                    ...
                recovery.update_sandbox(...)            # can raise
            except Exception:
                ...
                if thread is not None and thread.is_alive():
                    thread.stop()                       # killed, never returned
```

The warm pool is filled **only at startup** (`__init__`) and never replenished, so every failed spawn that reused a warm thread permanently shrank the pool — steadily degrading the warm-start optimization until it's gone.

## Fix
Track whether the thread was borrowed from the warm pool (`reused_warm`) and, on rollback, return it to `_warm_pool` when it's still alive instead of stopping it. The next spawn that pops it calls `reset()` again, reconfiguring it cleanly — the same operation a fresh borrow performs. Non-warm (freshly created) threads are still stopped as before.

## Testing
- New `test_failed_spawn_returns_borrowed_warm_thread`: with `warm_pool=1` and `recovery.update_sandbox` patched to raise (it runs *after* the warm thread is popped and reset), the failed spawn now leaves the warm thread back in the pool, alive.
  - **Before the fix:** `len(sup._warm_pool)` drops to `0` (thread stopped) → assertion fails.
  - **After the fix:** pool still holds the same live thread.
- Full non-soak suite: `393 passed, 2 skipped`.
- `isort`/`black`/`flake8` clean; pylint 8.85/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_