### PR TITLE
Validate sandbox names in cgroup/recovery path helpers

### DIFF
--- a/pyisolate/cgroup.py
+++ b/pyisolate/cgroup.py
@@ -88,6 +88,24 @@ def _failure(status: CgroupEnforcement, message: str) -> CgroupEnforcement:
     return failed
 
 
+def _validate_name(name: str) -> str:
+    """Reject names that would escape the managed cgroup root.
+
+    Callers (``Supervisor.spawn``) already constrain names, but ``create`` is a
+    public helper; a name containing a path separator or ``..`` would resolve
+    outside ``_BASE``, so guard against it here as defense in depth.
+    """
+
+    if not isinstance(name, str) or not name:
+        raise ValueError("cgroup name must be a non-empty string")
+    # Only reject what actually escapes a single path component on Linux: the
+    # path separator, the parent/current refs, and an embedded NUL. Otherwise
+    # weird-but-contained names (which the metrics layer sanitizes) are allowed.
+    if name in {".", ".."} or "/" in name or "\x00" in name:
+        raise ValueError(f"unsafe cgroup name: {name!r}")
+    return name
+
+
 def create(
     name: str,
     cpu_ms: int | None = None,
@@ -105,6 +123,7 @@ def create(
     if mode not in {"dev", "compatibility", "hardened"}:
         raise ValueError(f"invalid rollout mode: {mode}")
 
+    name = _validate_name(name)
     path = _BASE / name
     try:
         path.mkdir(parents=True, exist_ok=True)

--- a/pyisolate/recovery.py
+++ b/pyisolate/recovery.py
@@ -112,10 +112,29 @@ def drop_sandbox(name: str) -> None:
         _write_registry(sandboxes)
 
 
+def _validate_name(name: str) -> str:
+    """Reject names that would escape the managed temp root.
+
+    ``Supervisor.spawn`` already constrains names, but these helpers are public;
+    a name containing a path separator or ``..`` would resolve outside
+    ``_TEMP_ROOT`` -- and for ``cleanup_temp_dir`` would ``rmtree`` an arbitrary
+    directory -- so guard against it here as defense in depth.
+    """
+
+    if not isinstance(name, str) or not name:
+        raise ValueError("sandbox name must be a non-empty string")
+    # Only reject what actually escapes a single path component on Linux: the
+    # path separator, the parent/current refs, and an embedded NUL. Otherwise
+    # weird-but-contained names (which the metrics layer sanitizes) are allowed.
+    if name in {".", ".."} or "/" in name or "\x00" in name:
+        raise ValueError(f"unsafe sandbox name: {name!r}")
+    return name
+
+
 def allocate_temp_dir(name: str) -> Path:
     """Allocate a deterministic per-sandbox temp directory."""
 
-    path = _TEMP_ROOT / name
+    path = _TEMP_ROOT / _validate_name(name)
     path.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -126,7 +145,7 @@ def cleanup_temp_dir(path_or_name: str | Path) -> None:
     if isinstance(path_or_name, Path):
         path = path_or_name
     else:
-        path = _TEMP_ROOT / path_or_name
+        path = _TEMP_ROOT / _validate_name(path_or_name)
     shutil.rmtree(path, ignore_errors=True)
 
 

--- a/tests/test_cgroup.py
+++ b/tests/test_cgroup.py
@@ -143,3 +143,12 @@ def test_create_reports_controller_enforcement(tmp_path, monkeypatch):
     assert status.memory is True
     assert status.enforced is True
     assert status.errors == ()
+
+
+@pytest.mark.parametrize("bad", ["../escaped", "a/b", "..", ".", "", "a/../b"])
+def test_create_rejects_unsafe_names(monkeypatch, tmp_path, bad):
+    monkeypatch.setattr(cgroup, "_BASE", tmp_path)
+    with pytest.raises(ValueError):
+        cgroup.create(bad)
+    # Rejected before any mkdir, so nothing is created inside or outside _BASE.
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -5,6 +5,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import pytest
+
 import pyisolate as iso
 from pyisolate import cgroup, recovery
 from pyisolate.bpf.manager import BPFManager
@@ -108,3 +110,29 @@ def test_cleanup_drops_registry_and_temp_dir_for_dead_sandbox(tmp_path, monkeypa
         assert not temp_dir.exists()
     finally:
         sup.shutdown()
+
+
+@pytest.mark.parametrize("bad", ["../escaped", "a/b", "..", ".", "", "a/../b"])
+def test_allocate_temp_dir_rejects_unsafe_names(monkeypatch, tmp_path, bad):
+    monkeypatch.setattr(recovery, "_TEMP_ROOT", tmp_path)
+    with pytest.raises(ValueError):
+        recovery.allocate_temp_dir(bad)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_cleanup_temp_dir_rejects_escaping_name(monkeypatch, tmp_path):
+    temp_root = tmp_path / "root"
+    temp_root.mkdir()
+    monkeypatch.setattr(recovery, "_TEMP_ROOT", temp_root)
+
+    # A directory outside the temp root must not be deletable via a traversal
+    # name -- cleanup_temp_dir calls shutil.rmtree on the joined path.
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "data.txt").write_text("keep me")
+
+    with pytest.raises(ValueError):
+        recovery.cleanup_temp_dir("../victim")
+
+    assert victim.exists()
+    assert (victim / "data.txt").read_text() == "keep me"


### PR DESCRIPTION
## Summary
`cgroup.create`, `recovery.allocate_temp_dir`, and `recovery.cleanup_temp_dir` built filesystem paths by joining a caller-supplied name onto the managed root with **no validation**:

```python
    path = _BASE / name          # cgroup.create
    path = _TEMP_ROOT / name      # recovery.allocate_temp_dir / cleanup_temp_dir
```

A name containing a path separator or `..` resolves **outside** the managed root. For `cleanup_temp_dir` — which calls `shutil.rmtree` on the joined path — a traversal name like `../victim` could delete an arbitrary directory.

`Supervisor.spawn` already constrains names, so these public helpers aren't reachable with a hostile name through the documented API — this is **defense-in-depth** on the exported helpers.

## Fix
Reject names that escape a single path component: empty, `.`, `..`, a `/` separator, or an embedded NUL.

The validation is deliberately **narrow**. The system intentionally tolerates weird-but-contained names — `test_export_sanitizes_sandbox_name` overrides `NAME_PATTERN` and spawns a sandbox named `weird "sand\box\nname` to verify the metrics layer sanitizes Prometheus labels. On Linux only `/` and `\x00` are path-significant, so backslashes, quotes, and newlines (all valid single-component filenames) remain allowed and that test keeps passing.

## Testing
- New parametrized tests assert all three helpers reject traversal/separator names (`../escaped`, `a/b`, `a/../b`, `..`, `.`, `""`).
- New `test_cleanup_temp_dir_rejects_escaping_name`: a directory that is a **sibling of the temp root** survives a `cleanup_temp_dir("../victim")` request (before the fix it would be `rmtree`'d).
  - On the old code these **13 cases fail** (no `ValueError`; the victim is deleted).
- The existing metrics sanitization test (weird name) still passes.
- Full non-soak suite: `405 passed, 2 skipped`.
- `isort`/`black`/`flake8` clean; pylint 9.91/10 (gate `fail-under = 8.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG

---
_Generated by [Claude Code](https://claude.ai/code/session_014PHgCArkYCtLXhYTh6N6aG)_