### PR TITLE
Enforce process-backend quotas instead of silently dropping them

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,8 +65,20 @@ silently.
 7. **Crash isolation** — A crash in a guest process cannot bring down the
    supervisor.
 
-Resource quotas (CPU/RAM/I/O) are enforced by `rlimit` and cgroup v2 controls
-where available. Anything not listed above is *not* guaranteed.
+**Resource quotas.** `cpu_ms`, `mem_bytes`, and `open_files_max` are applied to
+the guest process as `RLIMIT_CPU` / `RLIMIT_AS` / `RLIMIT_NOFILE` before any
+guest code runs, and appear in the confinement report. `wall_time_ms` is
+enforced by a supervisor-side timer that kills a guest which overruns it —
+necessary because a guest blocked on I/O burns no CPU and `RLIMIT_CPU` never
+fires. `RLIMIT_CPU` has one-second granularity, so a sub-second `cpu_ms` rounds
+up and the weaker effective limit is logged.
+
+Quotas this backend has no way to enforce — `network_ops_max`,
+`output_bytes_max`, `child_work_max`, `numa_node`, which the sub-interpreter
+backend implements with in-process counters — are **rejected at spawn** with
+`NotImplementedError` rather than accepted and ignored.
+
+Anything not listed above is *not* guaranteed.
 
 ---
 

--- a/pyisolate/runtime/child.py
+++ b/pyisolate/runtime/child.py
@@ -227,6 +227,7 @@ def _serve(sock: socket.socket) -> None:
         report = apply_confinement(
             mem_bytes=bootstrap.get("mem_bytes"),
             cpu_seconds=bootstrap.get("cpu_seconds"),
+            open_files_max=bootstrap.get("open_files_max"),
             fs_read=bootstrap.get("fs_read"),
             fs_write=bootstrap.get("fs_write"),
             net_connect_ports=_net_connect_ports(bootstrap.get("tcp")),

--- a/pyisolate/runtime/confine.py
+++ b/pyisolate/runtime/confine.py
@@ -60,6 +60,11 @@ _AUDIT_ARCH_X86_64 = 0xC000003E
 _SECCOMP_DATA_NR_OFFSET = 0
 _SECCOMP_DATA_ARCH_OFFSET = 4
 
+# Descriptors the guest runtime needs regardless of its own quota: stdin/stdout/
+# stderr and the supervisor channel, plus slack for the interpreter's own opens
+# during import.
+_NOFILE_CHANNEL_HEADROOM = 16
+
 # x86-64 syscall numbers for the deny-list. These are a stable ABI and never
 # change for this architecture. A normal compute workload never issues any of
 # them; every entry is an escape, execution, kernel-management, or
@@ -194,6 +199,7 @@ def _apply_rlimits(
     *,
     mem_bytes: int | None,
     cpu_seconds: int | None,
+    open_files_max: int | None,
 ) -> None:
     # Never leak memory contents through a core dump of the guest.
     try:
@@ -215,6 +221,22 @@ def _apply_rlimits(
             report.rlimits.append(f"cpu={cpu_seconds}")
         except (ValueError, OSError):
             report.skipped.append("rlimit_cpu")
+
+    if open_files_max is not None:
+        # The guest inherits the socketpair end it talks to the supervisor on,
+        # plus stdio, so the limit has to leave room for those or the child
+        # cannot even report its confinement. Reserve a small fixed headroom
+        # rather than handing the guest its full requested budget for its own
+        # opens plus the channel.
+        effective = open_files_max + _NOFILE_CHANNEL_HEADROOM
+        try:
+            soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+            if hard != resource.RLIM_INFINITY:
+                effective = min(effective, hard)
+            resource.setrlimit(resource.RLIMIT_NOFILE, (effective, hard))
+            report.rlimits.append(f"nofile={effective}")
+        except (ValueError, OSError):
+            report.skipped.append("rlimit_nofile")
 
 
 def _apply_landlock(
@@ -253,6 +275,7 @@ def apply_confinement(
     *,
     mem_bytes: int | None = None,
     cpu_seconds: int | None = None,
+    open_files_max: int | None = None,
     fs_read: list[str] | None = None,
     fs_write: list[str] | None = None,
     net_connect_ports: list[int] | None = None,
@@ -271,7 +294,12 @@ def apply_confinement(
     report = ConfinementReport()
     report.no_new_privs = _set_no_new_privs()
 
-    _apply_rlimits(report, mem_bytes=mem_bytes, cpu_seconds=cpu_seconds)
+    _apply_rlimits(
+        report,
+        mem_bytes=mem_bytes,
+        cpu_seconds=cpu_seconds,
+        open_files_max=open_files_max,
+    )
     _apply_landlock(
         report,
         fs_read=fs_read,

--- a/pyisolate/runtime/process_backend.py
+++ b/pyisolate/runtime/process_backend.py
@@ -18,6 +18,8 @@ work; this module establishes the process boundary and transport.
 from __future__ import annotations
 
 import json
+import logging
+import math
 import queue
 import socket
 import struct
@@ -31,11 +33,37 @@ from ..policy.model import RuntimePolicy
 from .protocol import BrokerRequest
 from .thread import Stats
 
+logger = logging.getLogger(__name__)
+
 _LEN = struct.Struct("!I")
 
 # Guest results and errors cross the boundary as JSON. Never unpickle data
 # produced by untrusted guest code in the supervisor process.
 _CHILD_MODULE = "pyisolate.runtime.child"
+
+
+def _cpu_seconds_from_ms(cpu_ms: Optional[int]) -> Optional[int]:
+    """Convert a millisecond CPU budget to the whole seconds ``RLIMIT_CPU`` takes.
+
+    ``RLIMIT_CPU`` has one-second granularity, so a sub-second budget cannot be
+    expressed exactly and rounds *up* to one second. Rounding up keeps the limit
+    real (the guest is still killed) but weaker than requested, so it is logged
+    rather than applied silently -- a quota that quietly differs from the one
+    the caller asked for is the failure mode this wiring exists to remove.
+    Precise sub-second CPU accounting needs cgroup ``cpu.max``.
+    """
+    if cpu_ms is None:
+        return None
+    seconds = max(1, math.ceil(cpu_ms / 1000))
+    if cpu_ms < 1000:
+        logger.warning(
+            "cpu_ms=%d is below RLIMIT_CPU's one-second granularity; the guest "
+            "process is limited to %ds of CPU instead. Use wall_time_ms for "
+            "finer bounds.",
+            cpu_ms,
+            seconds,
+        )
+    return seconds
 
 
 def _extract_fs_tcp(policy: Any) -> tuple[Optional[list[str]], Optional[list[str]]]:
@@ -132,7 +160,10 @@ class ProcessSandbox:
         capabilities: Optional[dict[str, Any]] = None,
         backend: str = "process",
         mem_bytes: Optional[int] = None,
+        cpu_ms: Optional[int] = None,
         cpu_seconds: Optional[int] = None,
+        wall_time_ms: Optional[int] = None,
+        open_files_max: Optional[int] = None,
         confine: bool = True,
         require_seccomp: bool = False,
         require_landlock: bool = False,
@@ -142,6 +173,21 @@ class ProcessSandbox:
         self._outbox: "queue.Queue[Any]" = queue.Queue()
         self._closed = False
         self._lock = threading.Lock()
+        # Wall-clock enforcement. RLIMIT_CPU bounds CPU time in the guest, but a
+        # guest that blocks forever burns no CPU, so wall time is enforced here
+        # in the supervisor: arm a timer when an operation is dispatched and
+        # kill the guest if it has not reported completion in time.
+        self.wall_time_ms = wall_time_ms
+        self._wall_timer: Optional[threading.Timer] = None
+        self._pending_ops = 0
+        self._timer_lock = threading.Lock()
+        # A dying guest is noticed by two racing observers -- the wall-clock
+        # timer and the reader thread seeing EOF -- and a waiter must get
+        # exactly one error, the specific one.
+        self._termination_lock = threading.Lock()
+        self._termination_surfaced = False
+        if cpu_seconds is None:
+            cpu_seconds = _cpu_seconds_from_ms(cpu_ms)
         # Tenant-quota bookkeeping mirrors SandboxThread so the supervisor's
         # shared reservation helpers can account for process sandboxes too.
         self._tenant: Optional[str] = None
@@ -196,6 +242,7 @@ class ProcessSandbox:
                 "confine": confine,
                 "mem_bytes": mem_bytes,
                 "cpu_seconds": cpu_seconds,
+                "open_files_max": open_files_max,
                 "require_seccomp": require_seccomp,
                 "require_landlock": require_landlock,
             }
@@ -252,9 +299,82 @@ class ProcessSandbox:
         if not self._closed:
             self._closed = True
             self._confined.set()
+            self._surface_termination()
+
+    # -- wall-clock enforcement -------------------------------------------
+
+    def _op_started(self) -> None:
+        """Record a dispatched operation and arm the wall-clock timer."""
+        if self.wall_time_ms is None:
+            return
+        with self._timer_lock:
+            self._pending_ops += 1
+            if self._wall_timer is None:
+                self._arm_timer_locked()
+
+    def _op_finished(self) -> None:
+        """Clear one completed operation, re-arming while others are pending."""
+        if self.wall_time_ms is None:
+            return
+        with self._timer_lock:
+            self._pending_ops = max(0, self._pending_ops - 1)
+            self._cancel_timer_locked()
+            if self._pending_ops:
+                # Operations are pipelined: the guest executes them serially, so
+                # the next one starts now and gets its own full budget.
+                self._arm_timer_locked()
+
+    def _arm_timer_locked(self) -> None:
+        assert self.wall_time_ms is not None
+        timer = threading.Timer(self.wall_time_ms / 1000.0, self._on_wall_timeout)
+        timer.daemon = True
+        self._wall_timer = timer
+        timer.start()
+
+    def _cancel_timer_locked(self) -> None:
+        if self._wall_timer is not None:
+            self._wall_timer.cancel()
+            self._wall_timer = None
+
+    def _surface_termination(self) -> None:
+        """Hand a waiting ``recv`` exactly one error for an unexpected death.
+
+        The wall-clock timer and the reader thread can both observe the guest
+        dying, so the first one here wins and the other is a no-op. A quota
+        breach reports its specific error; anything else -- a seccomp kill, a
+        segfault -- reports the generic one.
+        """
+        with self._termination_lock:
+            if self._termination_surfaced:
+                return
+            self._termination_surfaced = True
+        if self.termination_reason == "wall_time_exceeded":
+            self._outbox.put(errors.WallTimeExceeded())
+        else:
             self._outbox.put(
                 errors.SandboxError("guest process terminated unexpectedly")
             )
+
+    def _on_wall_timeout(self) -> None:
+        """Kill a guest that overran its wall-clock budget and report it."""
+        with self._timer_lock:
+            self._wall_timer = None
+            self._pending_ops = 0
+        if not self.is_alive():
+            return
+        self.termination_reason = "wall_time_exceeded"
+        self._errors += 1
+        logger.warning(
+            "sandbox %s exceeded its %dms wall-clock quota; killing guest",
+            self.name,
+            self.wall_time_ms,
+        )
+        # Kill *before* surfacing the error so a caller that catches
+        # WallTimeExceeded and immediately inspects the sandbox sees a stopped
+        # guest rather than one still burning CPU. ``termination_reason`` is set
+        # first so whichever observer gets there reports the quota breach.
+        self.kill(timeout=0.2)
+        self._surface_termination()
 
     def _dispatch(self, frame: dict[str, Any]) -> None:
         ev = frame.get("ev")
@@ -262,7 +382,10 @@ class ProcessSandbox:
             self._outbox.put(frame.get("message"))
         elif ev == "error":
             self._errors += 1
+            self._op_finished()
             self._outbox.put(self._rebuild_exception(frame))
+        elif ev == "done":
+            self._op_finished()
         elif ev == "request":
             # A capability-gated broker request from the guest. Surface it as a
             # BrokerRequest via recv(), matching the sub-interpreter backend, so
@@ -277,8 +400,8 @@ class ProcessSandbox:
         elif ev == "confinement":
             self.confinement = frame
             self._confined.set()
-        # "ready", "done", "log", and "metric" are lifecycle/telemetry frames
-        # that do not feed recv(); logging/metrics routing is added with the
+        # "ready", "log", and "metric" are lifecycle/telemetry frames that do
+        # not feed recv(); logging/metrics routing is added with the
         # observability wiring for this backend.
 
     @staticmethod
@@ -301,11 +424,23 @@ class ProcessSandbox:
 
     def exec(self, src: str) -> None:
         self._ops += 1
-        self._send({"op": "exec", "source": src})
+        self._op_started()
+        try:
+            self._send({"op": "exec", "source": src})
+        except Exception:
+            self._op_finished()
+            raise
 
     def call(self, func: str, *args, timeout: float | None = None, **kwargs) -> Any:
         self._ops += 1
-        self._send({"op": "call", "target": func, "args": list(args), "kwargs": kwargs})
+        self._op_started()
+        try:
+            self._send(
+                {"op": "call", "target": func, "args": list(args), "kwargs": kwargs}
+            )
+        except Exception:
+            self._op_finished()
+            raise
         try:
             return self.recv(timeout)
         except errors.SandboxError:
@@ -375,6 +510,9 @@ class ProcessSandbox:
         return True
 
     def _teardown(self) -> None:
+        with self._timer_lock:
+            self._pending_ops = 0
+            self._cancel_timer_locked()
         with self._lock:
             self._closed = True
             try:

--- a/pyisolate/supervisor.py
+++ b/pyisolate/supervisor.py
@@ -54,6 +54,32 @@ def _normalize_backend(backend: str) -> BackendMode:
     return backend  # type: ignore[return-value]
 
 
+# Quotas the sub-interpreter backend enforces with in-process counters that have
+# no equivalent in the process backend yet: the guest runs in another address
+# space, so the supervisor cannot see its socket operations, its stdout volume,
+# or the threads it starts. Accepting these silently would hand callers a limit
+# that does nothing, which is worse than refusing them.
+PROCESS_UNSUPPORTED_QUOTAS: tuple[str, ...] = (
+    "network_ops_max",
+    "output_bytes_max",
+    "child_work_max",
+    "numa_node",
+)
+
+
+def _reject_unsupported_process_quotas(**quotas: Optional[int]) -> None:
+    requested = sorted(name for name, value in quotas.items() if value is not None)
+    if not requested:
+        return
+    names = ", ".join(requested)
+    raise NotImplementedError(
+        f"backend='process' cannot enforce {names}; it would be accepted and "
+        "ignored. Use backend='subinterpreter' for in-process counter quotas, "
+        "or express the limit with cpu_ms/mem_bytes/wall_time_ms/open_files_max, "
+        "which this backend enforces in the kernel."
+    )
+
+
 def _require_implemented_backend(backend: BackendMode) -> None:
     if backend in IMPLEMENTED_BACKENDS:
         return
@@ -342,7 +368,14 @@ class Supervisor:
                 policy=policy,
                 allowed_imports=allowed_imports,
                 capabilities=capabilities,
+                cpu_ms=cpu_ms,
                 mem_bytes=mem_bytes,
+                wall_time_ms=wall_time_ms,
+                open_files_max=open_files_max,
+                network_ops_max=network_ops_max,
+                output_bytes_max=output_bytes_max,
+                child_work_max=child_work_max,
+                numa_node=numa_node,
                 tenant=tenant,
                 tenant_quota=tenant_quota,
             )
@@ -512,17 +545,35 @@ class Supervisor:
         policy: Any,
         allowed_imports: Optional[list[str]],
         capabilities: Optional[dict[str, Any]],
-        mem_bytes: Optional[int],
-        tenant: Optional[str],
-        tenant_quota: Optional[int],
+        cpu_ms: Optional[int] = None,
+        mem_bytes: Optional[int] = None,
+        wall_time_ms: Optional[int] = None,
+        open_files_max: Optional[int] = None,
+        network_ops_max: Optional[int] = None,
+        output_bytes_max: Optional[int] = None,
+        child_work_max: Optional[int] = None,
+        numa_node: Optional[int] = None,
+        tenant: Optional[str] = None,
+        tenant_quota: Optional[int] = None,
     ) -> Sandbox:
         """Spawn a sandbox behind a real OS-process boundary.
 
         This path deliberately skips the SandboxThread-specific machinery
-        (warm pool, in-process quota watchdog, per-thread cgroup attach). Kernel
-        confinement of the guest process (seccomp/rlimits/Landlock/cgroups) is
-        layered on in follow-up work.
+        (warm pool, in-process quota watchdog, per-thread cgroup attach).
+
+        Quotas this backend can enforce are forwarded to the guest process:
+        ``cpu_ms`` and ``mem_bytes`` and ``open_files_max`` become rlimits
+        applied before guest code runs, and ``wall_time_ms`` is enforced by a
+        supervisor-side timer. Quotas with no enforcement path here are
+        rejected rather than accepted and ignored -- see
+        :data:`PROCESS_UNSUPPORTED_QUOTAS`.
         """
+        _reject_unsupported_process_quotas(
+            network_ops_max=network_ops_max,
+            output_bytes_max=output_bytes_max,
+            child_work_max=child_work_max,
+            numa_node=numa_node,
+        )
         with self._lock:
             existing_thread = self._sandboxes.get(name)
             existing_proc = self._process_sandboxes.get(name)
@@ -545,7 +596,10 @@ class Supervisor:
                     allowed_imports=allowed_imports,
                     capabilities=capabilities,
                     backend="process",
+                    cpu_ms=cpu_ms,
                     mem_bytes=mem_bytes,
+                    wall_time_ms=wall_time_ms,
+                    open_files_max=open_files_max,
                     require_seccomp=self._rollout_mode == "hardened",
                     require_landlock=self._rollout_mode == "hardened",
                 )

--- a/tests/test_process_backend.py
+++ b/tests/test_process_backend.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -10,6 +11,7 @@ sys.path.insert(0, str(ROOT))
 import pytest
 
 import pyisolate as iso
+from pyisolate.runtime import confine, process_backend
 
 # The object-graph escape that fully defeats the sub-interpreter backend:
 # recover the *real* __import__ from a stdlib module's globals, bypassing the
@@ -156,3 +158,122 @@ def test_microvm_backend_remains_unimplemented():
     # rather than ever returning a working guest.
     with pytest.raises((iso.SandboxError, NotImplementedError)):
         iso.spawn("proc-vm", backend="microvm")
+
+
+# -- quota forwarding ------------------------------------------------------
+
+
+def test_wall_time_quota_kills_a_runaway_guest():
+    # A guest that blocks forever burns no CPU, so RLIMIT_CPU never fires; the
+    # supervisor-side wall clock is what bounds it.
+    sb = iso.spawn(
+        "proc-wall", allowed_imports=["time"], backend="process", wall_time_ms=300
+    )
+    try:
+        started = time.monotonic()
+        sb.exec("import time; time.sleep(30); post('finished')")
+        with pytest.raises(iso.WallTimeExceeded):
+            sb.recv(timeout=10)
+        assert time.monotonic() - started < 10
+        assert sb.termination_reason == "wall_time_exceeded"
+        # The guest must already be stopped when the error surfaces, not still
+        # burning CPU while the caller handles the exception.
+        assert not sb._thread.is_alive()
+    finally:
+        sb.close()
+
+
+def test_wall_time_quota_allows_work_that_finishes_in_budget():
+    with iso.spawn(
+        "proc-wall-ok", allowed_imports=["math"], backend="process", wall_time_ms=10_000
+    ) as sb:
+        sb.exec("from math import sqrt; post(sqrt(16))")
+        assert sb.recv(timeout=10) == 4.0
+        # The timer must be disarmed by the completion frame, not left to fire
+        # and kill a guest that already finished.
+        time.sleep(0.2)
+        assert sb._thread.is_alive()
+
+
+def test_wall_time_quota_rearms_across_sequential_operations():
+    with iso.spawn(
+        "proc-wall-seq", allowed_imports=["math"], backend="process", wall_time_ms=5_000
+    ) as sb:
+        for expected in (2.0, 3.0, 4.0):
+            sb.exec(f"from math import sqrt; post(sqrt({expected ** 2}))")
+            assert sb.recv(timeout=10) == expected
+        assert sb._thread.is_alive()
+
+
+def test_open_files_quota_reaches_the_guest_as_an_rlimit():
+    with iso.spawn(
+        "proc-nofile",
+        allowed_imports=["resource"],
+        backend="process",
+        open_files_max=32,
+    ) as sb:
+        report = sb._thread.wait_confined(timeout=5)
+        assert any(item.startswith("nofile=") for item in report["rlimits"])
+        sb.exec("import resource; post(resource.getrlimit(resource.RLIMIT_NOFILE)[0])")
+        soft = sb.recv(timeout=5)
+    # Headroom is added for stdio and the supervisor channel, but the guest is
+    # still bounded rather than inheriting the host's limit.
+    assert soft == 32 + confine._NOFILE_CHANNEL_HEADROOM
+
+
+def test_cpu_quota_reaches_the_guest_as_an_rlimit():
+    with iso.spawn(
+        "proc-cpu", allowed_imports=["resource"], backend="process", cpu_ms=5_000
+    ) as sb:
+        report = sb._thread.wait_confined(timeout=5)
+        assert "cpu=5" in report["rlimits"]
+        sb.exec("import resource; post(resource.getrlimit(resource.RLIMIT_CPU)[0])")
+        assert sb.recv(timeout=5) == 5
+
+
+def test_mem_quota_reaches_the_guest_as_an_rlimit():
+    with iso.spawn(
+        "proc-mem",
+        allowed_imports=["resource"],
+        backend="process",
+        mem_bytes=512 * 1024 * 1024,
+    ) as sb:
+        report = sb._thread.wait_confined(timeout=5)
+        assert f"as={512 * 1024 * 1024}" in report["rlimits"]
+
+
+def test_sub_second_cpu_budget_rounds_up_and_warns(caplog):
+    # RLIMIT_CPU has one-second granularity. Rounding up is honest only if it is
+    # visible, so the weaker-than-requested limit is logged.
+    with caplog.at_level("WARNING", logger="pyisolate.runtime.process_backend"):
+        assert process_backend._cpu_seconds_from_ms(50) == 1
+    assert "below RLIMIT_CPU's one-second granularity" in caplog.text
+    # A budget that fits the granularity rounds without a warning.
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="pyisolate.runtime.process_backend"):
+        assert process_backend._cpu_seconds_from_ms(2_500) == 3
+    assert caplog.text == ""
+    assert process_backend._cpu_seconds_from_ms(None) is None
+
+
+@pytest.mark.parametrize(
+    "quota",
+    ["network_ops_max", "output_bytes_max", "child_work_max", "numa_node"],
+)
+def test_unenforceable_quotas_are_refused_not_silently_ignored(quota):
+    # These used to be accepted and dropped on the floor, leaving callers with a
+    # limit that did nothing in the backend documented as the security boundary.
+    with pytest.raises(NotImplementedError, match=quota):
+        iso.spawn(f"proc-unsupported-{quota}", backend="process", **{quota: 1})
+
+
+def test_supported_quotas_are_not_refused():
+    with iso.spawn(
+        "proc-supported",
+        backend="process",
+        cpu_ms=5_000,
+        mem_bytes=512 * 1024 * 1024,
+        wall_time_ms=10_000,
+        open_files_max=64,
+    ) as sb:
+        assert sb.backend == "process"


### PR DESCRIPTION
## The problem

`Supervisor.spawn` accepts `cpu_ms`, `wall_time_ms`, `open_files_max`, `network_ops_max`, `output_bytes_max`, `child_work_max`, and `numa_node`. `_spawn_process` forwarded **only `mem_bytes`**. Everything else was accepted and discarded — no error, no warning. Measured on `main`:

```
spawn(backend="process", cpu_ms=50, wall_time_ms=100)  → 30M-iteration loop runs to completion
spawn(cpu_ms=50, wall_time_ms=100)                     → WallTimeExceeded
```

The sub-interpreter backend — the one documented as *not* a security boundary — enforced limits that the process backend ignored. SECURITY.md §2 meanwhile claimed "Resource quotas (CPU/RAM/I/O) are enforced by `rlimit` and cgroup v2 controls." A limit that looks configured and does nothing is the worst failure shape for this project.

## The change

**Forward what this backend can enforce.**

| Quota | Mechanism |
|---|---|
| `cpu_ms` | `RLIMIT_CPU` in the child, before guest code runs |
| `mem_bytes` | `RLIMIT_AS` (already worked) |
| `open_files_max` | `RLIMIT_NOFILE` |
| `wall_time_ms` | supervisor-side timer |

Wall time can't be an rlimit: a guest blocked on I/O burns no CPU, so `RLIMIT_CPU` never fires. The timer is armed when an operation is dispatched and disarmed by the child's completion frame, re-arming while operations are still pending.

**Reject what it cannot.** `network_ops_max`, `output_bytes_max`, `child_work_max`, and `numa_node` are in-process counters in the thread backend with no equivalent across an address-space boundary. They now raise `NotImplementedError` naming the parameter and pointing at the alternatives, rather than pretending to apply.

Verified against the original repro:

```
confinement rlimits: ['core=0', 'cpu=5', 'nofile=24']
enforced after 0.40s: WallTimeExceeded
termination_reason: wall_time_exceeded | alive: False
```

## Three details worth review

- **`RLIMIT_CPU` has one-second granularity.** A sub-second `cpu_ms` rounds *up* — silently applying a 20× weaker limit than requested would recreate this bug in miniature, so the effective value is logged at WARNING. Precise sub-second CPU needs cgroup `cpu.max` (not in this PR).
- **`RLIMIT_NOFILE` reserves headroom** (`_NOFILE_CHANNEL_HEADROOM = 16`) for stdio and the supervisor channel. Without it, a small `open_files_max` stops the child from even reporting its confinement.
- **Termination had a race.** The wall-clock timer and the reader thread both observe a dying guest; the reader's generic "terminated unexpectedly" could beat the specific `WallTimeExceeded` into the queue. Termination now surfaces exactly one error — the specific one — and the kill completes *before* it is raised, so a caller catching `WallTimeExceeded` doesn't find the guest still burning CPU. That ordering is asserted in the test.

## Tests

12 new tests: wall-clock kills a runaway guest (and the guest is dead when the error lands), in-budget work is untouched and the timer is disarmed, the timer re-arms across sequential ops, each rlimit is observable from inside the guest, sub-second `cpu_ms` rounds up and warns, and each unenforceable quota is refused.

Full suite 517 passed / 6 skipped (was 505). Wall-clock tests re-run 5× for flakiness — stable. flake8 clean.

SECURITY.md §2 now states the quota position precisely instead of the blanket claim.

## Scope

Depends on nothing; environment scrubbing (#285) and the fail-open filesystem default are separate branches. Both touch `process_backend.py` in different regions.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ebvMQ3vLxdK3joymz6Feg)_