### PR TITLE
Handle short writes in IOUring.write

### DIFF
--- a/pyisolate/broker/uring.py
+++ b/pyisolate/broker/uring.py
@@ -44,13 +44,34 @@ class IOUring:
         return bytes(buf[:res])
 
     async def write(self, fd: int, data: bytes) -> int:
-        """Write ``data`` to ``fd`` asynchronously."""
+        """Write all of ``data`` to ``fd``, looping over short writes.
+
+        A single underlying write (``os.write`` or one ``io_uring`` submission)
+        may transfer fewer bytes than requested when the destination buffer is
+        full, so loop until the whole buffer is delivered. This keeps callers
+        whose contract is "write every byte" -- e.g. a framed channel's ``send``
+        -- from silently dropping the tail of a frame. Returns the number of
+        bytes written (only ``< len(data)`` if the transport stops accepting).
+        """
+        view = memoryview(data)
+        total = 0
+        while True:
+            written = await self._write_once(fd, view[total:])
+            total += written
+            # Stop once the buffer is drained, or if a write made no progress
+            # (guards against an empty buffer and against a stalled transport).
+            if total >= len(view) or written <= 0:
+                break
+        return total
+
+    async def _write_once(self, fd: int, view: memoryview) -> int:
         if self._ring is None:
             loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(None, os.write, fd, data)
+            return await loop.run_in_executor(None, os.write, fd, view)
 
+        chunk = view.tobytes()
         sqe = self._ring.get_sqe()
-        uring.io_uring_prep_write(sqe, fd, data, len(data), 0)
+        uring.io_uring_prep_write(sqe, fd, chunk, len(chunk), 0)
         self._ring.submit_and_wait(1)
         cqe = self._ring.wait_cqe()
         return self._complete(cqe)

--- a/tests/test_uring.py
+++ b/tests/test_uring.py
@@ -86,3 +86,71 @@ def test_io_uring_write_error_propagates(monkeypatch):
 
     assert excinfo.value.errno == errno.EPIPE
     assert ring.seen
+
+
+def test_io_uring_write_loops_over_short_writes(monkeypatch):
+    # Each io_uring submission reports a short byte count; write() must keep
+    # submitting the remaining bytes until the whole buffer is delivered.
+    payload = b"abcdefghij"  # 10 bytes
+    counts = iter([4, 4, 2])
+    prep_lengths = []
+
+    class DummyCQE:
+        def __init__(self, res):
+            self.res = res
+
+    class DummyRing:
+        def setup(self, entries):
+            pass
+
+        def get_sqe(self):
+            return object()
+
+        def submit_and_wait(self, n):
+            return None
+
+        def wait_cqe(self):
+            return DummyCQE(next(counts))
+
+        def cqe_seen(self, cqe):
+            return None
+
+    ring = DummyRing()
+
+    class StubUring:
+        def __init__(self):
+            self.io_uring = lambda: ring
+
+        @staticmethod
+        def io_uring_prep_read(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def io_uring_prep_write(sqe, fd, buf, nbytes, offset):
+            prep_lengths.append(nbytes)
+
+    monkeypatch.setattr(uring_mod, "uring", StubUring())
+
+    io = IOUring()
+    total = asyncio.run(io.write(7, payload))
+
+    assert total == len(payload)
+    # Full buffer first, then only the bytes left after each short write.
+    assert prep_lengths == [10, 6, 2]
+
+
+def test_io_uring_write_delivers_all_bytes_through_pipe():
+    # End-to-end via the os.write fallback: a multi-byte payload round-trips.
+    rfd, wfd = os.pipe()
+    ring = IOUring()
+
+    async def _io():
+        written = await ring.write(wfd, b"length-framed")
+        os.close(wfd)
+        data = await ring.read(rfd, 13)
+        os.close(rfd)
+        return written, data
+
+    written, data = asyncio.run(_io())
+    assert written == 13
+    assert data == b"length-framed"


### PR DESCRIPTION
## Summary
`IOUring.write` issued a **single** `os.write` / `io_uring` submission and returned its byte count:

```python
        if self._ring is None:
            return await loop.run_in_executor(None, os.write, fd, data)   # may write < len(data)
        ...
        return self._complete(cqe)   # returns bytes written, possibly < len(data)
```

On a pipe or socket with a full kernel buffer, a single write can transfer **fewer** bytes than requested. The docstring promised to "write `data`", and the module's intended consumer is a framed channel whose `send` callable must write **every** byte (`SecureChannel`'s `send` contract). A short write there would silently truncate a frame and permanently desynchronise the length-prefixed stream. Latent today (no caller wires the two together yet), but a real landmine.

## Fix
Loop over the buffer until all bytes are delivered, in both the `io_uring` and `os.write` fallback paths. The loop is do-while, so an empty write still issues exactly one operation (preserving error propagation), and it stops early if a write makes no progress (guards against a stalled transport).

## Testing
- New `test_io_uring_write_loops_over_short_writes`: a stubbed ring reporting short counts `[4, 4, 2]` for a 10-byte payload asserts `write()` re-submits only the **remaining** bytes each round (`prep_lengths == [10, 6, 2]`) and returns the full length.
  - **Before the fix:** returns `4` (the tail is dropped) → assertion fails.
- New `test_io_uring_write_delivers_all_bytes_through_pipe`: end-to-end `os.write`-fallback round-trip.
- The existing `test_io_uring_write_error_propagates` (empty write) still passes.
- Full non-soak suite: `394 passed, 2 skipped`.
- `isort`/`black`/`flake8` clean; pylint 9.81/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_