### PR TITLE
Declare the operator's kubernetes dependency and fail with guidance

### DIFF
--- a/pyisolate/operator/__init__.py
+++ b/pyisolate/operator/__init__.py
@@ -1,4 +1,5 @@
 """Kubernetes operator for PyIsolate sandboxes."""
+
 from __future__ import annotations
 
 import logging
@@ -15,8 +16,19 @@ logger = logging.getLogger(__name__)
 
 
 def run_operator(namespace: str = "default") -> None:
-    """Start the operator watch loop."""
-    from kubernetes import client, config, watch  # type: ignore
+    """Start the operator watch loop.
+
+    Requires the optional ``kubernetes`` client, which is not a core dependency.
+    Install it with ``pip install pyisolate[operator]``.
+    """
+    try:
+        from kubernetes import client, config, watch  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "the PyIsolate Kubernetes operator requires the 'kubernetes' "
+            "package, which is not installed. Install it with "
+            "`pip install pyisolate[operator]`."
+        ) from exc
 
     config.load_incluster_config()
     api = client.CustomObjectsApi()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ pyisolate-doctor = "pyisolate.doctor:main"
 
 [project.optional-dependencies]
 pqcrypto = ["pqcrypto"]
+operator = ["kubernetes"]
 release = [
     "build",
     "twine",

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -3,6 +3,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 
 def load_operator():
     pkg = types.ModuleType("pyisolate")
@@ -32,6 +34,18 @@ def test_operator_module():
     assert hasattr(op, "run_operator")
     assert callable(op.run_operator)
     assert hasattr(op, "scale_sandboxes")
+
+
+def test_run_operator_without_kubernetes_gives_actionable_error():
+    try:
+        import kubernetes  # noqa: F401
+
+        pytest.skip("kubernetes is installed; missing-dependency path not exercised")
+    except ImportError:
+        pass
+    op = load_operator()
+    with pytest.raises(RuntimeError, match=r"pyisolate\[operator\]"):
+        op.run_operator()
 
 
 def test_operator_handles_relisted_added_and_modified(monkeypatch):


### PR DESCRIPTION
## Summary

`pyisolate/operator/run_operator()` imports the third-party `kubernetes` client, but it was never declared as a dependency or extra. On a clean install the call raised a bare `ImportError` with no hint about how to fix it.

## Changes

- Add a **`pyisolate[operator]`** optional-dependency group containing `kubernetes`.
- Wrap the import so a missing client raises a `RuntimeError` that points at `pip install pyisolate[operator]` instead of a bare `ImportError`.

## Tests

New test asserts the actionable error on hosts without the kubernetes client (skipped where it's installed). The existing operator tests inject a fake `kubernetes` module via `sys.modules` and are unaffected by the guard.

Found during a full-project review; one of several small correctness/packaging gaps being addressed one PR at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbbJc7Ntj159D9LNGevwC2)_