### PR TITLE
Fix the stale backend not-implemented message

### DIFF
--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -57,10 +57,9 @@ def _normalize_backend(backend: str) -> BackendMode:
 def _require_implemented_backend(backend: BackendMode) -> None:
     if backend in IMPLEMENTED_BACKENDS:
         return
+    implemented = ", ".join(repr(b) for b in IMPLEMENTED_BACKENDS)
     raise NotImplementedError(
-        f"backend={backend!r} is an explicit isolation mode, but this build only "
-        "implements backend='subinterpreter'. Use an external process or microVM "
-        "launcher until the native backend is available."
+        f"backend={backend!r} is not implemented; this build implements {implemented}."
     )
 
 


### PR DESCRIPTION
## Summary

`_require_implemented_backend` still claimed *"this build only implements `backend='subinterpreter'`"* and told callers to use an external process/microVM launcher — both outdated since the in-process `process` backend landed and has been the boundary mode for many PRs.

Derive the message from `IMPLEMENTED_BACKENDS` so it stays accurate as backends are added, instead of hardcoding a list that drifts.

No test asserted the old wording; `test_supervisor.py` / `test_process_backend.py` pass unchanged.

Found during a full-project review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbbJc7Ntj159D9LNGevwC2)_