### PR TITLE
Clean up the temp file in from_yaml_dict when serialization fails

### DIFF
--- a/pyisolate/policy/model.py
+++ b/pyisolate/policy/model.py
@@ -353,13 +353,16 @@ def from_yaml_dict(data: Mapping[str, Any]) -> RuntimePolicySet:
     except ModuleNotFoundError:  # pragma: no cover - package fallback
         from . import yaml  # type: ignore[attr-defined]
 
-    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yml") as tmp:
-        if hasattr(yaml, "safe_dump"):
-            yaml.safe_dump(dict(data), tmp)
-        else:  # pragma: no cover - only used with the minimal fallback parser
-            tmp.write(str(dict(data)))
-        tmp_path = tmp.name
+    tmp = tempfile.NamedTemporaryFile("w", delete=False, suffix=".yml")
+    # Capture the name before writing so cleanup runs even if the dump raises;
+    # delete=False means a failed serialization would otherwise leak the file.
+    tmp_path = tmp.name
     try:
+        with tmp:
+            if hasattr(yaml, "safe_dump"):
+                yaml.safe_dump(dict(data), tmp)
+            else:  # pragma: no cover - only used with the minimal fallback parser
+                tmp.write(str(dict(data)))
         return from_compiled_policy(compile_policy(tmp_path))
     finally:
         Path(tmp_path).unlink(missing_ok=True)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -793,3 +793,32 @@ def test_canonical_policy_accepts_consistent_actions():
     assert [r.action for r in rp.deny_fs] == ["deny"]
     assert [r.action for r in rp.allow_tcp] == ["connect"]
     assert [r.action for r in rp.deny_tcp] == ["deny"]
+
+
+def test_from_yaml_dict_cleans_up_tempfile_on_dump_error(tmp_path, monkeypatch):
+    # from_yaml_dict writes a delete=False temp file before compiling it. If the
+    # YAML serialization raises, the file must still be removed rather than
+    # leaked once per failure.
+    import tempfile
+
+    import yaml
+
+    from pyisolate.policy.model import from_yaml_dict
+
+    real_named_temp = tempfile.NamedTemporaryFile
+
+    def named_temp_in_tmp_path(*args, **kwargs):
+        kwargs.setdefault("dir", str(tmp_path))
+        return real_named_temp(*args, **kwargs)
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", named_temp_in_tmp_path)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("dump failed")
+
+    monkeypatch.setattr(yaml, "safe_dump", boom)
+
+    with pytest.raises(RuntimeError, match="dump failed"):
+        from_yaml_dict({"version": "1.0", "sandboxes": {}})
+
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
`from_yaml_dict` created a `delete=False` temporary file and only recorded its name **after** the YAML dump:

```python
    with tempfile.NamedTemporaryFile("w", delete=False, suffix=".yml") as tmp:
        if hasattr(yaml, "safe_dump"):
            yaml.safe_dump(dict(data), tmp)      # if this raises...
        ...
        tmp_path = tmp.name                       # ...never runs
    try:
        return from_compiled_policy(compile_policy(tmp_path))
    finally:
        Path(tmp_path).unlink(missing_ok=True)
```

If `safe_dump` raises, the `with` block exits and the exception escapes **before** the `try/finally` is ever entered — so the `delete=False` file is leaked (one `tmp*.yml` per failure), and `tmp_path` is left unbound.

## Fix
Capture the file name immediately after creating it, and wrap both the dump and the compile in a single `try/finally`, so the temp file is always removed whether the dump fails, the compile fails, or it succeeds.

## Testing
- New `test_from_yaml_dict_cleans_up_tempfile_on_dump_error`: points `NamedTemporaryFile` at a scratch dir, makes `yaml.safe_dump` raise, and asserts the dir is empty afterward.
  - **Before the fix:** a `tmp*.yml` file is left behind → assertion fails.
  - **After the fix:** the dir is empty.
- Full non-soak suite: `393 passed, 2 skipped`.
- `isort`/`black`/`flake8` clean; pylint 9.61/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_