### PR TITLE
Rewrite the ROADMAP to reflect the current state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,45 +1,72 @@
 # ROADMAP
 
-This document outlines planned milestones for PyIsolate. Items are a mix of
-implemented features, work implied by the existing design, and ideas to improve
-the project.
+PyIsolate is a **prototype**. This document tracks what already exists, what is
+actively being built, and where the project is headed. The security boundary is
+backend-conditional — see [docs/threat-model.md](docs/threat-model.md) for the
+normative statement.
 
-## 1 Short‑term goals
+## Delivered
 
-- **Complete agent implementations** — flesh out `BPFManager`, `CryptoBroker`,
-  and `ResourceWatchdog` so that they enforce policies rather than acting as
-  stubs.
-- **Policy hot‑reloading** — wire up `policy.refresh()` to update BPF maps
-  without restarting sandboxes.
-- **Metrics exporter** — collect per‑sandbox counters and expose Prometheus
-  gauges as sketched in `observability/metrics.py`.
+- **Backends** — `backend="subinterpreter"` (execution cell) and
+  `backend="process"` (the boundary mode): a real separate-process boundary with
+  `no_new_privs` + a seccomp deny-list, Landlock filesystem rules, Landlock
+  TCP-egress rules (ABI ≥ 4), a coarse per-cgroup eBPF/LSM deny-mask, and
+  `rlimit` caps, recorded in a per-sandbox confinement report.
+- **Broker transport** — X25519 (optional Kyber-768 hybrid) → ChaCha20-Poly1305
+  authenticated channel with per-direction replay counters; capability-gated
+  `request` cell op in both backends.
+- **Policy** — YAML policy model + compiler, token-gated hot-reload, and remote
+  refresh over bounded HTTP(S).
+- **No-GIL axis** — free-threaded build / GIL / native-extension classification
+  with a release gate and CI coverage.
+- **Observability** — Prometheus metrics, structured logging, `pyisolate doctor`
+  provenance, and a 10-point `--grade` conformance score.
+- **Packaging** — PyPI metadata + a Trusted-Publishing release workflow (tooling
+  in place; no release cut yet).
+- **microVM scaffolding** — VMM/KVM capability detection, fail-closed admission,
+  a Firecracker machine-config builder, and a VMM launcher (process lifecycle).
+- **Also shipped** — encrypted checkpointing, checkpoint migration to a peer,
+  NUMA-aware scheduling, a CLI, a policy editor, and pre-commit + CI.
 
-## 2 Security hardening
+## Now / next
 
-- **Landlock fallback** for systems without eBPF privileges.
-- **Post‑quantum handshake** using Kyber‑736 / Dilithium hybrids.
-- **Input validation** on broker messages and strict constant‑time error paths.
+- **Broker request execution** — the `request` op currently surfaces a
+  `BrokerRequest` to the host but nothing executes it or returns a result. Add a
+  request/response round-trip and a pluggable, capability-scoped handler so the
+  broker actually mediates privileged operations.
+- **Process-backend quota enforcement** — attach process-backed sandboxes to
+  cgroups and cover them with the `ResourceWatchdog` (today they get `rlimit`
+  only and are not watched), so the boundary mode gets the CPU/memory quota
+  enforcement the threat model credits it with.
+- **microVM guest agent + vsock transport** — the launcher can boot a VMM; the
+  remaining work is the in-guest agent and carrying the cell protocol over
+  vsock, which is what makes `backend="microvm"` a usable, working boundary.
+- **Cut `v0.0.1` to PyPI** — using the existing release workflow, once a Trusted
+  Publisher and `pypi` environment are configured.
+
+## Security hardening
+
+- **Richer eBPF/LSM enforcement** — move beyond the coarse per-cgroup deny-mask
+  toward per-path / per-destination allow-lists in the LSM layer.
+- **Landlock network `bind` restriction** — complement the existing egress
+  (`connect`) rules.
+- **Input validation & constant-time error paths** on broker messages.
 - **Hardware-assisted checks** — evaluate Intel CET, ARM pointer authentication,
-  and MTE for platforms that support them.
+  and MTE where supported.
+- **Supply chain** — reproducible builds, artifact signing, and eBPF-bytecode
+  pinning (currently roadmap, not guaranteed).
 
-## 3 Developer experience
+## Extended functionality
 
-- **Command‑line interface** for spawning and monitoring sandboxes.
-- **Pre‑commit hooks** and CI on all supported platforms.
-- **Package to PyPI** so users can install with `pip`.
+- **WASM build target** to run a sandbox inside browsers.
+- **gRPC control-plane plugin** for managing remote sandboxes.
+- **Language bindings** for Rust and Go.
+- **Kubernetes operator** — currently minimal (`pyisolate[operator]`); grow it
+  into a real reconciler with a documented CRD.
 
-## 4 Extended functionality
+## Long-term vision
 
-- **WASM build target** to run the sandbox inside browsers.
-- **gRPC control‑plane plugin** for managing remote sandboxes.
-- **Language bindings** for Rust and Go to drive PyIsolate from other projects.
-- **Remote policy enforcement** over HTTP.
-- **Encrypted checkpointing** for sandbox migration.
-
-## 5 Long‑term vision
-
-- **Distributed supervisor** that schedules sandboxes across multiple hosts.
+- **Distributed supervisor** scheduling sandboxes across hosts.
 - **Live migration** of running sandboxes between hosts.
-- **Policy plugin ecosystem** allowing community‑contributed guards and metrics.
+- **Policy plugin ecosystem** for community-contributed guards and metrics.
 - **Comprehensive dashboards** with Grafana and alerting hooks.
-


### PR DESCRIPTION
## Summary

The ROADMAP had drifted badly out of sync. It still listed as *short-term* work things long since delivered — policy hot-reload, the metrics exporter, Landlock fallback, the Kyber-768 hybrid, the CLI, pre-commit/CI, and "package to PyPI" — and described `BPFManager` / `CryptoBroker` / `ResourceWatchdog` as stubs, while saying **nothing** about the process/microVM backend arc that has been the actual work.

## Changes

Reorganized into **Delivered / Now-next / Security hardening / Extended / Long-term**, grounded in the real code. The *Now / next* section names the concrete open gaps surfaced by the project review:

- broker request **execution** (the `request` op surfaces a `BrokerRequest` but nothing executes it or returns a result);
- **process-backend quota enforcement** (process sandboxes get `rlimit` only — no cgroup attach, not watched by the `ResourceWatchdog`);
- the **microVM guest agent + vsock transport** (the launcher boots a VMM; this is what makes the backend usable);
- cutting **v0.0.1** with the existing release workflow.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbbJc7Ntj159D9LNGevwC2)_