### PR TITLE
Add microVM backend scaffolding with fail-closed admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,12 @@ See [docs/execution-model.md](docs/execution-model.md). We keep this model small
   * `rlimit` and cgroup resource caps.
   Each kernel layer is best-effort and recorded in the sandbox's confinement
   report; hardened rollout mode fails closed when a required layer is missing.
-* **`backend="microvm"`** - reserved; not yet implemented (fails closed).
+* **`backend="microvm"`** - the reserved hardware-VM boundary. The supervisor
+  probes the host for a supported VMM (Firecracker, Cloud Hypervisor, QEMU) and
+  an accessible `/dev/kvm`, and **fails closed** with a diagnostic naming what is
+  missing; when the host is capable it still refuses, because the guest launcher
+  and vsock transport are not yet implemented. It never degrades to a weaker
+  boundary.
 * **Broker** - sole path to privileged syscalls, sealed with AEAD (X25519 to
   ChaCha20-Poly1305) and strict per-direction replay counters.
 * **Fallback hardening** - even the process backend is defense-in-depth, not a

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -41,7 +41,12 @@ rollout mode a required-but-unavailable layer fails closed. Even at full
 strength this is **defense in depth, not a hardware VM boundary** — for
 high-assurance multitenancy, run one sandbox per process inside a VM or microVM.
 
-- **`backend="microvm"`** is reserved and not yet implemented; it fails closed.
+- **`backend="microvm"`** is the reserved hardware-VM boundary. The supervisor
+  probes for a supported VMM (Firecracker, Cloud Hypervisor, QEMU) and an
+  accessible `/dev/kvm` and **fails closed** with a diagnostic when they are
+  missing; even on a capable host it refuses, because the guest launcher and
+  vsock transport are not yet implemented. It never downgrades to a weaker
+  boundary.
 
 ---
 

--- a/pyisolate/runtime/microvm.py
+++ b/pyisolate/runtime/microvm.py
@@ -1,0 +1,212 @@
+"""microVM backend scaffolding for ``backend="microvm"``.
+
+This module is the supervisor-side groundwork for the microVM isolation mode:
+the strongest boundary PyIsolate targets, where the guest runs behind a
+hardware-virtualization boundary (KVM) instead of only kernel policy on a shared
+kernel. It provides three things that do **not** require a running hypervisor to
+be useful or testable:
+
+* **capability detection** — is a supported VMM (Firecracker, Cloud Hypervisor,
+  QEMU) on ``PATH`` and is ``/dev/kvm`` usable (:func:`detect_microvm_support`);
+* **machine-config generation** — turn a sandbox's limits into the JSON a VMM
+  consumes to boot a guest (:class:`MicroVMConfig`);
+* **fail-closed admission** — a precise, actionable error when the host cannot
+  provide the boundary (:func:`require_microvm_support`).
+
+What it deliberately does **not** yet do is boot a guest or carry the cell
+protocol over vsock; that launcher is the next increment. Until then the
+supervisor routes ``backend="microvm"`` here and fails closed rather than
+silently downgrading to a weaker boundary — consistent with the threat model,
+which treats microVM as reserved and fail-closed.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import shutil
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from ..errors import SandboxError
+
+# VMMs PyIsolate knows how to target, in preference order. The value is the
+# executable name looked up on PATH.
+_KNOWN_VMMS: tuple[tuple[str, str], ...] = (
+    ("firecracker", "firecracker"),
+    ("cloud-hypervisor", "cloud-hypervisor"),
+    ("qemu", "qemu-system-x86_64"),
+)
+
+_KVM_DEVICE = "/dev/kvm"
+
+# Default guest kernel command line for a Firecracker-style minimal boot.
+_DEFAULT_BOOT_ARGS = "console=ttyS0 reboot=k panic=1 pci=off"
+
+
+class MicroVMUnavailable(SandboxError):
+    """Raised when a microVM boundary cannot be established on this host."""
+
+
+@dataclass(frozen=True)
+class MicroVMSupport:
+    """Result of probing the host for microVM prerequisites."""
+
+    vmm_kind: Optional[str]
+    vmm_path: Optional[str]
+    kvm: bool
+    reasons: tuple[str, ...] = ()
+
+    @property
+    def ready(self) -> bool:
+        """Whether a hardware-VM boundary can be launched here."""
+        return self.vmm_path is not None and self.kvm
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ready": self.ready,
+            "vmm_kind": self.vmm_kind,
+            "vmm_path": self.vmm_path,
+            "kvm": self.kvm,
+            "reasons": list(self.reasons),
+        }
+
+
+def detect_vmm() -> tuple[Optional[str], Optional[str]]:
+    """Return the first supported VMM found on ``PATH`` as ``(kind, path)``."""
+    for kind, executable in _KNOWN_VMMS:
+        path = shutil.which(executable)
+        if path is not None:
+            return kind, path
+    return None, None
+
+
+def kvm_available() -> bool:
+    """Return whether ``/dev/kvm`` exists and is readable+writable to us.
+
+    KVM requires read/write access to the device node; a present-but-inaccessible
+    ``/dev/kvm`` (missing group membership, container without the device) cannot
+    launch a VM, so it is reported as unavailable.
+    """
+    return os.path.exists(_KVM_DEVICE) and os.access(_KVM_DEVICE, os.R_OK | os.W_OK)
+
+
+def detect_microvm_support() -> MicroVMSupport:
+    """Probe the host for a usable VMM and KVM, collecting the blocking reasons."""
+    vmm_kind, vmm_path = detect_vmm()
+    kvm = kvm_available()
+    reasons: list[str] = []
+    if vmm_path is None:
+        names = ", ".join(executable for _, executable in _KNOWN_VMMS)
+        reasons.append(f"no supported VMM on PATH (looked for: {names})")
+    if not kvm:
+        if not os.path.exists(_KVM_DEVICE):
+            reasons.append(f"{_KVM_DEVICE} is not present (no hardware virtualization)")
+        else:
+            reasons.append(f"{_KVM_DEVICE} exists but is not readable+writable")
+    return MicroVMSupport(
+        vmm_kind=vmm_kind,
+        vmm_path=vmm_path,
+        kvm=kvm,
+        reasons=tuple(reasons),
+    )
+
+
+def require_microvm_support(
+    support: Optional[MicroVMSupport] = None,
+) -> MicroVMSupport:
+    """Return *support* if a microVM boundary is possible, else fail closed.
+
+    The microVM backend has no weaker mode to degrade to: either a hardware-VM
+    boundary can be launched or the request is refused. The raised error names
+    every missing prerequisite so an operator can fix the host.
+    """
+    support = support or detect_microvm_support()
+    if not support.ready:
+        detail = "; ".join(support.reasons) or "prerequisites unavailable"
+        raise MicroVMUnavailable(
+            "backend='microvm' requires a hardware-VM boundary that this host "
+            f"cannot provide: {detail}. Run on a host with a supported VMM and "
+            "an accessible /dev/kvm, or choose backend='process' for kernel-level "
+            "confinement without a VM."
+        )
+    return support
+
+
+@dataclass
+class MicroVMConfig:
+    """Inputs for a guest microVM, renderable to a VMM machine configuration.
+
+    The fields map onto a Firecracker-style boot: a guest kernel, a root
+    filesystem image, CPU/memory sizing, and a vsock device used to carry the
+    cell protocol between supervisor and guest.
+    """
+
+    kernel_image: str
+    rootfs_image: str
+    vsock_uds_path: str
+    vcpus: int = 1
+    mem_size_mib: int = 128
+    guest_cid: int = 3
+    boot_args: str = _DEFAULT_BOOT_ARGS
+    rootfs_read_only: bool = False
+    extra_drives: list[dict[str, Any]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.vcpus < 1:
+            raise ValueError("vcpus must be >= 1")
+        if self.mem_size_mib < 1:
+            raise ValueError("mem_size_mib must be >= 1")
+        # Firecracker reserves CIDs 0-2 (hypervisor/local/host); guests start at 3.
+        if self.guest_cid < 3:
+            raise ValueError("guest_cid must be >= 3 (0-2 are reserved)")
+
+    @classmethod
+    def from_limits(
+        cls,
+        *,
+        kernel_image: str,
+        rootfs_image: str,
+        vsock_uds_path: str,
+        mem_bytes: Optional[int] = None,
+        vcpus: int = 1,
+        guest_cid: int = 3,
+    ) -> "MicroVMConfig":
+        """Build a config from a sandbox's byte-denominated memory limit."""
+        mem_mib = 128 if mem_bytes is None else max(1, math.ceil(mem_bytes / (1 << 20)))
+        return cls(
+            kernel_image=kernel_image,
+            rootfs_image=rootfs_image,
+            vsock_uds_path=vsock_uds_path,
+            vcpus=vcpus,
+            mem_size_mib=mem_mib,
+            guest_cid=guest_cid,
+        )
+
+    def to_firecracker_json(self) -> dict[str, Any]:
+        """Render the full-VM JSON Firecracker accepts via ``--config-file``."""
+        drives = [
+            {
+                "drive_id": "rootfs",
+                "path_on_host": self.rootfs_image,
+                "is_root_device": True,
+                "is_read_only": self.rootfs_read_only,
+            }
+        ]
+        drives.extend(self.extra_drives)
+        return {
+            "boot-source": {
+                "kernel_image_path": self.kernel_image,
+                "boot_args": self.boot_args,
+            },
+            "drives": drives,
+            "machine-config": {
+                "vcpu_count": self.vcpus,
+                "mem_size_mib": self.mem_size_mib,
+                "smt": False,
+            },
+            "vsock": {
+                "guest_cid": self.guest_cid,
+                "uds_path": self.vsock_uds_path,
+            },
+        }

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -24,6 +24,7 @@ from .errors import PolicyAuthError, TenantQuotaExceeded
 from .observability.alerts import AlertManager
 from .observability.trace import Tracer
 from .policy import resolve_policy
+from .runtime import microvm as _microvm
 from .runtime.process_backend import ProcessSandbox
 from .runtime.protocol import CapabilityHandle, ControlRequest
 from .runtime.thread import SandboxThread
@@ -313,6 +314,11 @@ class Supervisor:
         """
         global NAME_PATTERN
         backend = _normalize_backend(backend)
+        if backend == "microvm":
+            # Dedicated fail-closed path: probe for a real VMM/KVM boundary and
+            # refuse with an actionable diagnostic rather than the generic
+            # not-implemented error. The launcher itself is still pending.
+            return self._spawn_microvm(name)
         _require_implemented_backend(backend)
         if not isinstance(name, str) or not name:
             raise ValueError("Sandbox name must be non-empty string")
@@ -478,6 +484,24 @@ class Supervisor:
             if strict:
                 raise
             logger.debug("sandbox_policy map update skipped for %s", cg_path)
+
+    def _spawn_microvm(self, name: str) -> Sandbox:
+        """Admit a microVM sandbox, failing closed until the launcher lands.
+
+        Probes the host for a usable VMM and KVM. When the boundary cannot be
+        established the caller gets a precise :class:`MicroVMUnavailable` naming
+        every missing prerequisite. When the host *is* capable, we still refuse
+        with :class:`NotImplementedError`, because the guest boot and vsock
+        transport are not yet wired -- but the refusal is honest about why,
+        instead of degrading to a weaker boundary.
+        """
+        support = _microvm.require_microvm_support()
+        raise NotImplementedError(
+            f"backend='microvm' prerequisites are present (VMM: "
+            f"{support.vmm_kind} at {support.vmm_path}, /dev/kvm accessible), but "
+            "the guest launcher and vsock transport are not yet implemented. "
+            "Use backend='process' for kernel-level confinement in the meantime."
+        )
 
     def _spawn_process(
         self,
@@ -709,7 +733,10 @@ def _get_supervisor() -> Supervisor:
 def spawn(*args, **kwargs):
     if "backend" in kwargs:
         backend = _normalize_backend(kwargs["backend"])
-        _require_implemented_backend(backend)
+        # microVM has a dedicated fail-closed path in Supervisor.spawn that
+        # reports *why* it is unavailable; let it through the generic guard.
+        if backend != "microvm":
+            _require_implemented_backend(backend)
         kwargs["backend"] = backend
     return _get_supervisor().spawn(*args, **kwargs)
 

--- a/tests/test_microvm.py
+++ b/tests/test_microvm.py
@@ -1,0 +1,209 @@
+"""Tests for the microVM backend scaffolding.
+
+Booting a real guest needs KVM, which CI hosts generally lack, so these tests
+exercise the pieces that do not require a hypervisor: VMM/KVM capability
+detection, the fail-closed admission gate, the machine-config builder, and the
+supervisor routing for ``backend="microvm"``.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import pytest
+
+import pyisolate as iso
+from pyisolate.errors import SandboxError
+from pyisolate.runtime import microvm
+
+# -- capability detection ---------------------------------------------------
+
+
+def test_detect_vmm_prefers_first_available(monkeypatch):
+    monkeypatch.setattr(
+        microvm.shutil,
+        "which",
+        lambda exe: "/usr/bin/firecracker" if exe == "firecracker" else None,
+    )
+    kind, path = microvm.detect_vmm()
+    assert kind == "firecracker"
+    assert path == "/usr/bin/firecracker"
+
+
+def test_detect_vmm_falls_through_to_qemu(monkeypatch):
+    monkeypatch.setattr(
+        microvm.shutil,
+        "which",
+        lambda exe: (
+            "/usr/bin/qemu-system-x86_64" if exe == "qemu-system-x86_64" else None
+        ),
+    )
+    kind, path = microvm.detect_vmm()
+    assert kind == "qemu"
+    assert path.endswith("qemu-system-x86_64")
+
+
+def test_detect_vmm_none_when_absent(monkeypatch):
+    monkeypatch.setattr(microvm.shutil, "which", lambda exe: None)
+    assert microvm.detect_vmm() == (None, None)
+
+
+def test_kvm_available_true_when_accessible(monkeypatch):
+    monkeypatch.setattr(microvm.os.path, "exists", lambda p: p == "/dev/kvm")
+    monkeypatch.setattr(microvm.os, "access", lambda p, mode: True)
+    assert microvm.kvm_available() is True
+
+
+def test_kvm_available_false_when_missing(monkeypatch):
+    monkeypatch.setattr(microvm.os.path, "exists", lambda p: False)
+    assert microvm.kvm_available() is False
+
+
+def test_detect_support_collects_reasons_when_nothing_available(monkeypatch):
+    monkeypatch.setattr(microvm.shutil, "which", lambda exe: None)
+    monkeypatch.setattr(microvm.os.path, "exists", lambda p: False)
+    support = microvm.detect_microvm_support()
+    assert support.ready is False
+    assert support.vmm_kind is None
+    joined = " ".join(support.reasons)
+    assert "no supported VMM" in joined
+    assert "/dev/kvm is not present" in joined
+
+
+def test_detect_support_reports_inaccessible_kvm(monkeypatch):
+    monkeypatch.setattr(microvm.shutil, "which", lambda exe: "/usr/bin/firecracker")
+    monkeypatch.setattr(microvm.os.path, "exists", lambda p: True)
+    monkeypatch.setattr(microvm.os, "access", lambda p, mode: False)
+    support = microvm.detect_microvm_support()
+    assert support.ready is False
+    assert any("not readable+writable" in reason for reason in support.reasons)
+
+
+def test_support_ready_and_as_dict(monkeypatch):
+    monkeypatch.setattr(microvm.shutil, "which", lambda exe: "/usr/bin/firecracker")
+    monkeypatch.setattr(microvm.os.path, "exists", lambda p: True)
+    monkeypatch.setattr(microvm.os, "access", lambda p, mode: True)
+    support = microvm.detect_microvm_support()
+    assert support.ready is True
+    payload = support.as_dict()
+    assert payload["ready"] is True
+    assert payload["vmm_kind"] == "firecracker"
+    assert payload["kvm"] is True
+
+
+# -- fail-closed admission --------------------------------------------------
+
+
+def test_require_support_raises_with_reasons_when_not_ready():
+    support = microvm.MicroVMSupport(
+        vmm_kind=None, vmm_path=None, kvm=False, reasons=("no supported VMM on PATH",)
+    )
+    with pytest.raises(microvm.MicroVMUnavailable, match="no supported VMM on PATH"):
+        microvm.require_microvm_support(support)
+
+
+def test_require_support_returns_support_when_ready():
+    support = microvm.MicroVMSupport(
+        vmm_kind="firecracker", vmm_path="/usr/bin/firecracker", kvm=True
+    )
+    assert microvm.require_microvm_support(support) is support
+
+
+def test_microvm_unavailable_is_a_sandbox_error():
+    assert issubclass(microvm.MicroVMUnavailable, SandboxError)
+
+
+# -- machine-config builder -------------------------------------------------
+
+
+def test_config_rejects_invalid_sizing():
+    kwargs = dict(kernel_image="/k", rootfs_image="/r", vsock_uds_path="/v.sock")
+    with pytest.raises(ValueError):
+        microvm.MicroVMConfig(vcpus=0, **kwargs)
+    with pytest.raises(ValueError):
+        microvm.MicroVMConfig(mem_size_mib=0, **kwargs)
+    with pytest.raises(ValueError):
+        microvm.MicroVMConfig(guest_cid=2, **kwargs)
+
+
+def test_config_from_limits_rounds_memory_up():
+    cfg = microvm.MicroVMConfig.from_limits(
+        kernel_image="/k",
+        rootfs_image="/r",
+        vsock_uds_path="/v.sock",
+        mem_bytes=(200 << 20) + 1,  # just over 200 MiB
+    )
+    assert cfg.mem_size_mib == 201
+
+
+def test_config_from_limits_defaults_memory_when_unbounded():
+    cfg = microvm.MicroVMConfig.from_limits(
+        kernel_image="/k", rootfs_image="/r", vsock_uds_path="/v.sock"
+    )
+    assert cfg.mem_size_mib == 128
+
+
+def test_to_firecracker_json_matches_schema():
+    cfg = microvm.MicroVMConfig(
+        kernel_image="/boot/vmlinux",
+        rootfs_image="/img/rootfs.ext4",
+        vsock_uds_path="/run/pyisolate/vm.sock",
+        vcpus=2,
+        mem_size_mib=256,
+        guest_cid=7,
+    )
+    doc = cfg.to_firecracker_json()
+    assert doc["boot-source"]["kernel_image_path"] == "/boot/vmlinux"
+    assert doc["machine-config"] == {
+        "vcpu_count": 2,
+        "mem_size_mib": 256,
+        "smt": False,
+    }
+    assert doc["vsock"] == {
+        "guest_cid": 7,
+        "uds_path": "/run/pyisolate/vm.sock",
+    }
+    root = doc["drives"][0]
+    assert root["is_root_device"] is True
+    assert root["path_on_host"] == "/img/rootfs.ext4"
+
+
+# -- supervisor integration -------------------------------------------------
+
+
+def test_spawn_microvm_fails_closed_when_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        microvm,
+        "detect_microvm_support",
+        lambda: microvm.MicroVMSupport(
+            vmm_kind=None,
+            vmm_path=None,
+            kvm=False,
+            reasons=("no supported VMM on PATH", "/dev/kvm is not present"),
+        ),
+    )
+    with pytest.raises(microvm.MicroVMUnavailable, match="/dev/kvm"):
+        iso.spawn("vm", backend="microvm")
+
+
+def test_spawn_microvm_reports_pending_launcher_when_host_ready(monkeypatch):
+    monkeypatch.setattr(
+        microvm,
+        "detect_microvm_support",
+        lambda: microvm.MicroVMSupport(
+            vmm_kind="firecracker", vmm_path="/usr/bin/firecracker", kvm=True
+        ),
+    )
+    with pytest.raises(NotImplementedError, match="launcher"):
+        iso.spawn("vm", backend="microvm")
+
+
+def test_microvm_is_a_supported_but_unimplemented_backend():
+    from pyisolate.supervisor import IMPLEMENTED_BACKENDS, SUPPORTED_BACKENDS
+
+    assert "microvm" in SUPPORTED_BACKENDS
+    # It is routed to a dedicated fail-closed path, not the generic
+    # implemented-backend list.
+    assert "microvm" not in IMPLEMENTED_BACKENDS

--- a/tests/test_process_backend.py
+++ b/tests/test_process_backend.py
@@ -118,5 +118,9 @@ def test_process_backend_unsupported_features_raise_not_implemented():
 
 
 def test_microvm_backend_remains_unimplemented():
-    with pytest.raises(RuntimeError):
+    # microVM is routed to a dedicated fail-closed admission path: it refuses
+    # with a diagnostic (MicroVMUnavailable, a SandboxError, when the host lacks
+    # a VMM/KVM; NotImplementedError when capable but the launcher is pending)
+    # rather than ever returning a working guest.
+    with pytest.raises((iso.SandboxError, NotImplementedError)):
         iso.spawn("proc-vm", backend="microvm")

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -193,7 +193,10 @@ def test_spawn_backend_is_explicit_subinterpreter():
 
 @pytest.mark.parametrize("backend", ["microvm"])
 def test_spawn_unimplemented_boundary_backends_fail_closed(backend):
-    with pytest.raises(NotImplementedError, match=backend):
+    # microVM fails closed with a diagnostic: MicroVMUnavailable (a SandboxError)
+    # when the host lacks a VMM/KVM, or NotImplementedError when the host is
+    # capable but the guest launcher is still pending.
+    with pytest.raises((iso.SandboxError, NotImplementedError), match=backend):
         iso.spawn(f"backend-{backend}", backend=backend)
 
 


### PR DESCRIPTION
## Summary

`backend="microvm"` previously raised a flat, generic `NotImplementedError` from the shared backend guard. This replaces it with a dedicated, **honest fail-closed path** so the strongest boundary PyIsolate targets has real groundwork and diagnostics — without pretending to boot a guest it cannot yet boot.

## What's included

New `pyisolate/runtime/microvm.py` provides the parts that don't need a running hypervisor to be useful or testable:

- **Capability detection** (`detect_microvm_support`) — is a supported VMM (Firecracker, Cloud Hypervisor, QEMU) on `PATH`, and is `/dev/kvm` readable+writable? Collects the blocking reasons.
- **Fail-closed admission** (`require_microvm_support`) — raises `MicroVMUnavailable` (a `SandboxError`) naming every missing prerequisite. microVM has no weaker mode to degrade to: either a hardware-VM boundary is possible or the request is refused.
- **Machine-config generation** (`MicroVMConfig`) — turns a sandbox's memory limit into the full-VM JSON a Firecracker-style VMM consumes (`boot-source` / `drives` / `machine-config` / `vsock`), with validation (vcpus ≥ 1, mem ≥ 1 MiB, guest CID ≥ 3).

`Supervisor.spawn` routes `backend="microvm"` to `_spawn_microvm`, which probes the host and either refuses with the diagnostic above, or — when the host *is* capable — refuses with a precise `NotImplementedError` noting the guest launcher and vsock transport are still pending. The module-level `spawn()` guard lets microVM through to this path instead of the generic error.

## Explicitly out of scope

Booting a guest and carrying the cell protocol over vsock — that launcher is the next increment and needs KVM, which CI hosts lack. This PR is the detection + config + fail-closed admission layer, mirroring how the process backend landed transport-first (#267) before its confinement layers.

## Docs & tests

README and the threat model are updated to describe the probe-and-fail-closed behavior. Two existing tests that asserted the old generic error are updated to the fail-closed contract. New `tests/test_microvm.py` covers detection, admission, and config generation without needing KVM (host capability is monkeypatched both ways).

Full suite: **491 passed, 6 skipped**. pylint 9.57 (gate 8.0); black/isort/flake8/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbbJc7Ntj159D9LNGevwC2)_