### PR TITLE
Remove the lint job from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,26 +8,6 @@ on:
     - cron: "0 4 * * *"
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          python -m pip install -e .[dev]
-          pre-commit install-hooks
-      - name: Run isort
-        run: pre-commit run isort --all-files
-      - name: Run black
-        run: pre-commit run black --all-files
-      - name: Run pylint
-        run: pre-commit run pylint --all-files
-      - name: Run flake8
-        run: pre-commit run flake8 --all-files
-
   tests-unit:
     name: unit / py${{ matrix.python-version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What

Removes the `lint` job from `.github/workflows/ci.yml` (which ran isort, black, pylint, and flake8 via pre-commit). The remaining CI jobs — unit, hardening, no-gil, soak, cross-kernel, coverage — are unchanged.

## Note

The pre-commit hooks stay in `.pre-commit-config.yaml`, so linting/formatting is still available locally (`pre-commit run --all-files`); CI just no longer gates on it. Workflow YAML validated after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDSofWX5HwawsrwbN2nSXR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDSofWX5HwawsrwbN2nSXR)_