### PR TITLE
Test the no-GIL readiness axis and gate CI on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,8 @@ jobs:
         run: pytest -q tests/test_matrix_hardening.py -m "${{ matrix.slice }}"
 
   tests-no-gil:
-    name: no-gil race / py3.13t
+    name: no-gil axis + race / py3.13t
     runs-on: ubuntu-24.04
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -64,14 +63,23 @@ jobs:
         # cryptography/cffi cannot yet build wheels for the free-threaded 3.13
         # build, so a normal ``.[dev]`` install aborts before any test runs.
         # Install pyisolate without that dependency and rely on the suite's
-        # crypto stub (tests/conftest.py) so the race tests actually execute.
+        # crypto stub (tests/conftest.py) so the tests actually execute.
         # ``--no-deps`` skips *all* runtime deps, so re-add the pure-Python ones
         # the import path needs (pyyaml, platformdirs) -- everything declared in
         # ``project.dependencies`` except the unbuildable cryptography.
         run: |
           python -m pip install -e . --no-deps
           python -m pip install pytest pyyaml platformdirs
+      - name: Validate no-GIL readiness axis (must pass on the free-threaded build)
+        # Deterministic: asserts the axis classifies parallel-cell vs scheduled-
+        # compartment correctly and that the free-threaded build reports itself
+        # as such. A regression here is a real release-gate bug, not flakiness.
+        run: pytest -q tests/test_nogil.py
       - name: Run race tests under free-threaded build
+        # Concurrency stress can be timing-sensitive under free-threading; keep
+        # it advisory so a flaky race does not block, while the axis check above
+        # stays authoritative.
+        continue-on-error: true
         run: pytest -q tests/test_matrix_hardening.py -m "race and no_gil"
 
   tests-soak:

--- a/tests/test_nogil.py
+++ b/tests/test_nogil.py
@@ -1,0 +1,190 @@
+"""Tests for the no-GIL readiness axis (:mod:`pyisolate.nogil`).
+
+The no-GIL axis is a release gate: it decides whether a host may claim
+parallel-cell semantics or must fall back to scheduled compartments. The suite
+usually runs on a GIL-enabled interpreter, so the axis logic is exercised by
+monkeypatching the three inputs (build flag, runtime GIL state, loaded native
+extensions) rather than depending on the host being a free-threaded build.
+"""
+
+import importlib.machinery
+import sys
+import sysconfig
+import warnings
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from pyisolate import nogil
+
+
+def _fake_native_module(name: str) -> ModuleType:
+    """Build a module object that looks like an imported native extension."""
+    suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+    origin = f"/nonexistent/{name}{suffix}"
+    module = ModuleType(name)
+    module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None, origin=origin)
+    module.__file__ = origin
+    return module
+
+
+# -- primitive probes -------------------------------------------------------
+
+
+def test_is_no_gil_build_matches_sysconfig():
+    assert nogil.is_no_gil_build() == bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
+def test_is_gil_enabled_matches_interpreter():
+    checker = getattr(sys, "_is_gil_enabled", None)
+    if checker is None:
+        assert nogil.is_gil_enabled() is None
+    else:
+        assert nogil.is_gil_enabled() == bool(checker())
+
+
+def test_configured_safe_roots_parses_and_normalizes(monkeypatch):
+    monkeypatch.setenv(nogil._SAFE_ENV, " numpy , pandas.core ,, torch ")
+    # Whitespace is stripped, empty entries dropped, and dotted names collapse
+    # to their root module so a whole package can be marked in one entry.
+    assert nogil._configured_safe_roots() == {"numpy", "pandas", "torch"}
+
+
+def test_configured_safe_roots_empty_when_unset(monkeypatch):
+    monkeypatch.delenv(nogil._SAFE_ENV, raising=False)
+    assert nogil._configured_safe_roots() == set()
+
+
+# -- native extension inventory --------------------------------------------
+
+
+def test_imported_native_extensions_flags_unknown(monkeypatch):
+    monkeypatch.delenv(nogil._SAFE_ENV, raising=False)
+    monkeypatch.setitem(sys.modules, "fakenative", _fake_native_module("fakenative"))
+    records = {item["name"]: item for item in nogil.imported_native_extensions()}
+    assert "fakenative" in records
+    record = records["fakenative"]
+    assert record["no_gil_safe"] is False
+    assert record["status"] == "unknown"
+
+
+def test_imported_native_extensions_honors_safe_declaration(monkeypatch):
+    monkeypatch.setenv(nogil._SAFE_ENV, "fakenative")
+    monkeypatch.setitem(sys.modules, "fakenative", _fake_native_module("fakenative"))
+    records = {item["name"]: item for item in nogil.imported_native_extensions()}
+    assert records["fakenative"]["no_gil_safe"] is True
+    assert records["fakenative"]["status"] == "declared-safe"
+
+
+def test_pure_python_modules_are_not_reported_as_native(monkeypatch):
+    pure = ModuleType("purepy")
+    pure.__spec__ = importlib.machinery.ModuleSpec(
+        "purepy", loader=None, origin="/nonexistent/purepy.py"
+    )
+    pure.__file__ = "/nonexistent/purepy.py"
+    monkeypatch.setitem(sys.modules, "purepy", pure)
+    names = {item["name"] for item in nogil.imported_native_extensions()}
+    assert "purepy" not in names
+
+
+# -- the readiness axis -----------------------------------------------------
+
+
+def _force(monkeypatch, *, build, gil, unknown_ext):
+    monkeypatch.setattr(nogil, "is_no_gil_build", lambda: build)
+    monkeypatch.setattr(nogil, "is_gil_enabled", lambda: gil)
+    ext = [_fake_native_module("x")] if unknown_ext else []
+    records = [{"name": "x", "no_gil_safe": False, "status": "unknown"} for _ in ext]
+    monkeypatch.setattr(nogil, "imported_native_extensions", lambda: records)
+
+
+def test_axis_parallel_cells_when_free_threaded_and_clean(monkeypatch):
+    _force(monkeypatch, build=True, gil=False, unknown_ext=False)
+    report = nogil.no_gil_readiness_report()
+    assert report["axis"]["mode"] == "parallel_cells"
+    assert report["axis"]["parallel_cells_ready"] is True
+    assert report["axis"]["scheduled_compartments"] is False
+
+
+def test_axis_scheduled_when_not_a_no_gil_build(monkeypatch):
+    _force(monkeypatch, build=False, gil=None, unknown_ext=False)
+    report = nogil.no_gil_readiness_report()
+    assert report["axis"]["mode"] == "scheduled_compartments"
+    assert "--disable-gil" in report["axis"]["reason"]
+
+
+def test_axis_scheduled_when_process_gil_enabled(monkeypatch):
+    _force(monkeypatch, build=True, gil=True, unknown_ext=False)
+    report = nogil.no_gil_readiness_report()
+    assert report["axis"]["mode"] == "scheduled_compartments"
+    assert report["axis"]["parallel_cells_ready"] is False
+    assert "GIL" in report["axis"]["reason"]
+
+
+def test_axis_scheduled_when_native_extension_unknown(monkeypatch):
+    _force(monkeypatch, build=True, gil=False, unknown_ext=True)
+    report = nogil.no_gil_readiness_report()
+    assert report["axis"]["mode"] == "scheduled_compartments"
+    assert report["extensions"]["unknown_or_unmarked_count"] == 1
+    assert "native extension" in report["axis"]["reason"]
+
+
+def test_report_shape_is_stable(monkeypatch):
+    _force(monkeypatch, build=True, gil=False, unknown_ext=False)
+    report = nogil.no_gil_readiness_report()
+    assert set(report) == {"build", "runtime", "extensions", "axis"}
+    assert report["extensions"]["safe_declaration_env"] == nogil._SAFE_ENV
+    assert report["build"]["py_gil_disabled"] is True
+
+
+# -- the free-threaded warning ---------------------------------------------
+
+
+def test_warn_is_silent_on_a_gil_build(monkeypatch):
+    monkeypatch.setattr(nogil, "is_no_gil_build", lambda: False)
+    monkeypatch.delenv(nogil._WARN_ENV, raising=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        nogil.warn_if_unsafe_native_extensions()  # must not raise
+
+
+def test_warn_fires_for_unknown_extensions_on_free_threaded_build(monkeypatch):
+    monkeypatch.setattr(nogil, "is_no_gil_build", lambda: True)
+    monkeypatch.delenv(nogil._WARN_ENV, raising=False)
+    monkeypatch.setattr(
+        nogil,
+        "no_gil_readiness_report",
+        lambda: {"extensions": {"unknown_or_unmarked_count": 2}},
+    )
+    with pytest.warns(RuntimeWarning, match="not declared no-GIL-safe"):
+        nogil.warn_if_unsafe_native_extensions()
+
+
+def test_warn_is_silent_when_no_unknown_extensions(monkeypatch):
+    monkeypatch.setattr(nogil, "is_no_gil_build", lambda: True)
+    monkeypatch.delenv(nogil._WARN_ENV, raising=False)
+    monkeypatch.setattr(
+        nogil,
+        "no_gil_readiness_report",
+        lambda: {"extensions": {"unknown_or_unmarked_count": 0}},
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        nogil.warn_if_unsafe_native_extensions()
+
+
+def test_warn_can_be_disabled_by_env(monkeypatch):
+    monkeypatch.setattr(nogil, "is_no_gil_build", lambda: True)
+    monkeypatch.setenv(nogil._WARN_ENV, "0")
+
+    def _boom():  # pragma: no cover - must never be called when disabled
+        raise AssertionError("readiness report computed despite disabled warning")
+
+    monkeypatch.setattr(nogil, "no_gil_readiness_report", _boom)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        nogil.warn_if_unsafe_native_extensions()


### PR DESCRIPTION
The no-GIL axis in pyisolate.nogil is a release gate -- it decides whether a host may claim parallel-cell semantics or must fall back to scheduled compartments -- but it had no dedicated tests, and the free-threaded CI job was entirely advisory (continue-on-error) and only ran race tests.

- tests/test_nogil.py: cover the axis across the build / process-GIL / native-extension-safety combinations, the PYISOLATE_NOGIL_SAFE_MODULES declaration parsing and gating, native-vs-pure-Python module detection, and the RuntimeWarning path (fires on unknown extensions, silent otherwise, and suppressible via env). The inputs are monkeypatched so the logic is validated on ordinary GIL-enabled interpreters too.
- ci.yml: the no-gil job now runs the axis tests assertively (a regression is a real release-gate bug), while the timing-sensitive race tests stay advisory.

Full suite: 465 passed, 4 skipped.


Claude-Session: https://claude.ai/code/session_01PbbJc7Ntj159D9LNGevwC2