### PR TITLE
Restore the blank-line separator lost when two PRs merged

### DIFF
--- a/tests/test_process_backend.py
+++ b/tests/test_process_backend.py
@@ -277,6 +277,8 @@ def test_supported_quotas_are_not_refused():
         open_files_max=64,
     ) as sb:
         assert sb.backend == "process"
+
+
 # -- guest environment scrubbing ------------------------------------------
 
 


### PR DESCRIPTION
## main is currently red on the lint gate — this fixes it

PRs #285 and #286 both appended a new test section to the end of `tests/test_process_backend.py`. Each was correctly formatted on its own branch, but the textual merge joined the last function of one directly to the section comment of the other with one blank line where black wants two:

```diff
         assert sb.backend == "process"
+
+
 # -- guest environment scrubbing ------------------------------------------
```

**Neither PR's CI could have caught this** — the defect exists only in the merge result, not in either branch. It surfaced the moment the lint gate from #290 landed on main, which is that gate doing its job on its first run.

Two blank lines. Formatting only, no behavior change.

## Verified against current main

```
pre-commit run --all-files (SKIP=pytest)  → isort/black/pylint/flake8/mypy all Passed
pytest -m "not soak"                       → 533 passed, 11 skipped
```

---
_Generated by [Claude Code](https://claude.ai/code/session_012ebvMQ3vLxdK3joymz6Feg)_