### PR TITLE
Make test_remote_policy.py self-contained

### DIFF
--- a/tests/test_remote_policy.py
+++ b/tests/test_remote_policy.py
@@ -10,7 +10,20 @@ from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
 
 import pytest
 
+import pyisolate
 import pyisolate.policy as policy
+
+
+@pytest.fixture
+def policy_token():
+    # refresh_remote ends in Supervisor.reload_policy, which authorizes against
+    # the global supervisor's policy token. Set it here (and restore afterwards)
+    # so this file does not depend on an earlier test file having set it.
+    sup = pyisolate.supervisor._get_supervisor()
+    old = sup._policy_token
+    pyisolate.set_policy_token("tok")
+    yield "tok"
+    sup._policy_token = old
 
 
 class PolicyHandler(BaseHTTPRequestHandler):
@@ -25,7 +38,7 @@ class PolicyHandler(BaseHTTPRequestHandler):
         return
 
 
-def test_refresh_remote(tmp_path):
+def test_refresh_remote(tmp_path, policy_token):
     addr = ("127.0.0.1", 0)
     httpd = HTTPServer(addr, PolicyHandler)
     port = httpd.server_address[1]
@@ -66,7 +79,7 @@ class SlowFirstHandler(BaseHTTPRequestHandler):
         return
 
 
-def test_refresh_remote_retries_on_timeout(tmp_path):
+def test_refresh_remote_retries_on_timeout(tmp_path, policy_token):
     addr = ("127.0.0.1", 0)
     httpd = ThreadingHTTPServer(addr, SlowFirstHandler)
     port = httpd.server_address[1]


### PR DESCRIPTION
## Issue

`pytest tests/test_remote_policy.py` fails on current `main` when run as a standalone file: `test_refresh_remote` and `test_refresh_remote_retries_on_timeout` hit `PolicyAuthError: invalid policy token`. They only pass in the full suite because an earlier test file happens to leave the global supervisor's policy token set to `"tok"` — a hidden test-order dependency.

## Fix

Add a `policy_token` fixture that sets the token via `pyisolate.set_policy_token("tok")` before each affected test and restores the previous value afterwards, so the file neither depends on nor leaks global token state.

## Testing

- `pytest tests/test_remote_policy.py` now passes standalone.
- Full suite: 409 passed, 2 environment-gated skips; all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDSofWX5HwawsrwbN2nSXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDSofWX5HwawsrwbN2nSXR)_