### PR TITLE
Add a CHANGELOG and ignore coverage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 .env/
 /dist/
 /build/
+.coverage
+coverage.xml
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to PyIsolate are recorded here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). PyIsolate is a
+prototype in the `0.0.x` series and does not yet make Semantic Versioning
+guarantees; **no release should be treated as a hardened security boundary**.
+
+## [Unreleased]
+
+### Added
+- `backend="process"` boundary mode: a real separate-process boundary confined
+  by `no_new_privs` + a seccomp deny-list, Landlock filesystem rules, Landlock
+  TCP-egress rules (Landlock ABI ≥ 4), a coarse per-cgroup eBPF/LSM deny-mask,
+  and `rlimit` caps, recorded in a per-sandbox confinement report.
+- Capability-gated broker `request` mediation in the process backend (surfaces a
+  `BrokerRequest` to the supervisor; an ungranted capability is denied).
+- microVM backend scaffolding: VMM/KVM capability detection, fail-closed
+  admission, a Firecracker machine-config builder, and a VMM launcher.
+- No-GIL readiness axis tests and a free-threaded (`3.13t`) CI gate.
+- PyPI packaging metadata and a Trusted-Publishing release workflow.
+- `pyisolate doctor --grade` components for Landlock network egress and microVM
+  readiness (now a 10-point conformance score).
+- `scripts/benchmark.py` for reproducible spawn/round-trip measurements.
+- `pyisolate[operator]` optional-dependency group for the Kubernetes operator.
+
+### Changed
+- Threat model and `SECURITY.md` reconciled with the real, backend-conditional
+  boundary (the sub-interpreter backend is an execution cell, not a boundary
+  against hostile Python).
+
+### Known gaps
+- The broker `request` op is surfaced but not yet executed end-to-end.
+- Process-backed sandboxes are not attached to cgroups or watched by the
+  resource watchdog (they get `rlimit` only).
+- `backend="microvm"` fails closed: the guest agent and vsock cell transport are
+  not implemented yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = ["pyyaml", "cryptography", "platformdirs"]
 Homepage = "https://github.com/seanwevans/pyisolate"
 Repository = "https://github.com/seanwevans/pyisolate"
 Issues = "https://github.com/seanwevans/pyisolate/issues"
-Changelog = "https://github.com/seanwevans/pyisolate/blob/main/ROADMAP.md"
+Changelog = "https://github.com/seanwevans/pyisolate/blob/main/CHANGELOG.md"
 
 [build-system]
 # setuptools >= 77 emits PEP 639 license metadata (License-Expression /


### PR DESCRIPTION
## Summary

The project shipped release tooling (#274) but had **no changelog**, and `.gitignore` didn't cover coverage output — a stray `.coverage` from a local run trips the repo's untracked-file stop hook.

## Changes

- **`CHANGELOG.md`** — Keep a Changelog format with an `[Unreleased]` section summarizing the recent boundary / packaging / observability work, plus an honest **Known gaps** list (broker request not executed end-to-end, process backend not cgroup/watchdog-covered, microVM fails closed). The pyproject `Changelog` URL now points here instead of the ROADMAP.
- **`.gitignore`** — ignore `.coverage`, `coverage.xml`, and `.pytest_cache/`.

Documentation / housekeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbbJc7Ntj159D9LNGevwC2)_