### PR TITLE
Gate CI on lint, types, and a coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,25 @@ on:
     - cron: "0 4 * * *"
 
 jobs:
+  lint:
+    name: lint / format / types
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install -e .[dev]
+      # Runs the same hooks contributors get from `pre-commit install`, at the
+      # same pinned tool versions, so CI and local checks cannot disagree.
+      # pytest is skipped here because the jobs below already run the suite
+      # across the full matrix rather than once.
+      - name: Run pre-commit hooks
+        env:
+          SKIP: pytest
+        run: pre-commit run --all-files --show-diff-on-failure
+
   tests-unit:
     name: unit / py${{ matrix.python-version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -135,9 +154,16 @@ jobs:
         run: python -m pip install -e .[dev]
       - name: Run tests with coverage
         run: coverage run -m pytest -m "not soak"
+      # Fails when package coverage drops below the fail_under floor in
+      # pyproject.toml. Previously coverage was measured and uploaded but never
+      # checked, so it could regress without CI noticing.
+      - name: Check coverage against the floor
+        run: coverage report
       - name: Generate coverage report
+        if: always()
         run: coverage xml -o coverage.xml
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: coverage-report
           path: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,19 @@ markers = [
 
 [tool.isort]
 profile = "black"
+
+
+[tool.coverage.run]
+# Scope measurement to the package. Without this, coverage also reports the
+# test files themselves, which are ~100% by construction and inflate the total
+# into something that cannot regress meaningfully.
+source = ["pyisolate"]
+
+
+[tool.coverage.report]
+show_missing = true
+# A floor, not a target. The suite sits above this; the point is that a change
+# which drops package coverage substantially fails CI instead of being noticed
+# months later. Kernel-gated tests (Landlock, BPF, cgroup) skip on hosts without
+# those features, so the floor is set below the observed value rather than at it.
+fail_under = 70

--- a/tests/test_ebpf_contract.py
+++ b/tests/test_ebpf_contract.py
@@ -29,7 +29,9 @@ def _kernel_map_names() -> set[str]:
 def _kernel_deny_defines() -> dict[str, int]:
     text = _BPF_SRC.read_text(encoding="utf-8")
     found = {}
-    for name, shift in re.findall(r"#define\s+(PYI_DENY_\w+)\s+\(1U\s*<<\s*(\d+)\)", text):
+    for name, shift in re.findall(
+        r"#define\s+(PYI_DENY_\w+)\s+\(1U\s*<<\s*(\d+)\)", text
+    ):
         found[name] = 1 << int(shift)
     return found
 
@@ -51,12 +53,18 @@ def test_deny_mask_bits_match_kernel_defines():
 def test_compile_deny_mask_denies_everything_without_a_policy():
     mask = contract.compile_deny_mask(None)
     assert mask == (
-        contract.DENY_FS | contract.DENY_NET | contract.DENY_PROCESS | contract.DENY_RISKY
+        contract.DENY_FS
+        | contract.DENY_NET
+        | contract.DENY_PROCESS
+        | contract.DENY_RISKY
     )
 
 
 def test_compile_deny_mask_always_denies_process_and_risky():
-    for policy in (None, iso.policy.Policy().allow_fs("/tmp").allow_tcp("127.0.0.1:80")):
+    for policy in (
+        None,
+        iso.policy.Policy().allow_fs("/tmp").allow_tcp("127.0.0.1:80"),
+    ):
         mask = contract.compile_deny_mask(policy)
         assert mask & contract.DENY_PROCESS
         assert mask & contract.DENY_RISKY

--- a/tests/test_landlock.py
+++ b/tests/test_landlock.py
@@ -19,10 +19,7 @@ import pytest
 import pyisolate as iso
 from pyisolate.runtime import landlock
 from pyisolate.runtime.child import _net_connect_ports
-from pyisolate.runtime.process_backend import (
-    _extract_fs_read_write,
-    _extract_fs_tcp,
-)
+from pyisolate.runtime.process_backend import _extract_fs_read_write, _extract_fs_tcp
 
 requires_landlock = pytest.mark.skipif(
     not landlock.landlock_supported(),


### PR DESCRIPTION
## The problem

CI ran only tests. The repo has a complete `.pre-commit-config.yaml` — isort, black, pylint, flake8, mypy — but **nothing enforced it outside a contributor's own machine**. And the `coverage` job ran the suite, generated `coverage.xml`, uploaded it as an artifact, and never looked at the number. Both could regress silently, and one already had.

## The change

**A `lint` job** that runs the pre-commit hooks at their pinned versions. Using pre-commit rather than re-listing the tools means CI and `pre-commit install` cannot drift apart about what passes. `pytest` is skipped in that job via `SKIP=pytest` — the matrix jobs already run the suite across six Python/OS combinations rather than once.

**A coverage floor.** Two parts:
- Scope measurement to the package (`[tool.coverage.run] source = ["pyisolate"]`). Previously the report also counted the test files, which are ~100% by construction and inflate the total into a number that cannot meaningfully regress.
- `fail_under = 70`, and the CI job now runs `coverage report` so the threshold is actually checked.

70 is deliberately below the current **73%**: kernel-gated tests (Landlock, BPF, cgroup) skip on hosts lacking those features, so a floor set at the observed value would flake depending on the runner. It's a floor, not a target. The XML upload moved to `if: always()` so a regression is still inspectable when the check fails.

## The gate immediately found drift on `main`

Which is rather the point:

- `tests/test_landlock.py` — an import block isort wants collapsed to one line
- `tests/test_ebpf_contract.py` — three statements over the line limit that black reformats

Both are fixed in this PR so the new job starts green. Neither is a behavior change.

## Verified locally

```
pre-commit run --all-files (SKIP=pytest)  → isort/black/pylint/flake8/mypy all Passed
coverage report                            → TOTAL 73%, exit 0
coverage report --fail-under=95            → exit 2   (floor is wired, not decorative)
pytest -m "not soak"                       → 505 passed, 6 skipped
```

mypy is clean across 46 source files and pylint is 9.17 (above the existing `fail-under = 8.0`), so this gate reflects where the repo already is rather than imposing new debt.

## Follow-up worth considering separately

Coverage is inverted: enforcement code is the least tested (`child.py` 27%, `confine.py` 45%, `landlock.py` 57%, `thread.py` 55%) while telemetry sits at 100%. A repo-wide floor doesn't capture that — per-module floors on the security-critical modules would, but that's a bigger conversation than this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ebvMQ3vLxdK3joymz6Feg)_